### PR TITLE
Revamp macro system to fix scope extrusion bugs

### DIFF
--- a/core/baseclass.lua
+++ b/core/baseclass.lua
@@ -62,7 +62,7 @@ SILE.registerCommand("define", function (options, content)
     SILE.registerCommand(options["command"], content)
     return
   elseif options.command == "process" then
-    SU.error("Defining a macro named `process`? Yeah, that won't go well.")
+    SU.warn("Did you mean to re-definine the `\\process` macro? That probably won't go well.")
   end
   SILE.registerCommand(options["command"], function (_, _content)
     SU.debug("macros", "Processing a "..options["command"].."\n")

--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -59,6 +59,8 @@ SILE.process = function (input)
     local content = input[i]
     if type(content) == "string" then
       SILE.typesetter:typeset(content)
+    elseif type(content) == "function" then
+      content()
     elseif SILE.Commands[content.command] then
       SILE.call(content.command, content.options, content)
     elseif content.id == "texlike_stuff" or (not content.command and not content.id) then


### PR DESCRIPTION
The bug in #535 is due to a `\process` from a macro being evaluated after the macro finished executing.

A possible solution to that is to replace every occurrence of `\process` by the argument before processing the body. However, macros can also take functions as their arguments, so this works if `SILE.process` accepts ASTs containing functions.

So this fixes #535. The implementation also allows for several occurrences of `\process` in a macro.