### PR TITLE
Revive Docker Hub builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG sile_tag=master
-FROM archlinux AS sile-base
+FROM archlinux:20200306 AS sile-base
+RUN sed -i -e '/IgnorePkg *=/s/^.*$/IgnorePkg = coreutils/' /etc/pacman.conf
 
 RUN pacman --needed --noconfirm -Syuq && yes | pacman -Sccq
 


### PR DESCRIPTION
Docker Hub did something upstream a week or two ago that makes their filesystem mounts incompatible with fresh GNU coreutils. Local builds of Docker images have still been working perfectly. This revives the automatic builds on Hub.

Revert when [upstream issues](https://github.com/archlinux/archlinux-docker/issues/32) are sorted out.