### PR TITLE
Match space and breaks in text output to approximate PDF

### DIFF
--- a/core/text-output.lua
+++ b/core/text-output.lua
@@ -27,8 +27,9 @@ SILE.outputters.text = {
   popColor = function () end,
   outputHbox = function (value, width)
     width = SU.cast("number", width)
+    if not value.text then return end
+    writeline(value.text)
     if width > 0 then
-      writeline(value.text)
       started = true
       cursorX = cursorX + width
     end
@@ -37,10 +38,12 @@ SILE.outputters.text = {
   drawImage = function () end,
   imageSize = function () end,
   moveTo = function (x, y)
+    local bs = SILE.measurement("0.8bs"):tonumber()
+    local spc = SILE.measurement("0.8spc"):tonumber()
     if started then
-      if y > cursorY or x < cursorX then
+      if y > cursorY and y - cursorY > bs or x < cursorX then
         outfile:write("\n")
-      elseif x > cursorX then
+      elseif x > cursorX and x - cursorX > spc then
         outfile:write(" ")
       end
     end

--- a/core/text-output.lua
+++ b/core/text-output.lua
@@ -3,15 +3,12 @@ if (not SILE.outputters) then SILE.outputters = {} end
 local outfile
 local cursorX = 0
 local cursorY = 0
-local hboxCount = 0
+local started = false
 
 local writeline = function (...)
   local args = table.pack(...)
-  if hboxCount >= 1 then outfile:write(" ") end
   for i=1, #args do
     outfile:write(args[i])
-    if i < #args then outfile:write(" ") end
-    hboxCount = hboxCount + 1
   end
 end
 
@@ -28,16 +25,24 @@ SILE.outputters.text = {
   setColor = function() end,
   pushColor = function () end,
   popColor = function () end,
-  outputHbox = function (value)
-    writeline(value.text)
+  outputHbox = function (value, width)
+    width = SU.cast("number", width)
+    if width > 0 then
+      writeline(value.text)
+      started = true
+      cursorX = cursorX + width
+    end
   end,
   setFont = function () end,
   drawImage = function () end,
   imageSize = function () end,
   moveTo = function (x, y)
-    if y > cursorY or x <= cursorX then
-      outfile:write("\n")
-      hboxCount = 0
+    if started then
+      if y > cursorY or x < cursorX then
+        outfile:write("\n")
+      elseif x > cursorX then
+        outfile:write(" ")
+      end
     end
     cursorY = y
     cursorX = x

--- a/core/text-output.lua
+++ b/core/text-output.lua
@@ -41,10 +41,20 @@ SILE.outputters.text = {
     local bs = SILE.measurement("0.8bs"):tonumber()
     local spc = SILE.measurement("0.8spc"):tonumber()
     if started then
-      if y > cursorY and y - cursorY > bs or x < cursorX then
-        outfile:write("\n")
-      elseif x > cursorX and x - cursorX > spc then
-        outfile:write(" ")
+      if x < cursorX then
+          outfile:write("\n")
+      elseif y > cursorY then
+        if y - cursorY > bs then
+          outfile:write("\n")
+        else
+          outfile:write("‫")
+        end
+      elseif x > cursorX then
+        if x - cursorX > spc then
+          outfile:write(" ")
+        else
+          outfile:write("‫")
+        end
       end
     end
     cursorY = y


### PR DESCRIPTION
This fixes #773, but goes on to improve the feature with much more robust simulation of line breaks so that what would be a multi-column layout using frames in the PDF wraps all the lines the same way in the text output. This is useful in a way that extracting text from a PDF is not, and shows roughly what SILE is thinking is content.

For example you can check where hyphenation is happening with `grep -A1 -- '-$'`.