### PR TITLE
Create package to handle everything Pandoc might throw at us

### DIFF
--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -29,6 +29,14 @@ end)
 
 SILE.registerCommand("span", function (options, content)
   handlePandocArgs(options)
+  for _, class in pairs(options.classes) do
+    SU.debug("pandoc", "Add div class "..class)
+  end
+  SILE.process(content)
+end,"Generic inline wrapper")
+
+SILE.registerCommand("div", function (options, content)
+  handlePandocArgs(options)
   SILE.process(content)
 end,"Generic inline wrapper")
 
@@ -104,6 +112,7 @@ Modified from default:
 Provided specifically for Pandoc:
 
 \listitem \code{span}
+\listitem \code{div}
 \listitem \code{emph}
 \listitem \code{smallcaps}
 \listitem \code{strikeout}

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -27,42 +27,53 @@ SILE.registerCommand("rule", function (options, _)
   SILE.call("hrule", options)
 end)
 
-SILE.registerCommand("textem", function (options, content)
+SILE.registerCommand("span", function (options, content)
+  handlePandocArgs(options)
+  SILE.process(content)
+end,"Generic inline wrapper")
+
+SILE.registerCommand("emph", function (options, content)
   handlePandocArgs(options)
   SILE.call("em", {}, content)
 end,"Inline emphasis wrapper")
 
-SILE.registerCommand("textstrong", function (options, content)
+local oldStrong = SILE.Commands["strong"]
+SILE.registerCommand("strong", function (options, content)
   handlePandocArgs(options)
-  SILE.call("strong", {}, content)
+  oldStrong(options, content)
 end,"Inline strong wrapper")
 
-SILE.registerCommand("textsc", function (options, content)
+SILE.registerCommand("smallcaps", function (options, content)
   handlePandocArgs(options)
   SILE.call("font", { features = "+smcp" }, content)
 end,"Inline small caps wrapper")
 
-SILE.registerCommand("textup", function (options, content)
+SILE.registerCommand("csl-no-emph", function (options, content)
   handlePandocArgs(options)
   SILE.call("font", { style = "Roman" }, content)
 end,"Inline upright wrapper")
 
-SILE.registerCommand("textnormal", function (options, content)
+SILE.registerCommand("csl-no-strong", function (options, content)
   handlePandocArgs(options)
   SILE.call("font", { weight = 400 }, content)
-end,"Inline upright wrapper")
+end,"Inline normal weight wrapper")
+
+SILE.registerCommand("csl-no-smallcaps", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("font", { features = "-smcp" }, content)
+end,"Inline smallcaps disable wrapper")
 
 local scriptOffset = "0.7ex"
 local scriptSize = "1.5ex"
 
-SILE.registerCommand("textsuperscript", function (options, content)
+SILE.registerCommand("superscript", function (options, content)
   handlePandocArgs(options)
   SILE.call("raise", { height = scriptOffset }, function ()
     SILE.call("font", { size = scriptSize }, content)
   end)
 end,"Inline superscript wrapper")
 
-SILE.registerCommand("textsubscript", function (options, content)
+SILE.registerCommand("subscript", function (options, content)
   handlePandocArgs(options)
   SILE.call("lower", { height = scriptOffset }, function ()
     SILE.call("font", { size = scriptSize }, content)
@@ -73,11 +84,9 @@ SILE.registerCommand("unimplemented", function (options, content)
   handlePandocArgs(options)
   SU.debug("pandoc", "Un-implemented function")
   SILE.process(content)
-end,"Inline small caps wrapper")
+end,"Unimplemented Pandoc function wrapper")
 
-SILE.Commands["strike"] = SILE.Commands["unimplemented"]
-SILE.Commands["strike"] = SILE.Commands["unimplemented"]
-
+SILE.Commands["strikeout"] = SILE.Commands["unimplemented"]
 
 return { documentation = [[\begin{document}
 
@@ -88,16 +97,20 @@ Provided by in base classes etc.:
 \listitem \code{listarea}
 \listitem \code{listitem}
 
+Modified from default:
+
+\listitem \code{strong}
+
 Provided specifically for Pandoc:
 
 \listitem \code{span}
-\listitem \code{textem}
-\listitem \code{textstrong}
-\listitem \code{textsc}
-\listitem \code{textnosc}
-\listitem \code{textnoem}
-\listitem \code{textnostrong}
-\listitem \code{textsuperscript}
-\listitem \code{textsubscript}
+\listitem \code{emph}
+\listitem \code{smallcaps}
+\listitem \code{strikeout}
+\listitem \code{csl-no-emph}
+\listitem \code{csl-no-strong}
+\listitem \code{csl-no-smallcaps}
+\listitem \code{superscript}
+\listitem \code{subscript}
 
 \end{document}]] }

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -11,11 +11,18 @@ local handlePandocArgs = function (options)
   if options.id then
     SU.debug("pandoc", "Set ID on tag")
   end
-  for _, class in pairs(options.classes) do
-    if SILE.Commands["Class:"..class] then
-      SILE.Call("Class:"..class, options, {})
+  if options.lang then
+    SU.debug("pandoc", "Set lang tag: "..options.lang)
+    local fontfunc = SILE.Commands[SILE.Commands["font:" .. options.lang] and "font:" .. options.lang or "font"]
+    fontfunc({ language = options.lang })
+  end
+  if options.classes then
+    for _,class in pairs(options.classes:split(",")) do
+      SU.debug("pandoc", "Add div class: "..class)
+      if SILE.Commands["Class:"..class] then
+        SILE.Call("Class:"..class, options, {})
+      end
     end
-    SU.debug("pandoc", "Add div class "..class)
   end
 end
 
@@ -44,49 +51,50 @@ SILE.registerCommand("Div", function (options, content)
   SILE.settings.temporarily(function ()
     handlePandocArgs(options)
     SILE.process(content)
+    SILE.call("par")
   end)
 end,"Generic inline wrapper")
 
-SILE.registerCommand("Emph", function (options, content)
+SILE.registerCommand("Emph", function (_, content)
   SILE.call("em", {}, content)
 end,"Inline emphasis wrapper")
 
-SILE.registerCommand("Strong", function (options, content)
+SILE.registerCommand("Strong", function (_, content)
   SILE.call("strong", {}, content)
 end,"Inline strong wrapper")
 
-SILE.registerCommand("SmallCaps", function (options, content)
+SILE.registerCommand("SmallCaps", function (_, content)
   SILE.call("font", { features = "+smcp" }, content)
 end,"Inline small caps wrapper")
 
-SILE.registerCommand("csl-no-emph", function (options, content)
+SILE.registerCommand("csl-no-emph", function (_, content)
   SILE.call("font", { style = "Roman" }, content)
 end,"Inline upright wrapper")
 
-SILE.registerCommand("csl-no-strong", function (options, content)
+SILE.registerCommand("csl-no-strong", function (_, content)
   SILE.call("font", { weight = 400 }, content)
 end,"Inline normal weight wrapper")
 
-SILE.registerCommand("csl-no-smallcaps", function (options, content)
+SILE.registerCommand("csl-no-smallcaps", function (_, content)
   SILE.call("font", { features = "-smcp" }, content)
 end,"Inline smallcaps disable wrapper")
 
 local scriptOffset = "0.7ex"
 local scriptSize = "1.5ex"
 
-SILE.registerCommand("Superscript", function (options, content)
+SILE.registerCommand("Superscript", function (_, content)
   SILE.call("raise", { height = scriptOffset }, function ()
     SILE.call("font", { size = scriptSize }, content)
   end)
 end,"Inline superscript wrapper")
 
-SILE.registerCommand("Subscript", function (options, content)
+SILE.registerCommand("Subscript", function (_, content)
   SILE.call("lower", { height = scriptOffset }, function ()
     SILE.call("font", { size = scriptSize }, content)
   end)
 end,"Inline subscript wrapper")
 
-SILE.registerCommand("unimplemented", function (options, content)
+SILE.registerCommand("unimplemented", function (_, content)
   SU.debug("pandoc", "Un-implemented function")
   SILE.process(content)
 end,"Unimplemented Pandoc function wrapper")

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -11,6 +11,12 @@ local handlePandocArgs = function (options)
   if options.id then
     SU.debug("pandoc", "Set ID on tag")
   end
+  for _, class in pairs(options.classes) do
+    if SILE.Commands["Class:"..class] then
+      SILE.Call("Class:"..class, options, {})
+    end
+    SU.debug("pandoc", "Add div class "..class)
+  end
 end
 
 SILE.registerCommand("label", function(options, content)
@@ -21,75 +27,66 @@ SILE.registerCommand("tt", function(options, content)
   SILE.call("verbatim:font", options, content)
 end)
 
-SILE.registerCommand("rule", function (options, _)
+SILE.registerCommand("HorizontalRule", function (options, _)
   options.height = options.height or "0.2pt"
   options.width = options.width or SILE.typesetter.frame:lineWidth()
   SILE.call("hrule", options)
 end)
 
-SILE.registerCommand("span", function (options, content)
-  handlePandocArgs(options)
-  for _, class in pairs(options.classes) do
-    SU.debug("pandoc", "Add div class "..class)
-  end
-  SILE.process(content)
+SILE.registerCommand("Span", function (options, content)
+  SILE.settings.temporarily(function ()
+    handlePandocArgs(options)
+    SILE.process(content)
+  end)
 end,"Generic inline wrapper")
 
-SILE.registerCommand("div", function (options, content)
-  handlePandocArgs(options)
-  SILE.process(content)
+SILE.registerCommand("Div", function (options, content)
+  SILE.settings.temporarily(function ()
+    handlePandocArgs(options)
+    SILE.process(content)
+  end)
 end,"Generic inline wrapper")
 
-SILE.registerCommand("emph", function (options, content)
-  handlePandocArgs(options)
+SILE.registerCommand("Emph", function (options, content)
   SILE.call("em", {}, content)
 end,"Inline emphasis wrapper")
 
-local oldStrong = SILE.Commands["strong"]
-SILE.registerCommand("strong", function (options, content)
-  handlePandocArgs(options)
-  oldStrong(options, content)
+SILE.registerCommand("Strong", function (options, content)
+  SILE.call("strong", {}, content)
 end,"Inline strong wrapper")
 
-SILE.registerCommand("smallcaps", function (options, content)
-  handlePandocArgs(options)
+SILE.registerCommand("SmallCaps", function (options, content)
   SILE.call("font", { features = "+smcp" }, content)
 end,"Inline small caps wrapper")
 
 SILE.registerCommand("csl-no-emph", function (options, content)
-  handlePandocArgs(options)
   SILE.call("font", { style = "Roman" }, content)
 end,"Inline upright wrapper")
 
 SILE.registerCommand("csl-no-strong", function (options, content)
-  handlePandocArgs(options)
   SILE.call("font", { weight = 400 }, content)
 end,"Inline normal weight wrapper")
 
 SILE.registerCommand("csl-no-smallcaps", function (options, content)
-  handlePandocArgs(options)
   SILE.call("font", { features = "-smcp" }, content)
 end,"Inline smallcaps disable wrapper")
 
 local scriptOffset = "0.7ex"
 local scriptSize = "1.5ex"
 
-SILE.registerCommand("superscript", function (options, content)
-  handlePandocArgs(options)
+SILE.registerCommand("Superscript", function (options, content)
   SILE.call("raise", { height = scriptOffset }, function ()
     SILE.call("font", { size = scriptSize }, content)
   end)
 end,"Inline superscript wrapper")
 
-SILE.registerCommand("subscript", function (options, content)
-  handlePandocArgs(options)
+SILE.registerCommand("Subscript", function (options, content)
   SILE.call("lower", { height = scriptOffset }, function ()
     SILE.call("font", { size = scriptSize }, content)
   end)
 end,"Inline subscript wrapper")
 
 SILE.registerCommand("unimplemented", function (options, content)
-  handlePandocArgs(options)
   SU.debug("pandoc", "Un-implemented function")
   SILE.process(content)
 end,"Unimplemented Pandoc function wrapper")
@@ -107,19 +104,19 @@ Provided by in base classes etc.:
 
 Modified from default:
 
-\listitem \code{strong}
 
 Provided specifically for Pandoc:
 
-\listitem \code{span}
-\listitem \code{div}
-\listitem \code{emph}
-\listitem \code{smallcaps}
-\listitem \code{strikeout}
+\listitem \code{Span}
+\listitem \code{Div}
+\listitem \code{Emph}
+\listitem \code{Strong}
+\listitem \code{SmallCaps}
+\listitem \code{Strikeout}
 \listitem \code{csl-no-emph}
 \listitem \code{csl-no-strong}
 \listitem \code{csl-no-smallcaps}
-\listitem \code{superscript}
-\listitem \code{subscript}
+\listitem \code{Superscript}
+\listitem \code{Subscript}
 
 \end{document}]] }

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -1,3 +1,7 @@
+SILE.require("packages/url")
+SILE.require("packages/pdf")
+SILE.require("packages/image")
+SILE.require("packages/footnotes")
 SILE.require("packages/raiselower")
 
 -- Process arguments that might not actually have that much to do with their
@@ -8,6 +12,20 @@ local handlePandocArgs = function (options)
     SU.debug("pandoc", "Set ID on tag")
   end
 end
+
+SILE.registerCommand("label", function(options, content)
+  SILE.call("pdf:bookmark", options, content)
+end)
+
+SILE.registerCommand("tt", function(options, content)
+  SILE.call("verbatim:font", options, content)
+end)
+
+SILE.registerCommand("rule", function (options, _)
+  options.height = options.height or "0.2pt"
+  options.width = options.width or SILE.typesetter.frame:lineWidth()
+  SILE.call("hrule", options)
+end)
 
 SILE.registerCommand("textem", function (options, content)
   handlePandocArgs(options)

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -1,0 +1,85 @@
+SILE.require("packages/raiselower")
+
+-- Process arguments that might not actually have that much to do with their
+-- immediate function but affect the document in other ways, such as setting
+-- bookmarks on anything tagged with an ID attribute.
+local handlePandocArgs = function (options)
+  if options.id then
+    SU.debug("pandoc", "Set ID on tag")
+  end
+end
+
+SILE.registerCommand("textem", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("em", {}, content)
+end,"Inline emphasis wrapper")
+
+SILE.registerCommand("textstrong", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("strong", {}, content)
+end,"Inline strong wrapper")
+
+SILE.registerCommand("textsc", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("font", { features = "+smcp" }, content)
+end,"Inline small caps wrapper")
+
+SILE.registerCommand("textup", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("font", { style = "Roman" }, content)
+end,"Inline upright wrapper")
+
+SILE.registerCommand("textnormal", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("font", { weight = 400 }, content)
+end,"Inline upright wrapper")
+
+local scriptOffset = "0.7ex"
+local scriptSize = "1.5ex"
+
+SILE.registerCommand("textsuperscript", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("raise", { height = scriptOffset }, function ()
+    SILE.call("font", { size = scriptSize }, content)
+  end)
+end,"Inline superscript wrapper")
+
+SILE.registerCommand("textsubscript", function (options, content)
+  handlePandocArgs(options)
+  SILE.call("lower", { height = scriptOffset }, function ()
+    SILE.call("font", { size = scriptSize }, content)
+  end)
+end,"Inline subscript wrapper")
+
+SILE.registerCommand("unimplemented", function (options, content)
+  handlePandocArgs(options)
+  SU.debug("pandoc", "Un-implemented function")
+  SILE.process(content)
+end,"Inline small caps wrapper")
+
+SILE.Commands["strike"] = SILE.Commands["unimplemented"]
+SILE.Commands["strike"] = SILE.Commands["unimplemented"]
+
+
+return { documentation = [[\begin{document}
+
+Try to cover all the possible commands Pandoc's SILE export might throw at us.
+
+Provided by in base classes etc.:
+
+\listitem \code{listarea}
+\listitem \code{listitem}
+
+Provided specifically for Pandoc:
+
+\listitem \code{span}
+\listitem \code{textem}
+\listitem \code{textstrong}
+\listitem \code{textsc}
+\listitem \code{textnosc}
+\listitem \code{textnoem}
+\listitem \code{textnostrong}
+\listitem \code{textsuperscript}
+\listitem \code{textsubscript}
+
+\end{document}]] }


### PR DESCRIPTION
I've been using an automated book publishing workflow starting with canonical sources in Markdown, processed through Pandoc, written out to SILE for typesetting, and the result sent directly to press for some time now. A dozen books and dozens of other publications later, this workflow has been through several iterations:

1. I started with a hacked version of Pandoc that butchered the LaTeX output, crammed it in a SILE document wrapper, added some command patches so that it didn't just get thrown back up, and crossed my fingers. Books went to press this way, but it sure wasn't a process I could hand off to anybody else.

2. I then hacked together a new document writer for Pandoc (still modeled after the LaTeX one) that wrote out something a lot more SILE looking. This included ripping out everything it couldn't cope with anyway (i.e. tables, figures, math, etc.) and using simplified "sile-ish" commands. Still the default out of the box SILE didn't have all the necessary commands, so the template it was producing had to include definitions for them. More books went to press this way, but the Pandoc code was still to messy to contribute upstream.

3. More recently I started realizing that there was no reason _not to_ take more radical departures from the LaTeX like output and make the output more consistent and similar to the Pandoc's internal AST.  Trying to target "sile" as an output format is difficult when the format itself is still relatively incomplete. I started re-hashing the output with this in mind and discovered it was a lot easier to implement all the commands necessary in Lua than trying to recreate the expected document behavior from existing commands. I started a Lua library of my own to add SILE commands for everything Pandoc generates. Another book has gone to press this way.

Development got a lot easier once I got well into phase 3. Part of this is I'm much better with Lua than Haskell, but the other part of it is that Pandoc doesn't have to try to cobble together something that works, it can just pass off all the hard work to the typesetter and forget about it. **This has the added benefit of giving end users a way to manipulate the result much easier.** For example rather than trying to teach Pandoc how to output a rule using `\hrule[height=0.2pt,width=100%lw]` which makes the resulting document difficult to re-style if desired, it would just output `\HorizontalRule` (the command name matching the internal AST for the element type), the SILE command would have some defaults for this, and the user could override them in a style sheet if desired.  

As such I would like to propose that — instead of trying to teach Pandoc a bunch of "tricks" telling SILE exactly how to output each element of a document, we add a package that teaches SILE what to do with all the document elements Pandoc might ever throw at it. A template would still be needed on the Pandoc end, but this would be as bare bones as possible and basically just import the one package from SILE. Every element would be named to match the way Pandoc thinks about them, and all attributes would be passed on.

This PR isn't ready for merging yet, but it is a start to this approach and I wouldn't mind hearing some feedback. If this works it would make it relatively easy to finish and contribute the Pandoc end of things upstream.