### PR TITLE
fix(languages): Localize TOC title functions

### DIFF
--- a/languages/cs.lua
+++ b/languages/cs.lua
@@ -3649,6 +3649,6 @@ SILE.hyphenator.languages["cs"].exceptions =
 
 -- Internationalisation stuff
 SILE.doTexlike([[%
-\define[command=tableofcontents:title]{Obsah}%
+\define[command=tableofcontents:title:cs]{Obsah}%
 \define[command=book:chapter:pre:cs]{Kapitola }%
 ]])

--- a/languages/en.lua
+++ b/languages/en.lua
@@ -599,7 +599,7 @@ SILE.hyphenator.languages["en"].exceptions = {"as-so-ciate", "as-so-ciates",
 
 -- Internationalisation stuff
 SILE.doTexlike([[%
-\define[command=tableofcontents:title]{Table of Contents}%
+\define[command=tableofcontents:title:en]{Table of Contents}%
 \define[command=book:chapter:pre:en]{Chapter }%
 ]])
 

--- a/languages/tr.lua
+++ b/languages/tr.lua
@@ -616,7 +616,7 @@ SILE.hyphenator.languages["tr"].patterns =
 
 -- Internationalisation stuff
 SILE.doTexlike([[%
-\define[command=tableofcontents:title]{İçindekiler}%
+\define[command=tableofcontents:title:tr]{İçindekiler}%
 \define[command=book:chapter:pre:tr]{Bölüm }%
 ]])
 

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -65,13 +65,17 @@ SILE.registerCommand("tocentry", function (options, content)
   })
 end)
 
+SILE.registerCommand("tableofcontents:title", function (_, _)
+  local lang = SILE.settings.get("document.language")
+  SILE.call("tableofcontents:title:" .. lang)
+end)
+
 return {
   exports = { writeToc = writeToc, moveTocNodes = moveNodes },
   init = function (self)
     self:loadPackage("infonode")
     self:loadPackage("leaders")
 SILE.doTexlike([[%
-\define[command=tableofcontents:title]{}%
 \define[command=tableofcontents:notocmessage]{\tableofcontents:headerfont{Rerun SILE to process table of contents!}}%
 \define[command=tableofcontents:headerfont]{\font[size=24pt,weight=800]{\process}}%
 \define[command=tableofcontents:header]{\par\noindent\tableofcontents:headerfont{\tableofcontents:title}\medskip}%


### PR DESCRIPTION
Fixes #848.

This localization system _works_ but I consider it an ugly hack and am only pushing this through as a stand-in until #675 is ready for production.