### PR TITLE
chore(readme): Add Github Sponsors configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [alerque, simoncozens]


### PR DESCRIPTION
Hey @simoncozens have you thought about enabling Github [Sponsors](https://github.com/sponsors) on your account? I have and it would be nice to link to it from this project, but I wouldn't feel right about the button showing a link to me and not to you! You can see what it would look like if we did on the [CaSILE](https://github.com/sile-typesetter/casile) repository page. The way sponsors work has no real connection to specific projects so people pick what developers they want to sponsor and for how much. The button just links to suggested people to sponsor from each project.