### PR TITLE
test(fonts): Add test for font fallback package with no fallbacks

### DIFF
--- a/tests/font-fallback-empty.expected
+++ b/tests/font-fallback-empty.expected
@@ -1,0 +1,8 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	14.8819
+My 	29.7654
+Set font 	Gentium Plus;10;400;;normal;;LTR
+T	0	(ん)
+End page
+Finish

--- a/tests/font-fallback-empty.sil
+++ b/tests/font-fallback-empty.sil
@@ -1,0 +1,7 @@
+\begin[papersize=a6]{document}% KNOWNBAD
+\script[src=packages/font-fallback]
+%\font:add-fallback[family=Noto Serif CJK JP]
+\nofolios
+\noindent
+ん
+\end{document}


### PR DESCRIPTION
While messing with something else I noticed that loading the font-fallback package and not going on to specific a fallback stack causes a hard crash. This is undesirable behavior, so here is a test for it. This can probably be fixed (and the `KNOWNBAD` label removed) at the same time the error reporting logic is straightened out in relation to #716.