### PR TITLE
Update Google Groups links

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,6 @@ SILE is distributed under the [MIT licence][license].
   [indesign]: https://en.wikipedia.org/wiki/Adobe_InDesign
   [brew]: http://brew.sh
   [brewfonts]: https://github.com/Homebrew/homebrew-cask-fonts
-  [list-en]: https://groups.google.com/forum/#!forum/sile-users
-  [list-ja]: https://groups.google.com/forum/#!forum/sile-users-ja
+  [list-en]: https://groups.google.com/d/forum/sile-users
+  [list-ja]: https://groups.google.com/d/forum/sile-users-ja
   [nix]: https://nixos.org/nix


### PR DESCRIPTION
Related to #717.

These link formats will have less issues with user scripts or browsers that block trackers or that sort of thing. The Google Groups UI still loads the other format later, particularly for logged in users, but this format should be more stable to link to externally.

Note this does not fix the problem with the JA group for me.