### PR TITLE
Fix release snafu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,10 @@ core/*.so
 build/
 *.debug
 gh-pages
-sile-*
-*.zip
+sile-[0-9\.]*
+*.bz2
 *.xz
+*.zip
 *.rockslock
 .dockerignore
 
@@ -77,7 +78,6 @@ tags
 documentation/*.pdf
 examples/*.pdf
 gource.webm
-*.tar.bz2
 .fonts/*
-sile
+#sile# Work around bug in standard-version by not ignoring this artifact
 sile.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ release-preview:
 .PHONY: release
 release: tagrelease
 
-dist: examples docs all
+dist: examples docs all lua_modules_dist
 
 .PHONY: postrelease
 postrelease: dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sile",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The v0.10.2 release tarball had a couple issues. Most notably a race condition in the build process meant it assembled a list of files to package before it got the Lua modules ready for bundling. Because of the bug in the release number bumping I re-ran the clean steps in the middle of the release process and ended up with a source tarball that was _too_ clean. This includes fixes so that can't happen again, `make dist` should work on it's own without having run `make` or anything else past `./configure`.

Also closes #816 (broken upstream, workaround included here until it gets fixed).