### PR TITLE
fix(core): Return correct length from icu.bidi_runs with surrogate pairs

### DIFF
--- a/spec/surrogate_spec.lua
+++ b/spec/surrogate_spec.lua
@@ -1,0 +1,19 @@
+SILE = require("core/sile")
+local icu = require("justenoughicu")
+
+describe("SILE.linebreak", function()
+  local chars = { 0x10000, 0x10001, 0x10002 }
+  local utf8string = ""
+  for i = 1,#chars do
+    utf8string = utf8string .. SU.utf8char(chars[i])
+  end
+
+  it("should be the right length in UTF8", function()
+    assert.is.equal(#utf8string, 12)
+  end)
+
+  it("should be the right length from ICU", function()
+    local res = icu.bidi_runs(utf8string, "LTR")
+    assert.is.equal(res.length, 3)
+  end)
+end)

--- a/src/justenoughicu.c
+++ b/src/justenoughicu.c
@@ -236,7 +236,7 @@ int icu_bidi_runs(lua_State *L) {
   }
 
   int count = ubidi_countRuns(bidi,&err);
-  int start, length;
+  int start, length, codepointlength;
 
   lua_checkstack(L,count);
   for (int i=0; i < count; i++) {
@@ -270,10 +270,11 @@ int icu_bidi_runs(lua_State *L) {
     lua_settable(L, -3);
 
     lua_pushstring(L, "length");
+    codepointlength = length;
     for (int j=start; j< start+length; j++) {
-      if (U_IS_TRAIL(*(input_as_uchar+j))) length--;
+      if (U_IS_TRAIL(*(input_as_uchar+j))) codepointlength--;
     }
-    lua_pushinteger(L, length);
+    lua_pushinteger(L, codepointlength);
     lua_settable(L, -3);
 
     lua_pushstring(L, "dir");


### PR DESCRIPTION
Fixes #839. We were modifying a loop variable while in the loop, meaning
that we didn't run right to the end of the string.