### PR TITLE
Fix up frame naming for jbook & language=main

### DIFF
--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -148,14 +148,17 @@ SILE.outputters.libtexpdf = {
     self.rule(frame:left(), frame:bottom(), frame:width(), 0.5)
     --self.rule(frame:left() + frame:width()/2 - 5, (frame:top() + frame:bottom())/2+5, 10, 10)
     local stuff = SILE.shaper:createNnodes(frame.id, SILE.font.loadDefaults({}))
-    stuff = stuff[1].nodes[1].value.glyphString -- Horrible hack
-    local buf = {}
-    for i = 1, #stuff do
-      local glyph = stuff[i]
-      buf[#buf+1] = string.char(math.floor(glyph % 2^32 / 2^8))
-      buf[#buf+1] = string.char(glyph % 0x100)
+    local buf = "nil"
+    if stuff[1].nodes then -- Hide horrible hack from certain death
+      stuff = stuff[1].nodes[1].value.glyphString -- Horrible hack
+      buf = {}
+      for i = 1, #stuff do
+        local glyph = stuff[i]
+        buf[#buf+1] = string.char(math.floor(glyph % 2^32 / 2^8))
+        buf[#buf+1] = string.char(glyph % 0x100)
+      end
+      buf = table.concat(buf, "")
     end
-    buf = table.concat(buf, "")
     if font == 0 then SILE.outputter.setFont(SILE.font.loadDefaults({})) end
     pdf.setstring(frame:left():tonumber(), (SILE.documentState.paperSize[2] - frame:top()):tonumber(), buf, string.len(buf), font, 0)
     pdf.colorpop()

--- a/tests/bug-915.expected
+++ b/tests/bug-915.expected
@@ -1,0 +1,8 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	24.7039
+My 	58.1933
+Set font 	Noto Sans CJK JP;10;400;;normal;;LTR
+T	1531	(よ)
+End page
+Finish

--- a/tests/bug-915.sil
+++ b/tests/bug-915.sil
@@ -1,0 +1,9 @@
+\begin[papersize=a6,class=jbook]{document}
+\script[src=packages/frametricks]
+\language[main=ja]
+\noindent
+\nofolios
+\font[family=Noto Sans CJK JP]
+よ
+\showframe
+\end{document}


### PR DESCRIPTION
Closes #915.

I blame @simoncozens who *knew* better when he went ahead with 2565771c.

https://github.com/sile-typesetter/sile/blob/2565771cee1f502cc4a7919c9fc520d3484981a7/core/libtexpdf-output.lua#L71

Someday [his code might actually eat him](https://twitter.com/CalebMaclennan/status/1280812395577905152). It will serve him right if his gravestone has terrible kerning. I'll contribute to a memorial fund to have a better one carved ... but not in the first week or two.