### PR TITLE
Force autoconf and add sile script to install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ SUBDIRS = libtexpdf src
 endif
 
 dist_man_MANS = sile.1
+bin_SCRIPTS = sile
 subdir_files = $(shell find core classes languages packages lua-libraries -type f -print)
 nobase_dist_pkgdata_DATA = $(subdir_files)
 EXTRA_DIST = CHANGELOG.md README.md LICENSE tests examples documentation sile-dev-1.rockspec build-aux/git-version-gen .version

--- a/Makefile.am
+++ b/Makefile.am
@@ -305,6 +305,8 @@ else
 testprep: lua_modules | $(TESTPREPDEPS)
 endif
 
+CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS)
+
 gource.webm:
 	mkdir -p /tmp/gravatars
 	convert examples/images/sile-logo.jpg -negate -resize 50% /tmp/sile-logo.jpg

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,8 +18,8 @@ case `uname` in
     Darwin*) glibtoolize ;;
     *)        libtoolize ;;
 esac
-aclocal
+aclocal --force
 automake --force-missing --add-missing
-autoreconf
+autoreconf --force
 
 (cd libtexpdf; autoreconf -I m4)


### PR DESCRIPTION
- [x] Help out build systems that cache the git tree and think they know what version they are on by forcing the configure step to have clean files when bootstrapped.
- [x] Include pre-built *sile* script on `make install`! This got dropped (correctly) from the source tarball but needs to end up in the install routine somehow.