### PR TITLE
fix(build): Fix version detection in sparse git checkouts (#803)

### DIFF
--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -152,7 +152,8 @@ then
 # derive a version string.
 elif test "`git log -1 --pretty=format:x . 2>/dev/null`" = x \
     && v=`git describe --tags --abbrev=7 --match="$prefix*" HEAD 2>/dev/null \
-          || git describe --tags --abbrev=7 HEAD 2>/dev/null` \
+          || git describe --tags --abbrev=7 HEAD 2>/dev/null \
+          || git log -1 --pretty=format:'v0-HEAD-%h' 2>/dev/null` \
     && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
     && case $v in
          $prefix[0-9]*) ;;


### PR DESCRIPTION
Previous fix got us into the case statement but didn't provide any useful information once we got there. This provides *something*, at least.