### PR TITLE
chore(docker): Refresh package index before installations

### DIFF
--- a/build-aux/docker-yay-runner.sh
+++ b/build-aux/docker-yay-runner.sh
@@ -2,6 +2,7 @@
 set -e +o pipefail
 
 # Setup AUR helper
+pacman --needed --noconfirm -Syuq
 pacman --needed --noconfirm --asdeps -S git base-devel go
 useradd -m docker
 echo 'docker:' | chpasswd -e


### PR DESCRIPTION
This shouldn't be necessary because it's literally done in the
previous step, but Docker thinks it can cache steps separately and if it
doesn't detect a change to the input parameters might not actually run
that step at all. Before we try to install anything ourselves, actually
freshen the whole distro ourselves...