### PR TITLE
Revert "refactor(core): Use descriptive function names in pagebuilder"

### DIFF
--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -389,7 +389,7 @@ SILE.defaultTypesetter = std.object {
     if SILE.scratch.insertions then SILE.scratch.insertions.thisPage = {} end
     pageNodeList, res = SILE.pagebuilder:findBestBreak({
       vboxlist = self.state.outputQueue,
-      target   = self:getTargetLength(),
+      target   = self:pageTarget(),
       restart  = self.frame.state.pageRestart
     })
     if not pageNodeList then -- No break yet


### PR DESCRIPTION
This reverts commit 657098ab1409bae2cb9d3fd051f73fcb08cc7d92, which was causing problems with overlapping footnotes and miscalculations of the footnote frame size.