### PR TITLE
Fix rare crash when font is specified by filename

### DIFF
--- a/core/base-shaper.lua
+++ b/core/base-shaper.lua
@@ -30,6 +30,7 @@ SILE.shapers.base = pl.class({
         SILE.settings.temporarily(function ()
           SILE.settings.set("font.size", options.size)
           SILE.settings.set("font.family", options.family)
+          SILE.settings.set("font.filename", options.filename)
           ss = ss:absolute()
         end)
         return ss


### PR DESCRIPTION
Fixes #604, though I am not sure if this is a correct/complete fix, as discussed in the issue.
In any case, it shouldn't break anything.

Even if this doesn't get merged, it could be useful for others facing the same issue.