### PR TITLE
Add more Pandoc goodies

### DIFF
--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -13,32 +13,48 @@ local handlePandocArgs = function (options)
     SU.debug("pandoc", "Set ID on tag")
   end
   if options.lang then
-    SU.debug("pandoc", "Set lang tag: "..options.lang)
+    SU.debug("pandoc", "Set lang in tag: "..options.lang)
     local fontfunc = SILE.Commands[SILE.Commands["font:" .. options.lang] and "font:" .. options.lang or "font"]
     local innerWrapper = wrapper
     wrapper = function (content) innerWrapper(function () fontfunc({ language = options.lang }, content) end) end
+    options.lang = nil
   end
   if options.classes then
-    for _,class in pairs(options.classes:split(",")) do
-      SU.debug("pandoc", "Add div class: "..class)
+    for _, class in pairs(options.classes:split(",")) do
+      SU.debug("pandoc", "Add inner class wrapper: "..class)
       if SILE.Commands["class:"..class] then
         local innerWrapper = wrapper
         wrapper = function (content) innerWrapper(function () SILE.Commands["class:"..class](options, content) end) end
       end
     end
+    options.classes = nil
   end
-  return wrapper
+  return wrapper, options
 end
 
-SILE.registerCommand("nbsp", function(_, _)
+-- Document level stuff
+
+
+-- Blocks
+
+SILE.registerCommand("BlockQuote", function (_, content)
+  SILE.call("quote", {}, content)
+end)
+
+-- Inlines
+
+
+-- Needs refactoring
+
+SILE.registerCommand("nbsp", function (_, _)
   SILE.call("kern", { width = "1spc" })
 end)
 
-SILE.registerCommand("label", function(options, content)
+SILE.registerCommand("label", function (options, content)
   SILE.call("pdf:bookmark", options, content)
 end)
 
-SILE.registerCommand("tt", function(options, content)
+SILE.registerCommand("tt", function (options, content)
   SILE.call("verbatim:font", options, content)
 end)
 

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -30,6 +30,10 @@ local handlePandocArgs = function (options)
   return wrapper
 end
 
+SILE.registerCommand("nbsp", function(_, _)
+  SILE.call("kern", { width = "1spc" })
+end)
+
 SILE.registerCommand("label", function(options, content)
   SILE.call("pdf:bookmark", options, content)
 end)

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -39,9 +39,12 @@ SILE.registerCommand("tt", function(options, content)
 end)
 
 SILE.registerCommand("HorizontalRule", function (options, _)
-  options.height = options.height or "0.2pt"
-  options.width = options.width or SILE.typesetter.frame:lineWidth()
-  SILE.call("hrule", options)
+  SILE.call("raise", { height = options.raise or "0.8ex" }, function ()
+    SILE.call("hrule", {
+        height = options.height or "0.5pt",
+        width = options.width or "100%lw"
+      })
+  end)
 end)
 
 SILE.registerCommand("Span", function (options, content)

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -151,8 +151,91 @@ end)
 
 -- Inlines
 
--- -\define[command=listitem]{\smallskip{}\glue[width=-1em]• \glue[width=0.3em]\process\smallskip}%
+SILE.registerCommand("Cite", function (options, content)
+  -- TODO: options is citation list?
+end, "Creates a Cite inline element")
 
+SILE.registerCommand("Code", function (options, content)
+  local wrapper, args = handlePandocArgs(options)
+  wrapper(function ()
+    SILE.call("code", args, content)
+  end)
+end, "Creates a Code inline element")
+
+SILE.registerCommand("Emph", function (_, content)
+  SILE.call("em", {}, content)
+end, "Creates an inline element representing emphasised text.")
+
+SILE.registerCommand("Image", function (options, _)
+  local wrapper, args = handlePandocArgs(options)
+  wrapper(function ()
+    SILE.call("img", args)
+  end)
+end, "Creates a Image inline element")
+
+SILE.registerCommand("LineBreak", function (_, _)
+  SILE.call("break")
+end, "Create a LineBreak inline element")
+
+SILE.registerCommand("Link", function (options, content)
+  local wrapper, args = handlePandocArgs(options)
+  wrapper(function ()
+    SILE.call("url", args, content)
+  end)
+end, "Creates a link inline element, usually a hyperlink.")
+
+SILE.registerCommand("Math", function (options, content)
+  -- TODO options is math type
+  SILE.process("content")
+end, "Creates a Math element, either inline or displayed.")
+
+SILE.registerCommand("Note", function (_, content)
+  SILE.call("footnote", {}, content)
+end, "Creates a Note inline element")
+
+SILE.registerCommand("Quoted", function (options, content)
+  -- TODO: options.type
+  SILE.process(content)
+end, "Creates a Quoted inline element given the quote type and quoted content.")
+
+SILE.registerCommand("RawInline", function (options, content)
+  local format = options.format
+  -- TODO: execute as script? pass to different input parser?
+  SILE.process(content)
+end, "Creates a Quoted inline element given the quote type and quoted content.")
+
+SILE.registerCommand("SmallCaps", function (_, content)
+  SILE.call("font", { features = "+smcp" }, content)
+end, "Creates text rendered in small caps")
+
+SILE.registerCommand("Span", function (options, content)
+  handlePandocArgs(options)(content)
+end, "Creates a Span inline element")
+
+SILE.registerCommand("Strikeout", function (_, content)
+  -- TODO: cross it out, unicode munging?
+  SILE.process(content)
+end, "Creates text which is striked out.")
+
+SILE.registerCommand("Strong", function (_, content)
+  SILE.call("strong", {}, content)
+end, "Creates a Strong element, whose text is usually displayed in a bold font.")
+
+local scriptOffset = "0.7ex"
+local scriptSize = "1.5ex"
+
+SILE.registerCommand("Subscript", function (_, content)
+  SILE.call("lower", { height = scriptOffset }, function ()
+    SILE.call("font", { size = scriptSize }, content)
+  end)
+end, "Creates a Subscript inline element")
+
+SILE.registerCommand("Superscript", function (_, content)
+  SILE.call("raise", { height = scriptOffset }, function ()
+    SILE.call("font", { size = scriptSize }, content)
+  end)
+end, "Creates a Superscript inline element")
+-- -\define[command=listitem]{\smallskip{}\glue[width=-1em]• \glue[width=0.3em]\process\smallskip}%
 
 -- Needs refactoring
 
@@ -168,22 +251,6 @@ SILE.registerCommand("tt", function (options, content)
   SILE.call("verbatim:font", options, content)
 end)
 
-SILE.registerCommand("Span", function (options, content)
-  handlePandocArgs(options)(content)
-end,"Generic inline wrapper")
-
-SILE.registerCommand("Emph", function (_, content)
-  SILE.call("em", {}, content)
-end,"Inline emphasis wrapper")
-
-SILE.registerCommand("Strong", function (_, content)
-  SILE.call("strong", {}, content)
-end,"Inline strong wrapper")
-
-SILE.registerCommand("SmallCaps", function (_, content)
-  SILE.call("font", { features = "+smcp" }, content)
-end,"Inline small caps wrapper")
-
 SILE.registerCommand("csl-no-emph", function (_, content)
   SILE.call("font", { style = "Roman" }, content)
 end,"Inline upright wrapper")
@@ -195,21 +262,6 @@ end,"Inline normal weight wrapper")
 SILE.registerCommand("csl-no-smallcaps", function (_, content)
   SILE.call("font", { features = "-smcp" }, content)
 end,"Inline smallcaps disable wrapper")
-
-local scriptOffset = "0.7ex"
-local scriptSize = "1.5ex"
-
-SILE.registerCommand("Superscript", function (_, content)
-  SILE.call("raise", { height = scriptOffset }, function ()
-    SILE.call("font", { size = scriptSize }, content)
-  end)
-end,"Inline superscript wrapper")
-
-SILE.registerCommand("Subscript", function (_, content)
-  SILE.call("lower", { height = scriptOffset }, function ()
-    SILE.call("font", { size = scriptSize }, content)
-  end)
-end,"Inline subscript wrapper")
 
 SILE.registerCommand("unimplemented", function (_, content)
   SU.debug("pandoc", "Un-implemented function")

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -54,6 +54,7 @@ SILE.registerCommand("BlockQuote", function (_, content)
 end)
 
 SILE.registerCommand("BulletList", function (_, content)
+  -- luacheck: ignore pandocListType
   local pandocListType = "bullet"
   SILE.settings.temporarily(function ()
     SILE.settings.set("document.rskip","10pt")
@@ -137,12 +138,14 @@ end)
 
 SILE.registerCommand("RawBlock", function (options, content)
   local format = options.format
+  SU.debug("pandoc", format)
   -- TODO: execute as script? pass to different input parser?
   SILE.process(content)
   SILE.typesetter:leaveHmode()
 end)
 
 SILE.registerCommand("Table", function (options, content)
+  SU.debug("pandoc", options.caption)
   -- TODO: options.caption
   -- TODO: options.align
   -- TODO: options.width
@@ -154,6 +157,7 @@ end)
 -- Inlines
 
 SILE.registerCommand("Cite", function (options, content)
+  SU.debug("pandoc", options, content)
   -- TODO: options is citation list?
 end, "Creates a Cite inline element")
 
@@ -187,8 +191,9 @@ SILE.registerCommand("Link", function (options, content)
 end, "Creates a link inline element, usually a hyperlink.")
 
 SILE.registerCommand("Math", function (options, content)
+  SU.debug("pandoc", options)
   -- TODO options is math type
-  SILE.process("content")
+  SILE.process(content)
 end, "Creates a Math element, either inline or displayed.")
 
 SILE.registerCommand("Note", function (_, content)
@@ -196,12 +201,14 @@ SILE.registerCommand("Note", function (_, content)
 end, "Creates a Note inline element")
 
 SILE.registerCommand("Quoted", function (options, content)
+  SU.debug("pandoc", options.type)
   -- TODO: options.type
   SILE.process(content)
 end, "Creates a Quoted inline element given the quote type and quoted content.")
 
 SILE.registerCommand("RawInline", function (options, content)
   local format = options.format
+  SU.debug("pandoc", format)
   -- TODO: execute as script? pass to different input parser?
   SILE.process(content)
 end, "Creates a Quoted inline element given the quote type and quoted content.")
@@ -258,6 +265,8 @@ SILE.registerCommand("ListItem", function (_, content)
   SILE.call("smallskip")
   SILE.call("glue", { width = "-1em"})
   SILE.call("rebox", { width = "1em" }, function ()
+    -- Not: Relies on Lua scope shadowing to find immediate parent list type
+    -- luacheck: ignore pandocListType
     if pandocListType == "bullet" then
       SILE.typesetter:typeset("•")
     else

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -13,7 +13,7 @@ local handlePandocArgs = function (options)
   local wrapper = SILE.settings.wrap()
   if options.id then
     SU.debug("pandoc", "Set ID on tag")
-    SILE.call("pdf:bookmark", options, content)
+    SILE.call("pdf:destination", { name = options.id })
   end
   if options.lang then
     SU.debug("pandoc", "Set lang in tag: "..options.lang)
@@ -54,6 +54,7 @@ SILE.registerCommand("BlockQuote", function (_, content)
 end)
 
 SILE.registerCommand("BulletList", function (_, content)
+  local pandocListType = "bullet"
   SILE.settings.temporarily(function ()
     SILE.settings.set("document.rskip","10pt")
     SILE.settings.set("document.lskip","20pt")
@@ -236,7 +237,6 @@ SILE.registerCommand("Superscript", function (_, content)
     SILE.call("font", { size = scriptSize }, content)
   end)
 end, "Creates a Superscript inline element")
--- -\define[command=listitem]{\smallskip{}\glue[width=-1em]• \glue[width=0.3em]\process\smallskip}%
 
 -- Utility wrapper classes
 
@@ -251,6 +251,22 @@ end,"Inline normal weight wrapper")
 SILE.registerCommand("class:csl-no-smallcaps", function (_, content)
   SILE.call("font", { features = "-smcp" }, content)
 end,"Inline smallcaps disable wrapper")
+
+-- Non native types
+
+SILE.registerCommand("ListItem", function (_, content)
+  SILE.call("smallskip")
+  SILE.call("glue", { width = "-1em"})
+  SILE.call("rebox", { width = "1em" }, function ()
+    if pandocListType == "bullet" then
+      SILE.typesetter:typeset("•")
+    else
+      SILE.typesetter:typeset("-")
+    end
+  end)
+  SILE.process(content)
+  SILE.call("smallskip")
+end)
 
 return { documentation = [[\begin{document}
 

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -13,6 +13,7 @@ local handlePandocArgs = function (options)
   local wrapper = SILE.settings.wrap()
   if options.id then
     SU.debug("pandoc", "Set ID on tag")
+    SILE.call("pdf:bookmark", options, content)
   end
   if options.lang then
     SU.debug("pandoc", "Set lang in tag: "..options.lang)
@@ -237,63 +238,22 @@ SILE.registerCommand("Superscript", function (_, content)
 end, "Creates a Superscript inline element")
 -- -\define[command=listitem]{\smallskip{}\glue[width=-1em]• \glue[width=0.3em]\process\smallskip}%
 
--- Needs refactoring
+-- Utility wrapper classes
 
-SILE.registerCommand("nbsp", function (_, _)
-  SILE.call("kern", { width = "1spc" })
-end)
-
-SILE.registerCommand("label", function (options, content)
-  SILE.call("pdf:bookmark", options, content)
-end)
-
-SILE.registerCommand("tt", function (options, content)
-  SILE.call("verbatim:font", options, content)
-end)
-
-SILE.registerCommand("csl-no-emph", function (_, content)
+SILE.registerCommand("class:csl-no-emph", function (_, content)
   SILE.call("font", { style = "Roman" }, content)
 end,"Inline upright wrapper")
 
-SILE.registerCommand("csl-no-strong", function (_, content)
+SILE.registerCommand("class:csl-no-strong", function (_, content)
   SILE.call("font", { weight = 400 }, content)
 end,"Inline normal weight wrapper")
 
-SILE.registerCommand("csl-no-smallcaps", function (_, content)
+SILE.registerCommand("class:csl-no-smallcaps", function (_, content)
   SILE.call("font", { features = "-smcp" }, content)
 end,"Inline smallcaps disable wrapper")
 
-SILE.registerCommand("unimplemented", function (_, content)
-  SU.debug("pandoc", "Un-implemented function")
-  SILE.process(content)
-end,"Unimplemented Pandoc function wrapper")
-
-SILE.Commands["strikeout"] = SILE.Commands["unimplemented"]
-
 return { documentation = [[\begin{document}
 
-Try to cover all the possible commands Pandoc's SILE export might throw at us.
-
-Provided by in base classes etc.:
-
-\listitem \code{listarea}
-\listitem \code{listitem}
-
-Modified from default:
-
-
-Provided specifically for Pandoc:
-
-\listitem \code{Span}
-\listitem \code{Div}
-\listitem \code{Emph}
-\listitem \code{Strong}
-\listitem \code{SmallCaps}
-\listitem \code{Strikeout}
-\listitem \code{csl-no-emph}
-\listitem \code{csl-no-strong}
-\listitem \code{csl-no-smallcaps}
-\listitem \code{Superscript}
-\listitem \code{Subscript}
+Cover all the possible commands Pandoc's SILE export might throw at us.
 
 \end{document}]] }

--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -83,9 +83,8 @@ SILE.registerCommand("Div", function (options, content)
 end, "Generic block wrapper")
 
 SILE.registerCommand("Header", function (options, content)
-  local analogs = { "part", "chapter", "section", "subsection" }
-  local analog = analogs[options.level+2] -- Pandoc's -1 level is \part
-  options.level = nil
+  local analog = options.type
+  options.level, options.type = nil, nil
   local wrapper, args = handlePandocArgs(options)
   wrapper(function ()
     if analog and SILE.Commands[analog] then
@@ -273,6 +272,17 @@ SILE.registerCommand("ListItem", function (_, content)
       SILE.typesetter:typeset("-")
     end
   end)
+  SILE.process(content)
+  SILE.call("smallskip")
+end)
+
+SILE.registerCommand("ListItemTerm", function (_, content)
+  SILE.call("smallskip")
+  SILE.call("strong", content)
+  SILE.typesetter:typeset(" : ")
+end)
+
+SILE.registerCommand("ListItemDefinition", function (_, content)
   SILE.process(content)
   SILE.call("smallskip")
 end)


### PR DESCRIPTION
In working on a SILE Writer for Pandoc ([discussion](https://github.com/jgm/pandoc/issues/6087), [PR](https://github.com/jgm/pandoc/pull/6088)) I keep bumping into things to tweak from the SILE side to match Pondoc's output. This is a running list of those tweaks, to be periodically added to `master` (so Pandoc testers can easily use it from Docker's `siletypesetter/sile:master` image), and at the very least merged when the writer is upstreamed into Pandoc master (and released to a stable build version before Pandoc support lands).