### PR TITLE
fix(typesetter): Make `typesetter.breakwidth` a measurement

### DIFF
--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -67,7 +67,7 @@ SILE.settings.declare({
 
 SILE.settings.declare({
   name = "typesetter.breakwidth",
-  type = "length or nil",
+  type = "measurement or nil",
   default = nil,
   help = "Width to break lines at"
 })

--- a/tests/bidi.expected
+++ b/tests/bidi.expected
@@ -1,0 +1,172 @@
+Set paper size 	419.5275636	595.275597
+Begin page
+Mx 	20.9764
+My 	47.2138
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	46 90	(My)
+Mx 	62.3532
+T	73 80 87 70 83 68 83 66 2373	(hovercraft)
+Mx 	174.5801
+T	74 84	(is)
+Mx 	198.6319
+T	71 86 77 77	(full)
+Mx 	240.3838
+T	80 71	(of)
+Mx 	268.2606
+T	70 70 77 84	(eels)
+Mx 	307.1356
+T	15	(.)
+Mx 	20.9764
+My 	76.2138
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1184 1180 1178 1191 1176 1183 1193 1172	(בצלופחים)
+Mx 	114.7155
+T	1175 1171 1183 1185	(מלאה)
+Mx 	171.1297
+T	1180 1183 1196	(שלי)
+Mx 	212.6189
+T	1197 1191 1178 1195 1175	(הרחפת)
+Mx 	20.9764
+My 	105.2138
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	48 79 70	(One)
+Mx 	70.7946
+T	85 88 80	(two)
+Mx 	117.3127
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1173 1172 1171	(אבג)
+Mx 	156.9559
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	85 73 83 70 70	(three)
+Mx 	217.4741
+T	71 80 86 83	(four)
+Mx 	20.9764
+My 	134.2138
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1184 1180 1180 1197 1196	(שתיים)
+Mx 	83.3612
+T	1174 1178 1171	(אחד)
+Mx 	125.8460
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	34 35 36	(ABC)
+Mx 	181.6058
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1189 1172 1195 1171	(ארבע)
+Mx 	237.5656
+T	1196 1176 1183 1196	(שלוש)
+Mx 	20.9764
+My 	163.2138
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	46 90	(My)
+Mx 	60.2430
+T	73 80 87 70 83 68 83 66 2373	(hovercraft)
+Mx 	20.9764
+My 	192.2138
+T	74 84	(is)
+Mx 	45.0026
+T	71 86 77 77	(full)
+Mx 	86.7287
+T	80 71	(of)
+Mx 	114.5799
+T	70 70 77 84	(eels)
+Mx 	153.4549
+T	15	(.)
+Mx 	20.9764
+My 	221.2138
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1175 1171 1183 1185	(מלאה)
+Mx 	75.2680
+T	1180 1183 1196	(שלי)
+Mx 	114.6347
+T	1197 1191 1178 1195 1175	(הרחפת)
+Mx 	20.9764
+My 	250.2138
+T	1184 1180 1178 1191 1176 1183 1193 1172	(בצלופחים)
+Mx 	359.6762
+My 	279.9388
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	70 70 77 84	(eels)
+Mx 	331.7993
+T	80 71	(of)
+Mx 	290.0475
+T	71 86 77 77	(full)
+Mx 	265.9956
+T	74 84	(is)
+Mx 	153.7688
+T	73 80 87 70 83 68 83 66 2373	(hovercraft)
+Mx 	112.3919
+T	46 90	(My)
+Mx 	106.8919
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	15	(.)
+Mx 	337.9512
+My 	308.9388
+T	1197 1191 1178 1195 1175	(הרחפת)
+Mx 	296.4620
+T	1180 1183 1196	(שלי)
+Mx 	240.0479
+T	1175 1171 1183 1185	(מלאה)
+Mx 	146.3087
+T	1184 1180 1178 1191 1176 1183 1193 1172	(בצלופחים)
+Mx 	359.5762
+My 	337.9388
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	85 88 80	(two)
+Mx 	309.7580
+T	48 79 70	(One)
+Mx 	270.1148
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1173 1172 1171	(אבג)
+Mx 	219.6467
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	71 80 86 83	(four)
+Mx 	159.1285
+T	85 73 83 70 70	(three)
+Mx 	363.6012
+My 	366.9388
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1174 1178 1171	(אחד)
+Mx 	301.2164
+T	1184 1180 1180 1197 1196	(שתיים)
+Mx 	245.4566
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	34 35 36	(ABC)
+Mx 	188.2968
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	1196 1176 1183 1196	(שלוש)
+Mx 	132.3370
+T	1189 1172 1195 1171	(ארבע)
+Mx 	293.8512
+My 	395.9388
+Set font 	SBL Hebrew;25;400;;normal;;LTR
+T	73 80 87 70 83 68 83 66 2373	(hovercraft)
+Mx 	254.5845
+T	46 90	(My)
+Mx 	359.6762
+My 	424.9388
+T	70 70 77 84	(eels)
+Mx 	331.8250
+T	80 71	(of)
+Mx 	290.0988
+T	71 86 77 77	(full)
+Mx 	266.0727
+T	74 84	(is)
+Mx 	260.5727
+Set font 	SBL Hebrew;25;400;;normal;;RTL
+T	15	(.)
+Mx 	337.9512
+My 	453.9388
+T	1197 1191 1178 1195 1175	(הרחפת)
+Mx 	298.5845
+T	1180 1183 1196	(שלי)
+Mx 	244.2929
+T	1175 1171 1183 1185	(מלאה)
+Mx 	312.3512
+My 	482.9388
+T	1184 1180 1178 1191 1176 1183 1193 1172	(בצלופחים)
+Mx 	207.4176
+My 	553.7327
+Set font 	Gentium Plus;10;400;;normal;;LTR
+T	20	(1)
+End page
+Finish


### PR DESCRIPTION
Found a bug while running an old bidi test, which should also be checked in.