### PR TITLE
chore(tests): Not all systems support grep -P, use Perl instead.

### DIFF
--- a/tests/regressions.pl
+++ b/tests/regressions.pl
@@ -14,8 +14,9 @@ for (@specifics ? @specifics : <tests/*.sil>) {
 	my $actual = $_; $actual =~ s/\.sil$/\.actual/;
   my ($unsupported, $knownbad);
   if (-f $expectation) {
-		# Entirely skip tests designed for an OS that is not us
-		if (system("head -n1 $_ | grep -q -P -v 'OS=(?!$^O)'")) {
+        open my $exp, $expectation or die $!;
+        my $firstline = <$exp>;
+        if ($firstline =~ /OS=(?!$^O)/) {
 			push @unsupported, $_;
 			next;
 		}


### PR DESCRIPTION
Rewrite regression handler to examine the expectations file itself
rather than shelling out to (possibly unsupported) grep magic.