### PR TITLE
fix(core): Guess original parent of split frames post page break

### DIFF
--- a/core/baseclass.lua
+++ b/core/baseclass.lua
@@ -205,7 +205,6 @@ SILE.baseClass = std.object {
 
   declareFrame = function (self, id, spec)
     spec.id = id
-    SILE.frames[id] = nil
     self.pageTemplate.frames[id] = SILE.newFrame(spec)
     --   next = spec.next,
     --   left = spec.left and fW(spec.left),

--- a/core/frame.lua
+++ b/core/frame.lua
@@ -241,7 +241,12 @@ SILE.getFrame = function (id)
   if type(id) == "table" then
     SU.error("Passed a table, expected a string", true)
   end
-  return SILE.frames[id] or SU.warn("Couldn't find frame ID "..id, true)
+  local frame
+  while not frame do
+    frame = SILE.frames[id]
+    id = id:gsub("_$", "")
+  end
+  return frame or SU.warn("Couldn't find frame ID "..id, true)
 end
 
 SILE.parseComplexFrameDimension = function (dimension)

--- a/packages/hanmenkyoshi.lua
+++ b/packages/hanmenkyoshi.lua
@@ -46,7 +46,6 @@ end)
 local declareHanmenFrame = function (self, id, spec)
   if id then
     spec.id = id
-    SILE.frames[id] = nil
   else
     spec = id
   end


### PR DESCRIPTION
Partial / temporary solution for #763. Not marking as fixed because I think the overflow mechanism should be completely overhauled to re-parent content into new frames. The next page might not have frames that are any relation to the previous one and right now we assume the line shape transfers over. This guess work is right in most cases, but the inherent assumption is still a bug.