### PR TITLE
Native math typesetting support via ASCIIMath→MathML

### DIFF
--- a/core/math.lua
+++ b/core/math.lua
@@ -135,6 +135,7 @@ local _mbox = _box {
   relX = 0, -- x position relative to its parent box
   relY = 0, -- y position relative to its parent box
   value = {},
+  mode = mathMode.display,
   __tostring = function (s) return s.type end,
   init = function(self)
     local options = {
@@ -219,7 +220,6 @@ local _stackbox = _mbox {
   styleChildren = function(self)
     for i, n in ipairs(self.children) do
       n.mode = self.mode
-      n.options = std.tree.clone(self.options)
     end
   end,
   setChildrenRelXY = function(self)
@@ -304,22 +304,11 @@ local _subscript = _mbox {
   end,
   styleChildren = function(self)
     self.children[1].mode = self.mode
-    if self.children[2] then self.children[2].mode = getSubscriptMode(self.mode) end
-    if self.children[3] then self.children[3].mode = getSuperscriptMode(self.mode) end
-    self.children[1].options = std.tree.clone(self.options)
-
-    local constants = getMathMetrics(self.options).constants
-    for i = 2,3 do
-      if self.children[i] then
-        self.children[i].options = std.tree.clone(self.options)
-        if self.children[i].mode == mathMode.script or self.children[i].mode == math.scriptCramped then
-          local fontSize = SILE.font.loadDefaults(self.options).size * constants.scriptPercentScaleDown
-          self.children[i].options.size = fontSize
-        elseif self.children[i].mode == mathMode.scriptScript or self.children[i].mode == math.scriptScriptCramped then
-          local fontSize = SILE.font.loadDefaults(self.options).size * constants.scriptScriptPercentScaleDown
-          self.children[i].options.size = fontSize
-        end
-      end
+    if self.children[2] then
+      self.children[2].mode = getSubscriptMode(self.mode)
+    end
+    if self.children[3] then
+      self.children[3].mode = getSuperscriptMode(self.mode)
     end
   end,
   setChildrenRelXY = function(self)
@@ -376,7 +365,7 @@ local _terminal = _mbox {
   setChildrenRelXY = function(self) end
 }
 
--- text node
+-- text node. For any actual text output
 local _text = _terminal {
   type = "text",
   _type = "Text",
@@ -404,8 +393,10 @@ local _text = _terminal {
   end,
   shape = function(self)
     local face = SILE.font.cache(self.options, SILE.shaper.getFace)
-    if self.mode == mathMode.script or self.mode == mathMode.scriptCramped then
-      local fontSize = math.floor(self.options.size * 0.7)
+    if self.mode == mathMode.script or self.mode == mathMode.scriptCramped or
+        self.mode == mathMode.scriptScript or self.mode == mathMode.scriptScriptCramped then
+      local constants = getMathMetrics(self.options).constants
+      local fontSize = math.floor(self.options.size * ((self.mode == mathMode.script or self.mode == mathMode.scriptCramped) and 0.7 or 0.5))
       face.size = fontSize
       self.options.size = fontSize
     end

--- a/core/math.lua
+++ b/core/math.lua
@@ -214,6 +214,7 @@ local _stackbox = _mbox {
   styleChildren = function(self)
     for i, n in ipairs(self.children) do
       n.mode = self.mode
+      n.options = std.tree.clone(self.options)
     end
   end,
   setChildrenRelXY = function(self)
@@ -300,10 +301,24 @@ local _subscript = _mbox {
     self.children[1].mode = self.mode
     if self.children[2] then self.children[2].mode = getSubscriptMode(self.mode) end
     if self.children[3] then self.children[3].mode = getSuperscriptMode(self.mode) end
+    self.children[1].options = std.tree.clone(self.options)
+
+    local constants = getMathMetrics(self.options).constants
+    for i = 2,3 do
+      if self.children[i] then
+        self.children[i].options = std.tree.clone(self.options)
+        if self.children[i].mode == mathMode.script or self.children[i].mode == math.scriptCramped then
+          local fontSize = SILE.font.loadDefaults(self.options).size * constants.scriptPercentScaleDown
+          self.children[i].options.size = fontSize
+        elseif self.children[i].mode == mathMode.scriptScript or self.children[i].mode == math.scriptScriptCramped then
+          local fontSize = SILE.font.loadDefaults(self.options).size * constants.scriptScriptPercentScaleDown
+          self.children[i].options.size = fontSize
+        end
+      end
+    end
   end,
   setChildrenRelXY = function(self)
     local constants = getMathMetrics(self.options).constants
-    print(constants)
     self.children[1].relX = 0
     self.children[1].relY = 0
     if self.children[2] then

--- a/core/math.lua
+++ b/core/math.lua
@@ -479,7 +479,7 @@ local _text = _terminal {
       for i = #glyphs, 1, -1 do
         self.width = i == #glyphs and SILE.length.make(glyphs[#glyphs].width) or self.width + glyphs[i].glyphAdvance
       end
-      for i = 2, #glyphs do
+      for i = 1, #glyphs do
         self.height = i == 1 and SILE.length.make(glyphs[i].height) or maxLength(self.height, glyphs[i].height)
         self.depth = i == 1 and SILE.length.make(glyphs[i].depth) or maxLength(self.depth, glyphs[i].depth)
       end

--- a/core/math.lua
+++ b/core/math.lua
@@ -1,0 +1,333 @@
+local nodefactory = require("core/nodefactory")
+require("core/typesetter")
+
+local mathStyle = {
+  display = 0,
+  displayCramped = 1,
+  text = 2,
+  textCramped = 3,
+  script = 4,
+  scriptCramped = 5,
+  scriptScript = 6,
+  scriptScriptCramped = 7
+}
+
+local atomType = {
+  ordinary = 0,
+  bigOperator = 1,
+  binaryOperator = 2,
+  relationalOperator = 3,
+  openingSymbol = 4,
+  closeSymbol = 5,
+  punctuationSymbol = 6,
+  inner = 7,
+  overlinedSymbol = 8,
+  underlinedSymbol = 9,
+  accentedSymbol = 10,
+  radicalSymbol = 11,
+  vcenter = 12
+}
+
+-- Style transition functions for superscript and subscript
+local function getSuperscriptStyle(style)
+  if style == mathStyle.display or style == mathStyle.displayCramped then return mathStyle.script                 -- D, T -> S
+  elseif style == mathStyle.displayCramped or style == mathStyle.textCramped then return mathStyle.scriptCramped  -- D', T' -> S'
+  elseif style == mathStyle.script or style == mathStyle.scriptScript then return mathStyle.scriptScript          -- S, SS -> SS
+  else return mathStyle.scriptScriptCramped end                                                                   -- S', SS' -> SS'
+end
+local function getSubscriptStyle(style)
+  if style == mathStyle.display or style == mathStyle.displayCramped
+      or style == mathStyle.displayCramped or style == mathStyle.textCramped then return mathStyle.scriptCramped  -- D, T, D', T' -> S'
+  else return mathStyle.scriptScriptCramped end                                                                   -- S, SS, S', SS' -> SS'
+end
+
+-- Style transition functions for fraction (numerator and denominator)
+local function getNumeratorStyle(style)
+  if style == mathStyle.display then return mathStyle.text                                                -- D -> T
+  elseif style == mathStyle.displayCramped then return mathStyle.textCramped                              -- D' -> T'
+  elseif style == mathStyle.text then return mathStyle.script                                             -- T -> S
+  elseif style == mathStyle.textCramped then return mathStyle.scriptCramped                               -- T' -> S'
+  elseif style == mathStyle.script or style == mathStyle.scriptScript then return mathStyle.scriptScript  -- S, SS -> SS
+  else return mathStyle.scriptScriptCramped end                                                           -- S', SS' -> SS'
+end
+local function getDenominatorStyle(style)
+  if style == mathStyle.display or style == mathStyle.displayCramped then return mathStyle.text           -- D, D' -> T'
+  elseif style == mathStyle.text or style == mathStyle.textCramped then return mathStyle.script           -- T, T' -> S'
+  else return mathStyle.scriptScriptCramped end                                                           -- S, SS, S', SS' -> SS'
+end 
+
+function _box:isMathBox () return self.type == "math" end
+
+-- function _box:isRule () return self.type == "rule" end
+
+-- math box, box with a horizontal shift value and could contain zero or more _mbox'es (or its child classes)
+-- the entire math environment itself is a top-level mbox.
+-- Typesetting of mbox evolves four steps:
+--   1. Determine the style for each mbox according to their parent.
+--   2. Shape the mbox hierarchy from leaf to top. Get the shape and relative position.
+--   3. Recursively determine the position of the mbox's to the root mbox (i.e., add up the relative positions along the tree path)
+--   4. Convert mbox into _nnode's to put in SILE's typesetting framwork
+local _mbox = _box {
+  _type = "Mbox",
+  type = "math",
+  style = nil,
+  options = SILE.font.loadDefaults({}),
+  level = 0, -- The level in mbox hierarchy
+  children = {}, -- The child nodes
+  relX = nil, -- x position relative to its parent box
+  relY = nil, -- y position relative to its parent box
+  absX = nil, -- x position relative to the root
+  absY = nil, -- y position relative to the root
+  value = {},
+  __tostring = function (s) return s.type end,
+  init = function(self) return self end,
+
+  styleChildren = function(self)
+    SU.error("This is a virtual function that need to be overriden by its child classes")
+  end,
+
+  setChildrenRelXY = function(self)
+    SU.error("This is a virtual function that need to be overriden by its child classes")
+  end,
+
+  shapeYourself = function(self)
+    SU.error("This is a virtual function that need to be overriden by its child classes")
+  end,
+
+  outputYourself = function(self, typesetter, line)
+    SU.error("This is a virtual function that need to be overriden by its child classes")
+  end,
+
+  -- Determine the style of its descendants
+  styleDescendants = function(self)
+    self:styleChildren()
+    for i, n in ipairs(self.children) do
+      n:styleDescendants()
+    end
+  end,
+
+  -- shapeTree shapes the mbox and all its descendants in a recursive fashion
+  -- The inner-most leaf nodes determine their shape first, and then propagate to their parents
+  -- During the process, each node will determine its size by (width, height, depth)
+  -- and (relX, relY) which the relative position to its parent
+  shapeTree = function(self)
+    for i, n in ipairs(self.children) do
+      n:shapeTree()
+    end
+    self:setChildrenRelXY()
+    self:shapeYourself()
+  end,
+
+  -- positionDescendants calculates the "absolute" position of the descendants, not including itself.
+  positionDescendants = function(self)
+    for i, n in ipairs(self.children) do
+      n.absX = self.absX + n.relX
+      n.absY = self.absY + n.relY
+      n:positionDescendants()
+    end
+  end,
+
+  -- Output the node and all its descendants
+  outputTree = function(self, typesetter, line)
+    self:outputYourself(typesetter, line)
+    for i, n in ipairs(self.children) do
+      n:outputTree(typesetter, line)
+    end
+  end
+}
+
+-- _stackbox stacks its content one, either horizontally or vertically
+local _stackbox = _mbox {
+  _type = "Stackbox",
+  direction = "H", -- 'H' for horizontal, 'V' for vertical
+  __tostring = function (self)
+    local result = self.direction.."Box("
+    for i, n in ipairs(self.children) do
+      result = result..(i == 1 and "" or ", ")..tostring(n)
+    end
+    result = result..")"
+    return result
+  end,
+
+  styleChildren = function(self)
+    for i, n in ipairs(self.children) do
+      n.style = self.style
+    end
+  end,
+  setChildrenRelXY = function(self)
+    if self.children and #(self.children) > 0 then
+      for i, n in ipairs(self.children) do
+        if i == 1 then
+          -- Assuming the first children has the same anchor point as the parent
+          n.relX = 0
+          n.relY = 0
+        else
+          if self.direction == "H" then
+            -- Horizontal stackbox
+            n.relX = self.children[i - 1].relX + self.children[i - 1].width
+            n.relY = 0
+          else -- self.direction == "V"
+            n.relX = 0
+            n.relY = self.children[i - 1].relY + self.children[i - 1].depth + n.height
+          end
+        end
+      end
+    else
+      self.relX = 0
+      self.relY = 0
+    end
+  end,
+  shapeYourself = function(self)
+    -- Get the minimum box that contains all children. Baseline is determined by relX, relY.
+    -- Along the stacking direction, the size of computed as last.end - first.start.
+    -- On the other direction, the size is max(end) - min(start).
+    -- Note that width/height/depth of children can all be negative.
+    if self.children and #(self.children) > 0 then
+      local first = self.children[1]
+      local last = self.children[#(self.children)]
+      if self.direction == 'H' then
+        self.width = last.relX + last.width - first.relX
+        for i, n in ipairs(self.children) do
+          if i == 1 then
+            self.height = n.height - n.relY
+            self.depth = n.depth + n.relY
+          else
+            if n.height - n.relY > self.height then self.height = n.height - n.relY end
+            if n.depth + n.relY > self.depth then self.depth = n.depth + n.relY end
+          end
+        end
+      else -- self.direction == 'V"
+        self.height = first.height - first.relY
+        self.depth = last.depth + first.relY
+        local minX = self.children[0].relX
+        local maxX = self.children[0].relX
+        for i, n in ipairs(self.children) do
+          if n.relX < minX then minX = n.relX end
+          if n.relX > maxX then maxX = n.relX end
+        end
+        self.width = maxX - minX
+      end
+    else
+      self.width = 0
+      self.height = 0
+      self.depth = 0
+    end
+  end,
+  -- Despite of its name, this function actually output the whole tree of nodes recursively
+  outputYourself = function(self)
+    for i, n in ipairs(self.children) do
+      n:outputYourself()
+    end
+  end
+}
+
+-- _terminal is the base class for leaf node
+local _terminal = _mbox {
+  type = "terminal",
+  styleChildren = function(self) end,
+  setChildrenRelXY = function(self) end
+}
+
+-- text node
+local _text = _terminal {
+  _type = "Text",
+  text = "",
+  options = SILE.font.loadDefaults({style="Italic"}),
+  __tostring = function(self) return "Text("..self.text..")" end,
+  shapeYourself = function(self)
+    local glyphs = SILE.shaper:shapeToken(self.text, self.options)
+    self.value.glyphString = {}
+    if glyphs and #glyphs > 0 then
+      for i = 1, #glyphs do
+        table.insert(self.value.glyphString, glyphs[i].gid)
+      end
+      self.width = glyphs[#glyphs].width
+      for i = 1, #glyphs-1 do
+        self.width = self.width + glyphs[i].glyphAdvance
+      end
+      self.height = glyphs[1].height
+      self.depth = glyphs[1].depth
+      for i = 2, #glyphs do
+        if glyphs[i].height > self.height then self.height = glyphs[i].height end
+        if glyphs[i].depth > self.depth then self.depth = glyphs[i].depth end
+      end
+      print(glyphs)
+    else
+      self.width = 0
+      self.height = 0
+      self.depth = 0
+    end
+  end,
+  outputYourself = function(self)
+    if not self.value.glyphString then return end
+    SILE.outputter.moveTo(SILE.typesetter.frame.state.cursorX, SILE.typesetter.frame.state.cursorY)
+    SILE.outputter.setFont(self.options)
+    SILE.outputter.outputHbox(self.value, self.width)
+  end
+}
+
+-- convert MathML into mbox
+local function ConvertMathML(content, mbox)
+  for i,v in ipairs(content) do
+    if type(v) == "string" then
+      v = v:gsub("^%s*(.-)%s*$", "%1")
+      if v and v ~= "" then
+        -- Add text node to mbox
+      end
+    elseif type(v) == "table" then
+      if v.id == 'command' then
+        if v.tag == 'mrow' then
+          local hbox = std.tree.clone(_stackbox({ direction='H' }))
+          ConvertMathML(v, hbox)
+          table.insert(mbox.children, hbox)
+        elseif v.tag == 'mi' then
+          local text = std.tree.clone(_text({ text=v[1] }))
+          table.insert(mbox.children, text)
+        end
+      else
+        ConvertMathML(v, mbox)
+      end
+    end
+  end
+end
+
+local newText = function(spec)
+  return _text(spec):init()
+end
+
+local newStackbox = function(spec)
+  return std.tree.clone(_stackbox(spec)):init()
+end
+
+SILE.nodefactory.math = {
+  newText=newText,
+  newStackbox = newStackbox
+}
+
+SILE.typesetter.pushMath = function(self, mbox)
+  return self:pushHorizontal(mbox)
+end
+
+SILE.registerCommand("mathml", function (options, content)
+  local mbox = newStackbox({ direction='V' })
+  ConvertMathML(content, mbox)
+
+  if #(mbox.children) == 1 then
+    mbox = mbox.children[1]
+  end
+  
+  SU.debug("math", mbox)
+  mbox.style = mathStyle.display -- or text
+  mbox:styleDescendants()
+
+  mbox:shapeTree()
+
+  mbox.absX = 0
+  mbox.absY = 0
+  mbox:positionDescendants()
+
+  print(mbox.width..' '..mbox.height..' '..mbox.depth)
+
+  SILE.typesetter:pushMath(mbox)
+
+end)

--- a/core/math.lua
+++ b/core/math.lua
@@ -47,11 +47,11 @@ local scriptType = {
 }
 
 local operatorAtomTypes = {
-  ['+'] = atomType.binAtoms,
-  ['-'] = atomType.binAtoms,
-  ['<'] = atomType.relAtoms,
-  ['>'] = atomType.relAtoms,
-  ['='] = atomType.relAtoms,
+  ['+'] = atomType.binaryOperator,
+  ['-'] = atomType.binaryOperator,
+  ['<'] = atomType.relationalOperator,
+  ['>'] = atomType.relationalOperator,
+  ['='] = atomType.relationalOperator,
 }
 
 -- Foward declaration
@@ -560,7 +560,7 @@ local newSubscript = function(spec)
 end
 
 newSpace = function(spec)
-  local ret = _space(spec)
+  local ret = std.tree.clone(_space(spec))
   ret:init()
   return ret
 end

--- a/core/math.lua
+++ b/core/math.lua
@@ -374,21 +374,19 @@ local function ConvertMathML(content)
   end
   if content.tag == 'math' then -- toplevel
     return newStackbox({
-      direction='V',
-      children=convertChildren(content)
-    })
+      direction='V', children=convertChildren(content) })
   elseif content.tag == 'mrow' then
     return newStackbox({
-      direction='H',
-      children=convertChildren(content)
-    })
+      direction='H', children=convertChildren(content) })
   elseif content.tag == 'mi' then
     return newText({ text=content[1] })
   elseif content.tag == 'msub' then
     return newSubscript({
-      kind="subscript",
-      children=convertChildren(content)
-    })
+      kind="subscript", children=convertChildren(content) })
+    elseif content.tag == 'msup' then
+      return newSubscript({
+        kind="superscript", children=convertChildren(content) })
+    
   else
     return nil
   end

--- a/core/math.lua
+++ b/core/math.lua
@@ -1,5 +1,5 @@
 local nodefactory = require("core/nodefactory")
-require("core/typesetter")
+local hb = require("justenoughharfbuzz")
 
 local mathStyle = {
   display = 0,
@@ -40,7 +40,17 @@ local function getFont(options)
     family=SILE.settings.get("math.font.family")
   })
   if options.family then font.family = options.family end
+  if options.size then font.size = options.size end
   return font
+end
+
+local function getMathConstant(options)
+  local font = getFont(options)
+  local face = SILE.font.cache(font, SILE.shaper.getFace)
+  if not face then
+    SU.error("Could not find requested font "..options.." or any suitable substitutes")
+  end
+  return hb.get_math_constants(face.data, face.index, font.size)
 end
 
 -- Style transition functions for superscript and subscript
@@ -85,14 +95,10 @@ function _box:isMathBox () return self.type == "math" end
 local _mbox = _box {
   _type = "Mbox",
   type = "math",
-  style = nil,
   options = {},
-  level = 0, -- The level in mbox hierarchy
   children = {}, -- The child nodes
-  relX = nil, -- x position relative to its parent box
-  relY = nil, -- y position relative to its parent box
-  absX = nil, -- x position relative to the root
-  absY = nil, -- y position relative to the root
+  relX = 0, -- x position relative to its parent box
+  relY = 0, -- y position relative to its parent box
   value = {},
   __tostring = function (s) return s.type end,
   init = function(self) return self end,
@@ -105,7 +111,7 @@ local _mbox = _box {
     SU.error("This is a virtual function that need to be overriden by its child classes")
   end,
 
-  shapeYourself = function(self)
+  shape = function(self)
     SU.error("This is a virtual function that need to be overriden by its child classes")
   end,
 
@@ -130,23 +136,14 @@ local _mbox = _box {
       n:shapeTree()
     end
     self:setChildrenRelXY()
-    self:shapeYourself()
-  end,
-
-  -- positionDescendants calculates the "absolute" position of the descendants, not including itself.
-  positionDescendants = function(self)
-    for i, n in ipairs(self.children) do
-      n.absX = self.absX + n.relX
-      n.absY = self.absY + n.relY
-      n:positionDescendants()
-    end
+    self:shape()
   end,
 
   -- Output the node and all its descendants
   outputTree = function(self, x, y)
     self:output(x, y)
     for i, n in ipairs(self.children) do
-      n:outputTree(x, y)
+      n:outputTree(x + n.relX, y + n.relY)
     end
   end
 }
@@ -192,7 +189,7 @@ local _stackbox = _mbox {
       self.relY = 0
     end
   end,
-  shapeYourself = function(self)
+  shape = function(self)
     -- Get the minimum box that contains all children. Baseline is determined by relX, relY.
     -- Along the stacking direction, the size of computed as last.end - first.start.
     -- On the other direction, the size is max(end) - min(start).
@@ -232,9 +229,45 @@ local _stackbox = _mbox {
   outputYourself = function(self, typesetter, line)
     local mathX = typesetter.frame.state.cursorX
     local mathY = typesetter.frame.state.cursorY
-    self:outputTree(mathX, mathY)
+    self:outputTree(mathX + self.relX, mathY + self.relY)
     typesetter.frame.state.cursorX = mathX + self.width
     typesetter.frame.state.curosrY = mathY
+  end,
+  output = function(self, x, y) end
+}
+
+local _subscript = _mbox {
+  _type = "Subscript",
+  kind = "subscript",
+
+  styleChildren = function(self)
+    self.children[1].style = self.style
+    if self.kind == "subscript" then
+      self.children[2].style = getSubscriptStyle(self.style)
+    elseif self.kind == "superscript" then
+      self.children[2].style = getSuperscriptStyle(self.style)
+    end
+  end,
+  setChildrenRelXY = function(self)
+    self.children[1].relX = 0
+    self.children[1].relY = 0
+    if self.kind == "subscript" then
+      self.children[2].relX = self.children[1].width
+      self.children[2].relY = 1
+    elseif self.kind == "superscript" then
+      self.children[2].relX = self.children[1].width
+      self.children[2].relY = -3.75
+    end
+  end,
+  shape = function(self)
+    self.width = self.children[1].width + self.children[2].width
+    if self.kind == "subscript" then
+      self.height = self.children[1].height
+      self.depth = self.children[2].depth + 1
+    elseif self.kind == "superscript" then
+      self.height = self.children[2].height + 3.75
+      self.depth = self.children[1].depth
+    end
   end,
   output = function(self, x, y) end
 }
@@ -251,28 +284,35 @@ local _text = _terminal {
   _type = "Text",
   text = "",
   options = { style="Italic" },
-  __tostring = function(self) return "Text("..self.text..")" end,
+  __tostring = function(self) return "Text("..(self.originalText or self.text)..")" end,
   init = function(self)
     local converted = ""
     for uchr in SU.utf8codes(self.text) do
+      local dst_char = SU.utf8char(uchr)
       if uchr >= 0x41 and uchr <= 0x5A then -- Latin capital letter
         if self.options.style == "Italic" then
-          converted = converted..SU.utf8char(mathScriptConversionTable.italicLatinUpper(uchr))
-        else
-          converted = converted..SU.utf8char(uchr)
+          dst_char = SU.utf8char(mathScriptConversionTable.italicLatinUpper(uchr))
         end
       elseif uchr >= 0x61 and uchr <= 0x7A then -- Latin non-capital letter
         if self.options.style == "Italic" then
-          converted = converted..SU.utf8char(mathScriptConversionTable.italicLatinLower(uchr))
-        else
-          converted = converted..SU.utf8char(uchr)
+          dst_char = SU.utf8char(mathScriptConversionTable.italicLatinLower(uchr))
         end
       end
+      converted = converted..dst_char
     end
-    self.text = converted
+    self.originalText = self.text
+    self.text = converted 
   end,
-  shapeYourself = function(self)
-    local glyphs = SILE.shaper:shapeToken(self.text, getFont(self.options))
+  shape = function(self)
+    local font = getFont(self.options)
+    if self.style == mathStyle.script or self.style == mathStyle.scriptCramped then
+      local fontSize = math.floor(font.size * 0.7)
+      font.size = fontSize
+      self.options.size = fontSize
+    end
+    local glyphs = SILE.shaper:shapeToken(self.text, font)
+    -- self.value.items = glyphs
+    -- self.value.complex = true
     self.value.glyphString = {}
     if glyphs and #glyphs > 0 then
       for i = 1, #glyphs do
@@ -296,14 +336,15 @@ local _text = _terminal {
   end,
   output = function(self, x, y)
     if not self.value.glyphString then return end
-    SILE.outputter.moveTo(x + self.absX, y + self.absY)
+    print('Output '..self.value.glyphString.." to "..x..", "..y)
+    SILE.outputter.moveTo(x, y)
     SILE.outputter.setFont(getFont(self.options))
     SILE.outputter.outputHbox(self.value, self.width)
   end
 }
 
 local newText = function(spec)
-  local ret = _text(spec)
+  local ret = std.tree.clone(_text(spec))
   ret:init()
   return ret
 end
@@ -314,28 +355,42 @@ local newStackbox = function(spec)
   return ret
 end
 
+local newSubscript = function(spec)
+  local ret = std.tree.clone(_subscript(spec))
+  ret:init()
+  return ret
+end
+
 -- convert MathML into mbox
-local function ConvertMathML(content, mbox)
-  for i,v in ipairs(content) do
-    if type(v) == "string" then
-      v = v:gsub("^%s*(.-)%s*$", "%1")
-      if v and v ~= "" then
-        -- Add text node to mbox
-      end
-    elseif type(v) == "table" then
-      if v.id == 'command' then
-        if v.tag == 'mrow' then
-          local hbox = newStackbox({ direction='H', level=mbox.level+1 })
-          ConvertMathML(v, hbox)
-          table.insert(mbox.children, hbox)
-        elseif v.tag == 'mi' then
-          local text = newText({ text=v[1], level=mbox.level+1 })
-          table.insert(mbox.children, text)
-        end
-      else
-        ConvertMathML(v, mbox)
-      end
+local function ConvertMathML(content)
+  if content == nil or content.id == nil or content.tag == nil then return nil end
+  local convertChildren = function(content)
+    local mboxes = {}
+    for i, n in ipairs(content) do
+      local box = ConvertMathML(n)
+      if box then table.insert(mboxes, box) end
     end
+    return mboxes
+  end
+  if content.tag == 'math' then -- toplevel
+    return newStackbox({
+      direction='V',
+      children=convertChildren(content)
+    })
+  elseif content.tag == 'mrow' then
+    return newStackbox({
+      direction='H',
+      children=convertChildren(content)
+    })
+  elseif content.tag == 'mi' then
+    return newText({ text=content[1] })
+  elseif content.tag == 'msub' then
+    return newSubscript({
+      kind="subscript",
+      children=convertChildren(content)
+    })
+  else
+    return nil
   end
 end
 
@@ -348,9 +403,10 @@ SILE.typesetter.pushMath = function(self, mbox)
   return self:pushHorizontal(mbox)
 end
 
-SILE.registerCommand("mathml", function (options, content)
-  local mbox = newStackbox({ direction='V' })
-  ConvertMathML(content, mbox)
+SILE.registerCommand("math", function (options, content)
+  local mode = (options and options.mode) and options.mode or 'text'
+
+  local mbox = ConvertMathML(content, mbox)
 
   if #(mbox.children) == 1 then
     mbox = mbox.children[1]
@@ -361,12 +417,10 @@ SILE.registerCommand("mathml", function (options, content)
 
   mbox:shapeTree()
 
-  mbox.absX = 0
-  mbox.absY = 0
-  mbox:positionDescendants()
-
   print(mbox.width..' '..mbox.height..' '..mbox.depth)
 
   SILE.typesetter:pushMath(mbox)
+
+  -- print(getMathConstant({}))
 
 end)

--- a/core/math.lua
+++ b/core/math.lua
@@ -79,7 +79,11 @@ local function getMathConstants(options)
   if not face then
     SU.error("Could not find requested font "..options.." or any suitable substitutes")
   end
-  return hb.get_math_constants(face.data, face.index, font.size)
+  local constants = hb.get_math_constants(face.data, face.index, font.size)
+  if constants == nil then
+    SU.error("You must use a math font for math rendering.")
+  end
+  return constants
 end
 
 -- Style transition functions for superscript and subscript

--- a/core/math.lua
+++ b/core/math.lua
@@ -320,11 +320,13 @@ local _subscript = _mbox {
     end
     if self.children[3] then
       self.children[3].relX = self.children[1].width
+      print(constants.superscriptShiftUpCramped..' '..constants.superscriptShiftUp..' '..constants.superscriptBottomMin)
       self.children[3].relY = -math.max(
-        isCrampedMode(self.children[3].mode) and constants.superscriptShiftUpCramped or constants.superscriptShiftUp, -- or cramped
+        isCrampedMode(self.mode) and constants.superscriptShiftUpCramped or constants.superscriptShiftUp, -- or cramped
         self.children[1].height - constants.superscriptBaselineDropMax,
         self.children[3].depth + constants.superscriptBottomMin
       )
+      print('self.children[3].relY = '..self.children[3].relY)
       -- Italics correction
       local lastGid = getRightMostGlyphId(self.children[1])
       if lastGid > 0 then
@@ -550,7 +552,7 @@ SILE.registerCommand("math", function (options, content)
   if mode == 'display' then
     mbox.mode = mathMode.display
   elseif mode == 'text' then
-    mbox.mode = mathMode.text
+    mbox.mode = mathMode.textCramped
   else
     SU.error('Unknown math mode '..mode)
   end

--- a/core/opentype-parser.lua
+++ b/core/opentype-parser.lua
@@ -316,7 +316,8 @@ local function parseMath(s)
     local result = {}
     for i = 1, count do
       if type == "&MathValueRecord" then
-        result[coverageTable[i]] = fetchMathValueRecord(table[i], offset, fd)
+        fetchMathValueRecord(table[i], offset, fd)
+        result[coverageTable[i]] = table[i]
       elseif type == "&MathKernInfoRecord" then
         result[coverageTable[i]] = {
           topRightMathKern = table[i].topRightMathKernOffset ~= 0 and parseMathKern(offset + table[i].topRightMathKernOffset, fd) or nil,
@@ -385,7 +386,7 @@ local function parseMath(s)
                                      " mathTopAccentAttachmentOffset:u2"..
                                      " extendedShapeCoverageOffset:u2"..
                                      " mathKernInfoOffset:u2", fd)
-  local mathItalicsCorrectionInfo = parsePerGlyphTable(header.mathGlyphInfoOffset + mathGlyphInfo.mathItalicsCorrectionInfoOffset, "&MathValueRecord", fd)
+  local mathItalicsCorrection = parsePerGlyphTable(header.mathGlyphInfoOffset + mathGlyphInfo.mathItalicsCorrectionInfoOffset, "&MathValueRecord", fd)
   local mathTopAccentAttachment = parsePerGlyphTable(header.mathGlyphInfoOffset + mathGlyphInfo.mathTopAccentAttachmentOffset, "&MathValueRecord", fd)
   local extendedShapeCoverage = parseCoverage(header.mathGlyphInfoOffset + mathGlyphInfo.extendedShapeCoverageOffset, fd)
   local mathKernInfo = parsePerGlyphTable(header.mathGlyphInfoOffset + mathGlyphInfo.mathKernInfoOffset, "&MathKernInfoRecord", fd)
@@ -393,7 +394,7 @@ local function parseMath(s)
 
   return {
     mathConstants = mathConstants,
-    mathItalicsCorrectionInfo = mathItalicsCorrectionInfo,
+    mathItalicsCorrection = mathItalicsCorrection,
     mathTopAccentAttachment = mathTopAccentAttachment,
     extendedShapeCoverage = extendedShapeCoverage,
     mathKern = mathKern,

--- a/core/opentype-parser.lua
+++ b/core/opentype-parser.lua
@@ -186,6 +186,12 @@ local function parseSvg(s)
   return offsets
 end
 
+local function parseHead(s)
+  if s:len() <= 0 then return end
+  local fd = vstruct.cursor(s)
+  return vstruct.read(">majorVersion:u2 minorVersion:u2 fontRevision:u4 checkSumAdjustment:u4 magicNumber:u4 flags:u2 unitsPerEm:u2 created:u8 modified:u8 xMin:i2 yMin:i2 xMax:i2 yMax:i2 macStyle:u2 lowestRecPPEM:u2 fontDirectionHint:i2 indexToLocFormat:i2 glyphDataFormat:i2", fd)
+end
+
 local function parseMath(s)
   if s:len() <= 0 then return end
   local fd = vstruct.cursor(s)
@@ -399,6 +405,7 @@ local parseFont = function(face)
   if not face.font then
     local font = {}
 
+    font.head = parseHead(hb.get_table(face.data, face.index, "head"))
     font.names = parseName(hb.get_table(face.data, face.index, "name"))
     font.maxp = parseMaxp(hb.get_table(face.data, face.index, "maxp"))
     font.colr = parseColr(hb.get_table(face.data, face.index, "COLR"))
@@ -436,4 +443,4 @@ local getSVG = function(face, gid)
   return svg
 end
 
-return { parseFont = parseFont, getSVG = getSVG }
+return { parseHead = parseHead, parseMath = parseMath, parseFont = parseFont, getSVG = getSVG }

--- a/core/opentype-parser.lua
+++ b/core/opentype-parser.lua
@@ -223,24 +223,26 @@ local function parseMath(s)
     record.deviceTableOffset = nil
   end
   local parseConstants = function(offset, fd)
-    local mathConstantNames = { "scriptPercentScaleDown", "scriptScriptPercentScaleDown", "delimitedSubFormulaMinHeight",
-      "displayOperatorMinHeight", "accentBaseHeight", "flattenedAccentBaseHeight",
-      "subscriptShiftDown", "subscriptTopMax", "subscriptBaselineDropMin",
-      "superscriptShiftUp", "superscriptShiftUpCramped", "superscriptBottomMin",
-      "superscriptBaselineDropMax", "subSuperscriptGapMin", "superscriptBottomMaxWithSubscript",
-      "spaceAfterScript", "upperLimitGapMin", "upperLimitBaselineRiseMin",
-      "lowerLimitGapMin", "lowerLimitBaselineDropMin", "stackTopShiftUp",
-      "stackTopDisplayStyleShiftUp", "stackBottomShiftDown", "stackBottomDisplayStyleShiftDown",
-      "stackGapMin", "stackDisplayStyleGapMin", "stretchStackTopShiftUp",
-      "stretchStackBottomShiftDown", "stretchStackGapAboveMin", "stretchStackGapBelowMin",
-      "fractionNumeratorShiftUp", "fractionNumeratorDisplayStyleShiftUp", "fractionDenominatorShiftDown",
-      "fractionDenominatorDisplayStyleShiftDown", "fractionNumeratorGapMin", "fractionNumDisplayStyleGapMin",
-      "fractionRuleThickness", "fractionDenominatorGapMin", "fractionDenomDisplayStyleGapMin",
-      "skewedFractionHorizontalGap", "skewedFractionVerticalGap", "overbarVerticalGap",
-      "overbarRuleThickness", "overbarExtraAscender", "underbarVerticalGap",
-      "underbarRuleThickness", "underbarExtraDescender", "radicalVerticalGap",
-      "radicalDisplayStyleVerticalGap", "radicalRuleThickness", "radicalExtraAscender",
-      "radicalKernBeforeDegree", "radicalKernAfterDegree", "radicalDegreeBottomRaisePercent" }
+    local mathConstantNames = {
+      "scriptPercentScaleDown", "scriptScriptPercentScaleDown", "delimitedSubFormulaMinHeight",
+      "displayOperatorMinHeight", "mathLeading", "axisHeight",
+      "accentBaseHeight", "flattenedAccentBaseHeight", "subscriptShiftDown",
+      "subscriptTopMax", "subscriptBaselineDropMin", "superscriptShiftUp",
+      "superscriptShiftUpCramped", "superscriptBottomMin", "superscriptBaselineDropMax",
+      "subSuperscriptGapMin", "superscriptBottomMaxWithSubscript", "spaceAfterScript",
+      "upperLimitGapMin", "upperLimitBaselineRiseMin", "lowerLimitGapMin",
+      "lowerLimitBaselineDropMin", "stackTopShiftUp", "stackTopDisplayStyleShiftUp",
+      "stackBottomShiftDown", "stackBottomDisplayStyleShiftDown", "stackGapMin",
+      "stackDisplayStyleGapMin", "stretchStackTopShiftUp", "stretchStackBottomShiftDown",
+      "stretchStackGapAboveMin", "stretchStackGapBelowMin", "fractionNumeratorShiftUp",
+      "fractionNumeratorDisplayStyleShiftUp", "fractionDenominatorShiftDown", "fractionDenominatorDisplayStyleShiftDown",
+      "fractionNumeratorGapMin", "fractionNumDisplayStyleGapMin", "fractionRuleThickness",
+      "fractionDenominatorGapMin", "fractionDenomDisplayStyleGapMin", "skewedFractionHorizontalGap",
+      "skewedFractionVerticalGap", "overbarVerticalGap", "overbarRuleThickness",
+      "overbarExtraAscender", "underbarVerticalGap", "underbarRuleThickness",
+      "underbarExtraDescender", "radicalVerticalGap", "radicalDisplayStyleVerticalGap",
+      "radicalRuleThickness", "radicalExtraAscender", "radicalKernBeforeDegree",
+      "radicalKernAfterDegree", "radicalDegreeBottomRaisePercent" }
     local mathConstantTypes = { "i2", "i2", "u2",
       "u2", "{ &MathValueRecord }", "{ &MathValueRecord }",
       "{ &MathValueRecord }", "{ &MathValueRecord }", "{ &MathValueRecord }",
@@ -258,7 +260,8 @@ local function parseMath(s)
       "{ &MathValueRecord }", "{ &MathValueRecord }", "{ &MathValueRecord }",
       "{ &MathValueRecord }", "{ &MathValueRecord }", "{ &MathValueRecord }",
       "{ &MathValueRecord }", "{ &MathValueRecord }", "{ &MathValueRecord }",
-      "{ &MathValueRecord }", "{ &MathValueRecord }", "i2" }
+      "{ &MathValueRecord }", "{ &MathValueRecord }", "{ &MathValueRecord }",
+      "{ &MathValueRecord }", "i2" }
     local mathConstantFormat = ">@"..offset
     for i = 1, #(mathConstantNames) do
       mathConstantFormat = mathConstantFormat.." "..mathConstantNames[i]..":"..mathConstantTypes[i]

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -33,6 +33,7 @@ require("core/hyphenator-liang")
 require("core/languages")
 require("core/font")
 require("core/packagemanager")
+require("core/math")
 
 SILE.frameParser = require("core/frameparser")
 SILE.linebreak = require("core/break")

--- a/src/justenoughharfbuzz.c
+++ b/src/justenoughharfbuzz.c
@@ -323,117 +323,6 @@ int get_table (lua_State *L) {
   return 1;
 }
 
-#ifdef HB_OT_TAG_MATH
-struct MathConstantNameEntry {
-  hb_ot_math_constant_t id;
-  char *name;
-};
-
-int get_math_constants(lua_State *L) {
-  static struct MathConstantNameEntry constantNames_percent[] = {
-    { HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN, "ScriptPercentScaleDown" },
-    { HB_OT_MATH_CONSTANT_SCRIPT_SCRIPT_PERCENT_SCALE_DOWN, "ScriptScriptPercentScaleDown" },
-  };
-  static struct MathConstantNameEntry constantNames_number[] = {
-    { HB_OT_MATH_CONSTANT_DELIMITED_SUB_FORMULA_MIN_HEIGHT, "DelimitedScriptSubFormulaMinHeight" },
-    { HB_OT_MATH_CONSTANT_DISPLAY_OPERATOR_MIN_HEIGHT, "DisplayOperatorMinHeight" },
-    { HB_OT_MATH_CONSTANT_MATH_LEADING, "MathLeading" },
-    { HB_OT_MATH_CONSTANT_AXIS_HEIGHT, "AxisHeight" },
-    { HB_OT_MATH_CONSTANT_ACCENT_BASE_HEIGHT, "AccentBaseHeight" },
-    { HB_OT_MATH_CONSTANT_FLATTENED_ACCENT_BASE_HEIGHT, "FlattenedAccentBaseHeight" },
-    { HB_OT_MATH_CONSTANT_SUBSCRIPT_SHIFT_DOWN, "SubscriptShiftDown" },
-    { HB_OT_MATH_CONSTANT_SUBSCRIPT_TOP_MAX, "SubscriptTopMax" },
-    { HB_OT_MATH_CONSTANT_SUBSCRIPT_BASELINE_DROP_MIN, "SubscriptBaselineDropMin" },
-    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP, "SuperscriptShiftUp" },
-    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP_CRAMPED, "SuperscriptShiftUpCramped" },
-    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MIN, "SuperscriptBottomMin" },
-    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BASELINE_DROP_MAX, "SuperscriptBaselineDropMax" },
-    { HB_OT_MATH_CONSTANT_SUB_SUPERSCRIPT_GAP_MIN, "SubSuperscriptGapMin" },
-    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MAX_WITH_SUBSCRIPT, "SuperscriptBottomMaxWithSubscript" },
-    { HB_OT_MATH_CONSTANT_SPACE_AFTER_SCRIPT, "SpaceAfterScript" },
-    { HB_OT_MATH_CONSTANT_UPPER_LIMIT_GAP_MIN, "UpperLimitGapMin" },
-    { HB_OT_MATH_CONSTANT_UPPER_LIMIT_BASELINE_RISE_MIN, "UpperLimitBaselineRiseMin" },
-    { HB_OT_MATH_CONSTANT_LOWER_LIMIT_GAP_MIN, "LowerLimitGapMin" },
-    { HB_OT_MATH_CONSTANT_LOWER_LIMIT_BASELINE_DROP_MIN, "LowerLimitBaselineDropMin" },
-    { HB_OT_MATH_CONSTANT_STACK_TOP_SHIFT_UP, "StackTopShiftUp" },
-    { HB_OT_MATH_CONSTANT_STACK_TOP_DISPLAY_STYLE_SHIFT_UP, "StackTopDisplayStyleShiftUp" },
-    { HB_OT_MATH_CONSTANT_STACK_BOTTOM_SHIFT_DOWN, "StackBottomShiftDown" },
-    { HB_OT_MATH_CONSTANT_STACK_BOTTOM_DISPLAY_STYLE_SHIFT_DOWN, "StackBottomDisplayStyleShiftDown" },
-    { HB_OT_MATH_CONSTANT_STACK_GAP_MIN, "StackGapMin" },
-    { HB_OT_MATH_CONSTANT_STACK_DISPLAY_STYLE_GAP_MIN, "StackDisplayStyleGapMin" },
-    { HB_OT_MATH_CONSTANT_STRETCH_STACK_TOP_SHIFT_UP, "StretchStackTopShiftUp" },
-    { HB_OT_MATH_CONSTANT_STRETCH_STACK_BOTTOM_SHIFT_DOWN, "StretchStackBottomShiftDown" },
-    { HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_ABOVE_MIN, "StretchStackGapAboveMin" },
-    { HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_BELOW_MIN, "StretchStackGapBelowMin" },
-    { HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_SHIFT_UP, "FractionNumberatorShiftUp" },
-    { HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_DISPLAY_STYLE_SHIFT_UP, "FractionNumberatorDisplayStyleShiftUp" },
-    { HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_SHIFT_DOWN, "FractionDenominatorShiftDown" },
-    { HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_DISPLAY_STYLE_SHIFT_DOWN, "FractionDenominatorDisplayStyleShiftDown" },
-    { HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_GAP_MIN, "FractionNumberatorGapMin" },
-    { HB_OT_MATH_CONSTANT_FRACTION_NUM_DISPLAY_STYLE_GAP_MIN, "FractionNumDisplayStyleGapMin" },
-    { HB_OT_MATH_CONSTANT_FRACTION_RULE_THICKNESS, "FractionRuleThickness" },
-    { HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_GAP_MIN, "FractionDenominatorGapMin" },
-    { HB_OT_MATH_CONSTANT_FRACTION_DENOM_DISPLAY_STYLE_GAP_MIN, "FractionDenomDisplayStyleGapMin" },
-    { HB_OT_MATH_CONSTANT_SKEWED_FRACTION_HORIZONTAL_GAP, "SkewedFractionHorizontalGap" },
-    { HB_OT_MATH_CONSTANT_SKEWED_FRACTION_VERTICAL_GAP, "SkewedFractionVerticalGap" },
-    { HB_OT_MATH_CONSTANT_OVERBAR_VERTICAL_GAP, "OverbarVerticalGap" },
-    { HB_OT_MATH_CONSTANT_OVERBAR_RULE_THICKNESS, "OverbarRuleThickness" },
-    { HB_OT_MATH_CONSTANT_OVERBAR_EXTRA_ASCENDER, "OverbarExtraAscender" },
-    { HB_OT_MATH_CONSTANT_UNDERBAR_VERTICAL_GAP, "UnderbarVerticalGap" },
-    { HB_OT_MATH_CONSTANT_UNDERBAR_RULE_THICKNESS, "UnderbarRuleThickness" },
-    { HB_OT_MATH_CONSTANT_UNDERBAR_EXTRA_DESCENDER, "UnderbarExtraDescender" },
-    { HB_OT_MATH_CONSTANT_RADICAL_VERTICAL_GAP, "RadicalVerticalGap" },
-    { HB_OT_MATH_CONSTANT_RADICAL_DISPLAY_STYLE_VERTICAL_GAP, "RadicalDisplayStyleVerticalGap" },
-    { HB_OT_MATH_CONSTANT_RADICAL_RULE_THICKNESS, "RadicalRuleThickness" },
-    { HB_OT_MATH_CONSTANT_RADICAL_EXTRA_ASCENDER, "RadicalExtraAscender" },
-    { HB_OT_MATH_CONSTANT_RADICAL_KERN_BEFORE_DEGREE, "RadicalKernBeforeDegree" },
-    { HB_OT_MATH_CONSTANT_RADICAL_KERN_AFTER_DEGREE, "RadicalKernAfterDegree" },
-    { HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT, "RadicalDegreeBottomRaisePercent" },
-  };
-
-  size_t font_l;
-  const char * font_s = luaL_checklstring(L, 1, &font_l);
-  unsigned int font_index = luaL_checknumber(L, 2);
-  double point_size = luaL_checknumber(L, 3);
-
-  hb_blob_t * blob = hb_blob_create (font_s, font_l, HB_MEMORY_MODE_WRITABLE, (void*)font_s, NULL);
-  hb_face_t * face = hb_face_create (blob, font_index);
-  hb_font_t * font = hb_font_create (face);
-  unsigned int upem = hb_face_get_upem(face);
-
-  if (hb_ot_math_has_data(face)) {
-    lua_newtable(L);
-    for (int i = 0; i < sizeof(constantNames_percent) / sizeof(struct MathConstantNameEntry); ++i) {
-      hb_ot_math_constant_t constantId = constantNames_percent[i].id;
-      char *constantName = constantNames_percent[i].name;
-
-      hb_position_t value = hb_ot_math_get_constant(font, constantId);
-
-      lua_pushstring(L, constantName);
-      lua_pushnumber(L, value / 100.0);
-      lua_settable(L, -3);
-    }
-    for (int i = 0; i < sizeof(constantNames_number) / sizeof(struct MathConstantNameEntry); ++i) {
-      hb_ot_math_constant_t constantId = constantNames_number[i].id;
-      char *constantName = constantNames_number[i].name;
-
-      hb_position_t value = hb_ot_math_get_constant(font, constantId);
-
-      lua_pushstring(L, constantName);
-      lua_pushnumber(L, value * point_size / upem);
-      lua_settable(L, -3);
-    }
-  } else {
-    lua_pushnil(L);
-  }
-  
-  hb_font_destroy(font);
-  hb_face_destroy(face);
-  hb_blob_destroy(blob);
-  return 1;
-}
-#endif
-
 #if !defined LUA_VERSION_NUM
 /* Lua 5.0 */
 #define luaL_Reg luaL_reg
@@ -462,9 +351,6 @@ static const struct luaL_Reg lib_table [] = {
   {"version", get_harfbuzz_version},
   {"shapers", list_shapers},
   {"get_table", get_table},
-#ifdef HB_OT_TAG_MATH
-  {"get_math_constants", get_math_constants},
-#endif
   {NULL, NULL}
 };
 

--- a/src/justenoughharfbuzz.c
+++ b/src/justenoughharfbuzz.c
@@ -348,7 +348,7 @@ int get_math_constants(lua_State *L) {
     { HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP_CRAMPED, "SuperscriptShiftUpCramped" },
     { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MIN, "SuperscriptBottomMin" },
     { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BASELINE_DROP_MAX, "SuperscriptBaselineDropMax" },
-    { HB_OT_MATH_CONSTANT_SUB_SUPERSCRIPT_GAP_MIN, "ScriptSubSuperscriptGapMin" },
+    { HB_OT_MATH_CONSTANT_SUB_SUPERSCRIPT_GAP_MIN, "SubSuperscriptGapMin" },
     { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MAX_WITH_SUBSCRIPT, "SuperscriptBottomMaxWithSubscript" },
     { HB_OT_MATH_CONSTANT_SPACE_AFTER_SCRIPT, "SpaceAfterScript" },
     { HB_OT_MATH_CONSTANT_UPPER_LIMIT_GAP_MIN, "UpperLimitGapMin" },

--- a/src/justenoughharfbuzz.c
+++ b/src/justenoughharfbuzz.c
@@ -323,6 +323,117 @@ int get_table (lua_State *L) {
   return 1;
 }
 
+#ifdef HB_OT_TAG_MATH
+struct MathConstantNameEntry {
+  hb_ot_math_constant_t id;
+  char *name;
+};
+
+int get_math_constants(lua_State *L) {
+  static struct MathConstantNameEntry constantNames_percent[] = {
+    { HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN, "ScriptPercentScaleDown" },
+    { HB_OT_MATH_CONSTANT_SCRIPT_SCRIPT_PERCENT_SCALE_DOWN, "ScriptScriptPercentScaleDown" },
+  };
+  static struct MathConstantNameEntry constantNames_number[] = {
+    { HB_OT_MATH_CONSTANT_DELIMITED_SUB_FORMULA_MIN_HEIGHT, "DelimitedScriptSubFormulaMinHeight" },
+    { HB_OT_MATH_CONSTANT_DISPLAY_OPERATOR_MIN_HEIGHT, "DisplayOperatorMinHeight" },
+    { HB_OT_MATH_CONSTANT_MATH_LEADING, "MathLeading" },
+    { HB_OT_MATH_CONSTANT_AXIS_HEIGHT, "AxisHeight" },
+    { HB_OT_MATH_CONSTANT_ACCENT_BASE_HEIGHT, "AccentBaseHeight" },
+    { HB_OT_MATH_CONSTANT_FLATTENED_ACCENT_BASE_HEIGHT, "FlattenedAccentBaseHeight" },
+    { HB_OT_MATH_CONSTANT_SUBSCRIPT_SHIFT_DOWN, "SubscriptShiftDown" },
+    { HB_OT_MATH_CONSTANT_SUBSCRIPT_TOP_MAX, "SubscriptTopMax" },
+    { HB_OT_MATH_CONSTANT_SUBSCRIPT_BASELINE_DROP_MIN, "SubscriptBaselineDropMin" },
+    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP, "SuperscriptShiftUp" },
+    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP_CRAMPED, "SuperscriptShiftUpCramped" },
+    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MIN, "SuperscriptBottomMin" },
+    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BASELINE_DROP_MAX, "SuperscriptBaselineDropMax" },
+    { HB_OT_MATH_CONSTANT_SUB_SUPERSCRIPT_GAP_MIN, "ScriptSubSuperscriptGapMin" },
+    { HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MAX_WITH_SUBSCRIPT, "SuperscriptBottomMaxWithSubscript" },
+    { HB_OT_MATH_CONSTANT_SPACE_AFTER_SCRIPT, "SpaceAfterScript" },
+    { HB_OT_MATH_CONSTANT_UPPER_LIMIT_GAP_MIN, "UpperLimitGapMin" },
+    { HB_OT_MATH_CONSTANT_UPPER_LIMIT_BASELINE_RISE_MIN, "UpperLimitBaselineRiseMin" },
+    { HB_OT_MATH_CONSTANT_LOWER_LIMIT_GAP_MIN, "LowerLimitGapMin" },
+    { HB_OT_MATH_CONSTANT_LOWER_LIMIT_BASELINE_DROP_MIN, "LowerLimitBaselineDropMin" },
+    { HB_OT_MATH_CONSTANT_STACK_TOP_SHIFT_UP, "StackTopShiftUp" },
+    { HB_OT_MATH_CONSTANT_STACK_TOP_DISPLAY_STYLE_SHIFT_UP, "StackTopDisplayStyleShiftUp" },
+    { HB_OT_MATH_CONSTANT_STACK_BOTTOM_SHIFT_DOWN, "StackBottomShiftDown" },
+    { HB_OT_MATH_CONSTANT_STACK_BOTTOM_DISPLAY_STYLE_SHIFT_DOWN, "StackBottomDisplayStyleShiftDown" },
+    { HB_OT_MATH_CONSTANT_STACK_GAP_MIN, "StackGapMin" },
+    { HB_OT_MATH_CONSTANT_STACK_DISPLAY_STYLE_GAP_MIN, "StackDisplayStyleGapMin" },
+    { HB_OT_MATH_CONSTANT_STRETCH_STACK_TOP_SHIFT_UP, "StretchStackTopShiftUp" },
+    { HB_OT_MATH_CONSTANT_STRETCH_STACK_BOTTOM_SHIFT_DOWN, "StretchStackBottomShiftDown" },
+    { HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_ABOVE_MIN, "StretchStackGapAboveMin" },
+    { HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_BELOW_MIN, "StretchStackGapBelowMin" },
+    { HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_SHIFT_UP, "FractionNumberatorShiftUp" },
+    { HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_DISPLAY_STYLE_SHIFT_UP, "FractionNumberatorDisplayStyleShiftUp" },
+    { HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_SHIFT_DOWN, "FractionDenominatorShiftDown" },
+    { HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_DISPLAY_STYLE_SHIFT_DOWN, "FractionDenominatorDisplayStyleShiftDown" },
+    { HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_GAP_MIN, "FractionNumberatorGapMin" },
+    { HB_OT_MATH_CONSTANT_FRACTION_NUM_DISPLAY_STYLE_GAP_MIN, "FractionNumDisplayStyleGapMin" },
+    { HB_OT_MATH_CONSTANT_FRACTION_RULE_THICKNESS, "FractionRuleThickness" },
+    { HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_GAP_MIN, "FractionDenominatorGapMin" },
+    { HB_OT_MATH_CONSTANT_FRACTION_DENOM_DISPLAY_STYLE_GAP_MIN, "FractionDenomDisplayStyleGapMin" },
+    { HB_OT_MATH_CONSTANT_SKEWED_FRACTION_HORIZONTAL_GAP, "SkewedFractionHorizontalGap" },
+    { HB_OT_MATH_CONSTANT_SKEWED_FRACTION_VERTICAL_GAP, "SkewedFractionVerticalGap" },
+    { HB_OT_MATH_CONSTANT_OVERBAR_VERTICAL_GAP, "OverbarVerticalGap" },
+    { HB_OT_MATH_CONSTANT_OVERBAR_RULE_THICKNESS, "OverbarRuleThickness" },
+    { HB_OT_MATH_CONSTANT_OVERBAR_EXTRA_ASCENDER, "OverbarExtraAscender" },
+    { HB_OT_MATH_CONSTANT_UNDERBAR_VERTICAL_GAP, "UnderbarVerticalGap" },
+    { HB_OT_MATH_CONSTANT_UNDERBAR_RULE_THICKNESS, "UnderbarRuleThickness" },
+    { HB_OT_MATH_CONSTANT_UNDERBAR_EXTRA_DESCENDER, "UnderbarExtraDescender" },
+    { HB_OT_MATH_CONSTANT_RADICAL_VERTICAL_GAP, "RadicalVerticalGap" },
+    { HB_OT_MATH_CONSTANT_RADICAL_DISPLAY_STYLE_VERTICAL_GAP, "RadicalDisplayStyleVerticalGap" },
+    { HB_OT_MATH_CONSTANT_RADICAL_RULE_THICKNESS, "RadicalRuleThickness" },
+    { HB_OT_MATH_CONSTANT_RADICAL_EXTRA_ASCENDER, "RadicalExtraAscender" },
+    { HB_OT_MATH_CONSTANT_RADICAL_KERN_BEFORE_DEGREE, "RadicalKernBeforeDegree" },
+    { HB_OT_MATH_CONSTANT_RADICAL_KERN_AFTER_DEGREE, "RadicalKernAfterDegree" },
+    { HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT, "RadicalDegreeBottomRaisePercent" },
+  };
+
+  size_t font_l;
+  const char * font_s = luaL_checklstring(L, 1, &font_l);
+  unsigned int font_index = luaL_checknumber(L, 2);
+  double point_size = luaL_checknumber(L, 3);
+
+  hb_blob_t * blob = hb_blob_create (font_s, font_l, HB_MEMORY_MODE_WRITABLE, (void*)font_s, NULL);
+  hb_face_t * face = hb_face_create (blob, font_index);
+  hb_font_t * font = hb_font_create (face);
+  unsigned int upem = hb_face_get_upem(face);
+
+  if (hb_ot_math_has_data(face)) {
+    lua_newtable(L);
+    for (int i = 0; i < sizeof(constantNames_percent) / sizeof(struct MathConstantNameEntry); ++i) {
+      hb_ot_math_constant_t constantId = constantNames_percent[i].id;
+      char *constantName = constantNames_percent[i].name;
+
+      hb_position_t value = hb_ot_math_get_constant(font, constantId);
+
+      lua_pushstring(L, constantName);
+      lua_pushnumber(L, value / 100.0);
+      lua_settable(L, -3);
+    }
+    for (int i = 0; i < sizeof(constantNames_number) / sizeof(struct MathConstantNameEntry); ++i) {
+      hb_ot_math_constant_t constantId = constantNames_number[i].id;
+      char *constantName = constantNames_number[i].name;
+
+      hb_position_t value = hb_ot_math_get_constant(font, constantId);
+
+      lua_pushstring(L, constantName);
+      lua_pushnumber(L, value * point_size / upem);
+      lua_settable(L, -3);
+    }
+  } else {
+    lua_pushnil(L);
+  }
+  
+  hb_font_destroy(font);
+  hb_face_destroy(face);
+  hb_blob_destroy(blob);
+  return 1;
+}
+#endif
+
 #if !defined LUA_VERSION_NUM
 /* Lua 5.0 */
 #define luaL_Reg luaL_reg
@@ -351,6 +462,9 @@ static const struct luaL_Reg lib_table [] = {
   {"version", get_harfbuzz_version},
   {"shapers", list_shapers},
   {"get_table", get_table},
+#ifdef HB_OT_TAG_MATH
+  {"get_math_constants", get_math_constants},
+#endif
   {NULL, NULL}
 };
 


### PR DESCRIPTION
Disclaimer: this PR is work-in-progress and far from complete. It is just to pull up its visibility to the community, which could support and improve the design and possibly also contribute to the code.

Milestones:

- [x] Basic structure and framework for math equation parsing and representation.
- [x] Parse MATH table from OpenType fonts to get layout parameters.
- [ ] Support common MathML tags
    - [x] Subscript, superscript and mixed sub-superscript.
    - [ ] Letter accents (e.g., hat, tilde)
    - [ ] Fraction
    - [ ] Radical
    - [ ] Brackets
    - [ ] Big operators (summation, integration)
    - [ ] Matrix
- [ ] Fully support the mathematical alphanumeric symbols defined in unicode.
- [ ] Support mathematical symbols from LaTeX `amssymb`.
- [ ] Better integration with SILE typesetter
    * Convert top-level horizontally layout math nodes into SILE's `_nnode` to enable line breaking within math.
    * Insert penalty nodes into the `_nnode` sequence to have better line breaking.
- [ ] LaTeX math to MathML converter.
- [ ] Add test cases.
- [ ] Update documentation.


### Motivation
I am aware of the recommendation of the math supporting approach in the [wiki](https://github.com/simoncozens/sile/wiki/faq#does-it-support-mathematics), and the work of integrating math support into SILE here: https://github.com/simoncozens/sile/issues/220. I have to say that solution will have several major drawbacks (big thanks to @akavel for correcting me here):
1. Equations are treated as images. There is no baseline information for the typesetter to align it with the other texts on the same line. And it also has no clue to make the equation to have the same font size as its context. Needless to say line-breaking inside inline math equations. In one word, this MathJax solution would make math equation a second-class citizen in SILE and the typesetter cannot actually typeset an equation.
2. (__edit__ 1) ~~The MathJax source code is converted into Lua, and the machine-generated code will be hard to read and hard to manage. Either we put the machine-generated code in SILE or we add the toolchain itself in the building system. Neither of them sounds like a good idea.~~
3. (__edit__ 1) ~~We are limited to the features that MathJax provides. See [here](http://docs.mathjax.org/en/latest/mathml.html#supported-mathml-commands) and [here](http://docs.mathjax.org/en/latest/tex.html#differences).~~
4. Performance. The performance will be limited because of the intermediate result (~~pdf~~) need to be saved on disk.

Therefore, I start to think. Why don't we start to write math typesetting logic inside SILE typesetter? Also math layout is complex, its logic is quite clear and even easier than line-breaking, or hypernation problems in traditional typesetting. We just need to organize the math equations into a tree of nodes instead of a sequential list in text typesetting. So I started to investigate this. Appendix G of [The TeXbook](https://ctan.org/pkg/texbook) provides an extensive but hard-to-read alrogithm for math typesetting. So I started with [Appendix G illuminated](https://www.tug.org/TUGboat/tb27-1/tb86jackowski.pdf), and also referred to [A Functional Description of TeX's Formula Layoout](https://people.eecs.berkeley.edu/~fateman/temp/neuform.pdf) and [Mathematical Typesetting with LaTeX](https://www.tug.org/~hvoss/PDF/mathmode.pdf) during the initial design. The current code is able to typeset subscript and superscript correctly with a Opentype math font. And the implementation can be served as a boilerplate for implementing other math layouts.

### Architecture
I don't think it is a good practice to re-implement all details of the math typesetting algorithm described in The TeXbook, which reads the input sequence into an `mlist` and converted it into a `hlist` and then did some black magic to make it happen. I just followed the general ideas and here are the most important aspects of the design:
* Math equations can break into a hierarchical structure of nodes (in the code it's `_mbox` and its child classes). `_mbox` is a subclass of `_box` (`_box` is defined in `nodefactory.lua` as the base class of node for general typesetting). Each node, along with its descendants, represents a part of the equation. This part can be treated as an individual equation but with possibly smaller font and cramped style.
* Each node have a atom type as defined in TeX that is used to specify the type of the content in this node. E.g., for binary operators `+` and `-` have the atom type of `Bin` (binary operator), while `=` has the atom type of `Rel` (relational operator). We need the atom type information to correctly handle the layout. E.g., kerning should be added bewteen `Bin` and `Ord` (ordinary) atoms in display or text style. The atom type is determined on the creation of the nodes.
* Each node has a certain style (which is named `mathMode` in the code). which can be `display`, `text`, `script`, `scriptScript` or their cramped forms. After the construction of the node tree, it determines the style of the children according to their parent. We call this process `styleChildren`, which is an important member function of `_mbox` that will be executed recursively before text shaping process. Each type of layout must define their `styleChildren` function.
* During the shaping process, unlike text shaping where we just infer the shape from the glyphs and assemble into words, we need to recursively determine the shape (width, height, depth) and the relative position of nodes. The relative position here means the position regarding to its parent node. As long as the shapes and positions of all children is determined, we can get the shape of the node itself. We call `shape` function recursively to shape the full equation tree. This `shape` function must also be defined in each type of layout.
* After done with shaping, our math layout structure is ready to render. We implemented `outputYourself` interface at the root-level of the structure in class `_stackbox`. Through this interface, SILE can output this math structure just like it calls other layout blocks. Inside this function, we call `output` function recursively to output every node in this math tree.

In conclusion, similar to text typesetting, the math typesetting process contains the following four steps:
1. Parse the input from `.sil` or `.xml` file. Most of this part is already handled by the lpeg parser in SILE.
2. Build math structure tree, determine atom type and math style (from outside in).
3. Shape math tree, determine shape and position recursively (from inside out).
4. Render the math tree by outputting recursively.

### MathML v.s. TeX math

I chose MathML as the representation of math equations because it complies to XML structure and can be seamlessly intergrated into SILE-style document. We may add a TeX-math-to-MathML converter for people to use TeX syntax later. But I think that would be an addon package instead of the core, because LaTeX have a different kind of syntax from SILE and it is not elegant to put that into the SILE core.

Although we are going with MathML without much doubt, we will miss a bunch of useful symbol definitions in TeX, such as `\rightarrow`, `\alpha`, `\neq`. To ease the use of MathML without struggling into typing these characters, they should be implemented in the MathML parser so we can will be using a superset of tags supported by MathML and these "symbol" tags will be translated directly to the corresponding character.

### SILE typesetter integration
SILE has a great implementation (from the even greater TeXbook) of the typesetting logic which supports glue and kerning. And math equations should also be compatible with the main typesetting algorithm. In the implementation of the math structures, we defined the shape and position of nodes as `SILE.length` class, which means every node in the equation can tolerate shrinking/stretch to some certain degrees. When typesetting a scaled line of text, the math equation will also be scaled proportionally. (Better than that, we even have the shrinking and stretching capability on the vertical direction, which will be useful when we want to, say, scale the line height in a page some we can accomodate certain number of lines on one page without overflowing.)

Another possible integration is to tweak the line-breaking penalty. We may prefer the inline equation to break at certain positions (like before or after a binary operator) and refrain from breaking at some other certain positions (like after the integration operator). We can insert penalty values between the math nodes just like what SILE already did in its typesetter.

### How to contribute
You may send PR to the `math` branch in my forked repository so it will be updated here. However, it is still under actively development so the PR should keep as small and as specific as possible. For example, you can implement an unsupported MathML tag, but not changing other logics in the same PR.

To render a sample document, you may need an Opentype math font (I am using [XITS Math](https://github.com/alif-type/xits)). After installing the font, you can try the following code
```tex
\begin[class=plain, papersize=100mm x 100mm]{document}
Display math:

\math[mode=display]{
	\mrow{
		\mi{E}
		\mo{=}
		\msup{
			\mi{mc}
			\mn{2}
		}
	}
}

Text math:

\begin{math}
	\mrow{
		\msubsup{
			\mi{f}
			\mn{1}
			\mrow{
				\mi{a}
				\mo{+}
				\mi{b}
			}
		}
		\mo{-}
		\msup{
			\mi{d}
			\mn{2}
		}
	}
\end{math}
\end{document}
```

And it will be rendered as:
![image](https://user-images.githubusercontent.com/1215413/56074919-d7cf8d00-5d6e-11e9-89f0-854d436622b8.png)

### Other Words
SILE is a great typesetting engine and its uniqueness may never be surpassed by other alternatives. I look forward to seeing math support in SILE so that SILE will take larger influences in the scientific world. If you have the passion and skills, please join us to improve SILE!

I was always thinking, LaTeX is great but it is also the barrier and burden for people to understand typesetting. Its obscure manual and steep learning curve stop many people from grasping it. The world really needs a free-of-charge, general-purposed typsetting software. I tried ConTeXt a few years before but it was hard to use. I can't understand what's happening under the hood from its sparsely documented user mannual. And I could hardly find more useful material on the Internet. SILE is the one, and may be the only one that does the job. It is flexible, and its source code is human-readable.

Great thanks for Simon to bring us such a good software and hope it is going to be even better.

