### PR TITLE
fix(nodes): Fix calling non-existent nodefactory function

### DIFF
--- a/core/nodefactory.lua
+++ b/core/nodefactory.lua
@@ -662,9 +662,13 @@ end
 
 setmetatable(nodefactory, {
     __index = function (_, prop)
-      SU.deprecated("SILE.nodefactory." .. prop, "SILE.nodefactory." .. prop:match("n?e?w?(.*)"):lower(), "0.10.0")
-      local old_constructor = _deprecated_nodefactory[prop]
-      return string.find(prop, "^new") and old_constructor or old_constructor()
+      if _deprecated_nodefactory[prop] then
+        SU.deprecated("SILE.nodefactory." .. prop, "SILE.nodefactory." .. prop:match("n?e?w?(.*)"):lower(), "0.10.0")
+        local old_constructor = _deprecated_nodefactory[prop]
+        return string.find(prop, "^new") and old_constructor or old_constructor()
+      else
+        SU.error("Attempt to access non-existent SILE.nodefactory." .. prop)
+      end
     end
   })
 


### PR DESCRIPTION
Attempting to call a `SILE.nodefactory` function that doesn't exist
would cause a crash with an irrelevant error message:

```
\begin[class=plain]{document}

\script{
  SILE.settings.set("document.parskip", SILE.nodefactory.foobar())
}

\end{document}
```

```
This is SILE v0.10.4.r10-ge9dcf23-dirty
<depr.sil>

! SILE.nodefactory.foobar() was deprecated in SILE v0.10.0. Please use SILE.nodefactory.foobar() instead. nil at depr.sil:3:1: in \script

Error detected:
	...ile/master.local_install/share/sile/core/nodefactory.lua:667: attempt to call a nil value (local 'old_constructor')
```

This makes it crash with the actually helpful message:

```
This is SILE v0.10.4.r10-ge9dcf23-dirty
<depr.sil>

Error detected:
	[string "..."]:2: attempt to call a nil value (field 'foobar')
```