### PR TITLE
chore(tooling): Drop one-time-use file reader in favor of Lua's builtin

### DIFF
--- a/languages/ug.lua
+++ b/languages/ug.lua
@@ -6,7 +6,7 @@
 -- Uyghur is Turkish, right?
 SILE.languageSupport.loadLanguage("tr")
 
-local chardata = pl.pretty.load(pl.utils.readfile("lua-libraries/char-def.lua")).characters.data
+local chardata = require("char-def")
 
 SILE.settings.declare({
   name = "languages.ug.hyphenoffset",

--- a/languages/unicode.lua
+++ b/languages/unicode.lua
@@ -1,6 +1,6 @@
 local icu = require("justenoughicu")
 
-local chardata = pl.pretty.load(pl.utils.readfile("lua-libraries/char-def.lua")).characters.data
+local chardata = require("char-def")
 
 -- luacheck: globals lasttype
 -- XXX - this is wrong and broken, but is also confusing. See bug #687

--- a/lua-libraries/char-def.lua
+++ b/lua-libraries/char-def.lua
@@ -141560,3 +141560,5 @@ characters.data={
   linebreak="cm",
  },
 }
+
+return characters.data


### PR DESCRIPTION
Fixes #767.