### PR TITLE
Cleanup build time warning messages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,9 +30,9 @@ endif
 
 BUILT_SOURCES = .version
 
-.version: $(shell test -d .git && awk '{print ".git/" $$2}' .git/HEAD)
+.version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
 	mv $@{,-prev} || touch $@-prev
-	( test -d .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
+	( test -e .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
 	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
 	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
 
@@ -166,8 +166,8 @@ patterndeps = $(wildcard $(DEPDIR)/$*.d) all testprep
 coverage: export SILE_COVERAGE=1
 coverage: test_previews
 
-HEADSHA ?= $(shell git rev-parse --short HEAD)
-BASESHA ?= $(shell git rev-parse --short $(HEADSHA)^)
+HEADSHA ?= $(shell test -e .git && git rev-parse --short HEAD)
+BASESHA ?= $(shell test -e .git && git rev-parse --short $(HEADSHA)^)
 
 clean-recursive: clean-tests
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ BUILT_SOURCES = .version
 .version: $(shell test -d .git && awk '{print ".git/" $$2}' .git/HEAD)
 	mv $@{,-prev} || touch $@-prev
 	( test -d .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
-	cmp -s $@{,-prev} || autoreconf configure.ac -f
+	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
 
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
+AUTOMAKE_OPTIONS = foreign
 
 if SYSTEM_LIBTEXPDF
 SUBDIRS = src
@@ -33,9 +34,11 @@ BUILT_SOURCES = .version
 	mv $@{,-prev} || touch $@-prev
 	( test -d .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
 	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
+	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
 
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
+	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
 
 # Whether to force tests to run from scratch
 CLEAN ?=

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,16 +10,16 @@ if [ ! -f "libtexpdf/configure.ac" ] && [ -e ".git" ]; then
     git submodule update --init --recursive --remote
 fi
 
-autoreconf --install
+autoreconf --install -W none
 
 # See discussion in https://github.com/sile-typesetter/sile/issues/82 and
 # https://web.archive.org/web/20170111053341/http://blog.gaku.net/autoconf/
 case `uname` in
-    Darwin*) glibtoolize ;;
-    *)        libtoolize ;;
+    Darwin*) glibtoolize -W none ;;
+    *)        libtoolize -W none ;;
 esac
-aclocal --force
-automake --force-missing --add-missing
-autoreconf --force
+aclocal --force -W none
+automake --force-missing --add-missing -W none
+autoreconf --force -W none
 
-(cd libtexpdf; autoreconf -I m4)
+(cd libtexpdf; autoreconf)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,4 +22,6 @@ aclocal --force -W none
 automake --force-missing --add-missing -W none
 autoreconf --force -W none
 
+sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
+
 (cd libtexpdf; autoreconf)

--- a/configure.ac
+++ b/configure.ac
@@ -182,3 +182,4 @@ AC_CONFIG_FILES([sile], [chmod +x sile])
 
 AC_OUTPUT
 m4_esyscmd_s([test -f configure && sed -i -e '/rm -f/s/ core / /' configure])
+m4_esyscmd_s([test -f aclocal.m4 && sed -i -e '/rm -f/s/ core / /' aclocal.m4])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS = -I m4
+
 if LINKLUA
 MY_LUA_LIB=$(LUA_LIB)
 UNDEFINED=-no-undefined


### PR DESCRIPTION
This should avoid or suppress some warnings during build that are confusing or distracting packagers from what the real issues are.