### PR TITLE
fix(frames): Avoid possible infinite loop when looking for a frame

### DIFF
--- a/core/frame.lua
+++ b/core/frame.lua
@@ -246,10 +246,12 @@ SILE.getFrame = function (id)
   if type(id) == "table" then
     SU.error("Passed a table, expected a string", true)
   end
-  local frame
+  local frame, last_attempt
   while not frame do
     frame = SILE.frames[id]
     id = id:gsub("_$", "")
+    if id == last_attempt then break end
+    last_attempt = id
   end
   return frame or SU.warn("Couldn't find frame ID "..id, true)
 end


### PR DESCRIPTION
@simoncozens [mentioned in chat](https://gitter.im/sile-typesetter/sile?at=5ea401e8e5ed621d4ddcbd62) he'd hit an infinite loop. I'm guessing this fixes it, no?