### PR TITLE
fix(build): Fix version detection in sparse git checkouts

### DIFF
--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -150,7 +150,7 @@ then
 # Otherwise, if there is at least one git commit involving the working
 # directory, and "git describe" output looks sensible, use that to
 # derive a version string.
-elif test "`git log -1 --pretty=format:x . 2>&1`" = x \
+elif test "`git log -1 --pretty=format:x . 2>/dev/null`" = x \
     && v=`git describe --tags --abbrev=7 --match="$prefix*" HEAD 2>/dev/null \
           || git describe --tags --abbrev=7 HEAD 2>/dev/null` \
     && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \


### PR DESCRIPTION
Building from a git clone worked before, but some distro packages (Arch Linux `sile-git` for example) use a sparse checkout without all the branches available. This throws git warnings for the branch names that don't have corresponding repository data, but they can be ignored as long as the current HEAD gives us something meaningful.