### PR TITLE
Remove (most) of the wildcard hacks from automake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ jobs:
             .fonts
             .sources
           key: fonts-${{ hashFiles('Makefile-fonts') }}
+      - name: Cache Lua Rocks
+        uses: actions/cache@v2
+        with:
+          path: |
+            lua_modules_dist
+          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile-dev-1.rockspec') }}
       - name: Fetch Tags
         run: git fetch --prune --tags
       - name: Install System Dependencies

--- a/Makefile-luarocks
+++ b/Makefile-luarocks
@@ -1,0 +1,44 @@
+SUPPORTED_LUAS = 5.3 5.2 5.1
+
+LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
+
+if !SYSTEM_LUAROCKS
+nobase_nodist_pkgdata_DATA = $(LUAMODULES)
+LUAMODLOCK := sile-dev-1.rockslock
+LUAMODSPEC := sile-dev-1.rockspec
+genrockslock := $(LUAROCKS) $(LUAROCKSARGS) list --porcelain | awk '{print $$1 " " $$2}'
+rocksmatch := cmp -s $(LUAMODLOCK) <($(genrockslock))
+endif
+
+.PHONY: installrocks disallow-dist-with-system-luarocks
+if !SYSTEM_LUAROCKS
+installrocks: $(LUAMODLOCK) $(shell $(rocksmatch) || echo lua_modules)
+
+lua_modules: $(LUAMODSPEC) $(shell $(rocksmatch) || echo force)
+	if test -e .git; then
+		$(LUAROCKS) $(LUAROCKSARGS) install --only-deps $<
+	else
+		rm -rf lua_modules
+		cp -a lua_modules_dist lua_modules
+		$(foreach LUA,$(filter-out $(LUA_VERSION),$(SUPPORTED_LUAS)),
+		find lua_modules -maxdepth 3 -type d -name "*$(LUA)" -execdir rm -rf {} \;)
+	fi
+
+$(LUAMODLOCK): lua_modules $(LUAMODSPEC)
+	$(genrockslock) > $@
+
+sile: installrocks
+
+disallow-dist-with-system-luarocks: ;
+else
+disallow-dist-with-system-luarocks:
+	$(error In order to make dist you must configure --without-system-luarocks)
+	exit 1
+endif
+
+.PHONY: lua_modules_dist
+lua_modules_dist: LUAROCKS = luarocks --tree lua_modules_dist
+lua_modules_dist: $(LUAMODSPEC) force disallow-dist-with-system-luarocks
+	$(foreach LUA,$(SUPPORTED_LUAS),
+	$(LUAROCKS) $(LUAROCKSARGS) --lua-version $(LUA) install --only-deps $<)
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ SUPPORTED_LUAS = 5.3 5.2 5.1
 
 MANUAL = documentation/sile.pdf
 
-Makefile-distfiles: build-aux/list-dist-files.sh .version $(wildcard lua_modules_dist)
+Makefile-distfiles: build-aux/list-dist-files.sh .version
 	$< 2>/dev/null > $@
 
 include Makefile-distfiles
@@ -22,7 +22,7 @@ bin_SCRIPTS = sile
 EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec fontconfig.conf
 EXTRA_DIST += .version Makefile-distfiles
 EXTRA_DIST += build-aux/git-version-gen build-aux/list-dist-files.sh
-EXTRA_DIST += $(extra_dist) $(MANUAL) $(EXAMPLES)
+EXTRA_DIST += $(LUAMODULESDIST) $(MANUAL) $(EXAMPLES)
 
 SHELL = bash
 .ONESHELL:
@@ -31,15 +31,13 @@ SHELL = bash
 .DELETE_ON_ERROR:
 am__remove_distdir =
 
-if !SYSTEM_LUAROCKS
-nobase_nodist_pkgdata_DATA = $(LUADISTFILES)
 LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
+if !SYSTEM_LUAROCKS
+nobase_nodist_pkgdata_DATA = $(LUAMODULES)
 LUAMODLOCK := sile-dev-1.rockslock
 LUAMODSPEC := sile-dev-1.rockspec
 genrockslock := $(LUAROCKS) $(LUAROCKSARGS) list --porcelain | awk '{print $$1 " " $$2}'
 rocksmatch := cmp -s $(LUAMODLOCK) <($(genrockslock))
-else
-LUAROCKS := luarocks --tree lua_modules_dist --lua-version $(LUA_VERSION)
 endif
 
 BUILT_SOURCES = .version
@@ -54,15 +52,16 @@ dist-hook: lua_modules_dist $(MANUAL) $(EXAMPLES)
 	echo $(VERSION) > $(distdir)/.tarball-version
 	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
 
+_DATA_HOOK_DEPS =
 if MANUAL
-install-data-hook: $(MANUAL)
+_DATA_HOOK_DEPS += $(MANUAL)
 endif
 
 if EXAMPLES
-install-data-hook: $(EXAMPLES)
+_DATA_HOOK_DEPS += $(EXAMPLES)
 endif
 
-install-data-hook:
+install-data-hook: $(_DATA_HOOK_DEPS)
 	:
 if MANUAL
 	rm -f "$(DESTDIR)/$(datarootdir)/$<"
@@ -136,6 +135,7 @@ disallow-dist-with-system-luarocks:
 endif
 
 .PHONY: lua_modules_dist
+lua_modules_dist: LUAROCKS = luarocks --tree lua_modules_dist
 lua_modules_dist: $(LUAMODSPEC) force disallow-dist-with-system-luarocks
 	$(foreach LUA,$(SUPPORTED_LUAS),
 	$(LUAROCKS) $(LUAROCKSARGS) --lua-version $(LUA) install --only-deps $<)

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,9 @@ BUILT_SOURCES = .version
 	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
 	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
 
-dist-hook: lua_modules_dist $(MANUAL) $(EXAMPLES)
+dist-hook: lua_modules_dist | $(MANUAL) $(EXAMPLES)
 	echo $(VERSION) > $(distdir)/.tarball-version
+	cp -fa $< $(distdir)/
 	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
 
 _DATA_HOOK_DEPS =

--- a/Makefile.am
+++ b/Makefile.am
@@ -205,11 +205,10 @@ if !SYSTEM_LUAROCKS
 _INSTALL = installrocks
 endif
 _FORCED = $(and $(SILE_COVERAGE)$(CLEAN),force)
-_MAKE_DEPS = $(wildcard $(DEPDIR)/$*.d)
 _TEST_DEPS = $(and $(filter tests/%,$@),$(addprefix .fonts/,$(TESTFONTFILES)))
 _DOCS_DEPS = $(and $(filter docs/%,$@),$(addprefix .fonts/,$(DOCSFONTFILES)))
 _EXAM_DEPS = $(and $(filter examples/%,$@),$(addprefix .fonts/,$(EXAMFONTFILES)))
-patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) | $(DEPDIRS) $(_MAKE_DEPS) $(_INSTALL) all
+patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) | $(DEPDIRS) $(_INSTALL) all
 
 %.pdf: %.sil $$(patterndeps)
 	$(runsile)

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ SUPPORTED_LUAS = 5.3 5.2 5.1
 
 MANUAL = documentation/sile.pdf
 
-Makefile-distfiles: build-aux/list-dist-files.sh .version
+Makefile-distfiles: build-aux/list-dist-files.sh .version $(wildcard lua_modules_dist)
 	$< 2>/dev/null > $@
 
 include Makefile-distfiles
@@ -19,7 +19,9 @@ include Makefile-distfiles
 dist_man_MANS = sile.1
 dist_doc_DATA = README.md CHANGELOG.md
 bin_SCRIPTS = sile
-EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec build-aux/git-version-gen .version fontconfig.conf Makefile-distfiles
+EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec fontconfig.conf
+EXTRA_DIST += .version Makefile-distfiles
+EXTRA_DIST += build-aux/git-version-gen build-aux/list-dist-files.sh
 EXTRA_DIST += $(extra_dist) $(MANUAL) $(EXAMPLES)
 
 SHELL = bash
@@ -30,6 +32,7 @@ SHELL = bash
 am__remove_distdir =
 
 if !SYSTEM_LUAROCKS
+nobase_nodist_pkgdata_DATA = $(LUADISTFILES)
 LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
 LUAMODLOCK := sile-dev-1.rockslock
 LUAMODSPEC := sile-dev-1.rockspec

--- a/Makefile.am
+++ b/Makefile.am
@@ -163,7 +163,8 @@ luarocks-lint: $(LUAMODSPEC)
 luacheck:
 	luacheck -j$(shell nproc) -q .
 
-busted: $(wildcard spec/*_spec.lua)
+.PHONY: busted
+busted: | $(_INSTALL) all
 	set -f; IFS=';'
 if SYSTEM_LUAROCKS
 	packagecpath=(./{,core/}?.$(SHARED_LIB_EXT))

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,13 +51,20 @@ dist-hook: lua_modules_dist $(MANUAL) $(EXAMPLES)
 
 if MANUAL
 install-data-hook: $(MANUAL)
-	rm -f "$(DESTDIR)/$(datarootdir)/$<"
-	install -Dm644 -t "$(DESTDIR)$(docdir)" $<
 endif
 
 if EXAMPLES
 install-data-hook: $(EXAMPLES)
-	install -Dm644 -t "$(DESTDIR)$(docdir)/examples" $^
+endif
+
+install-data-hook:
+	:
+if MANUAL
+	rm -f "$(DESTDIR)/$(datarootdir)/$<"
+	install -Dm644 -t "$(DESTDIR)$(docdir)" $(MANUAL)
+endif
+if EXAMPLES
+	install -Dm644 -t "$(DESTDIR)$(docdir)/examples" $(EXAMPLES)
 endif
 
 # Whether to force tests to run from scratch

--- a/Makefile.am
+++ b/Makefile.am
@@ -109,7 +109,7 @@ update_libtexpdf:
 gh-pages:
 	git worktree add -f $@ $@
 
-.PHONY: installrocks
+.PHONY: installrocks disallow-dist-with-system-luarocks
 if !SYSTEM_LUAROCKS
 installrocks: $(LUAMODLOCK) $(shell $(rocksmatch) || echo lua_modules)
 
@@ -127,10 +127,16 @@ $(LUAMODLOCK): lua_modules $(LUAMODSPEC)
 	$(genrockslock) > $@
 
 sile: installrocks
+
+disallow-dist-with-system-luarocks: ;
+else
+disallow-dist-with-system-luarocks:
+	$(error In order to make dist you must configure --without-system-luarocks)
+	exit 1
 endif
 
 .PHONY: lua_modules_dist
-lua_modules_dist: $(LUAMODSPEC) force
+lua_modules_dist: $(LUAMODSPEC) force disallow-dist-with-system-luarocks
 	$(foreach LUA,$(SUPPORTED_LUAS),
 	$(LUAROCKS) $(LUAROCKSARGS) --lua-version $(LUA) install --only-deps $<)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,6 @@ else
 SUBDIRS = libtexpdf src
 endif
 
-SUPPORTED_LUAS = 5.3 5.2 5.1
-
 MANUAL = documentation/sile.pdf
 
 Makefile-distfiles: build-aux/list-dist-files.sh .version
@@ -30,15 +28,6 @@ SHELL = bash
 .SECONDEXPANSION:
 .DELETE_ON_ERROR:
 am__remove_distdir =
-
-LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
-if !SYSTEM_LUAROCKS
-nobase_nodist_pkgdata_DATA = $(LUAMODULES)
-LUAMODLOCK := sile-dev-1.rockslock
-LUAMODSPEC := sile-dev-1.rockspec
-genrockslock := $(LUAROCKS) $(LUAROCKSARGS) list --porcelain | awk '{print $$1 " " $$2}'
-rocksmatch := cmp -s $(LUAMODLOCK) <($(genrockslock))
-endif
 
 BUILT_SOURCES = .version
 
@@ -108,38 +97,6 @@ update_libtexpdf:
 
 gh-pages:
 	git worktree add -f $@ $@
-
-.PHONY: installrocks disallow-dist-with-system-luarocks
-if !SYSTEM_LUAROCKS
-installrocks: $(LUAMODLOCK) $(shell $(rocksmatch) || echo lua_modules)
-
-lua_modules: $(LUAMODSPEC) $(shell $(rocksmatch) || echo force)
-	if test -e .git; then
-		$(LUAROCKS) $(LUAROCKSARGS) install --only-deps $<
-	else
-		rm -rf lua_modules
-		cp -a lua_modules_dist lua_modules
-		$(foreach LUA,$(filter-out $(LUA_VERSION),$(SUPPORTED_LUAS)),
-		find lua_modules -maxdepth 3 -type d -name "*$(LUA)" -execdir rm -rf {} \;)
-	fi
-
-$(LUAMODLOCK): lua_modules $(LUAMODSPEC)
-	$(genrockslock) > $@
-
-sile: installrocks
-
-disallow-dist-with-system-luarocks: ;
-else
-disallow-dist-with-system-luarocks:
-	$(error In order to make dist you must configure --without-system-luarocks)
-	exit 1
-endif
-
-.PHONY: lua_modules_dist
-lua_modules_dist: LUAROCKS = luarocks --tree lua_modules_dist
-lua_modules_dist: $(LUAMODSPEC) force disallow-dist-with-system-luarocks
-	$(foreach LUA,$(SUPPORTED_LUAS),
-	$(LUAROCKS) $(LUAROCKSARGS) --lua-version $(LUA) install --only-deps $<)
 
 DEPDIR := .deps
 REGRESSIONSCRIPT := ./tests/regressions.pl
@@ -369,6 +326,9 @@ include $(wildcard $(DEPFILES))
 
 # Actual rules for downloading test fonts are in a separate file
 include Makefile-fonts
+
+# All LuaRocks handling stuff consolidated
+include Makefile-luarocks
 
 CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,11 +11,15 @@ SUPPORTED_LUAS = 5.3 5.2 5.1
 
 MANUAL = documentation/sile.pdf
 
+Makefile-distfiles: build-aux/list-dist-files.sh .version
+	$< 2>/dev/null > $@
+
+include Makefile-distfiles
+
 dist_man_MANS = sile.1
 dist_doc_DATA = README.md CHANGELOG.md
 bin_SCRIPTS = sile
-nobase_dist_pkgdata_DATA = $(filter %.lua %.sil,$(shell find core classes languages packages lua-libraries -type f -print))
-EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec build-aux/git-version-gen .version fontconfig.conf
+EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec build-aux/git-version-gen .version fontconfig.conf Makefile-distfiles
 EXTRA_DIST += $(extra_dist) $(MANUAL) $(EXAMPLES)
 
 SHELL = bash
@@ -25,9 +29,7 @@ SHELL = bash
 .DELETE_ON_ERROR:
 am__remove_distdir =
 
-extra_dist = $(shell find lua_modules_dist -type f -print 2>/dev/null ||:)
 if !SYSTEM_LUAROCKS
-nobase_nodist_pkgdata_DATA = $(shell find lua_modules -type f -print 2>/dev/null ||:)
 LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
 LUAMODLOCK := sile-dev-1.rockslock
 LUAMODSPEC := sile-dev-1.rockspec
@@ -40,7 +42,7 @@ endif
 BUILT_SOURCES = .version
 
 .version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
-	mv $@{,-prev} || touch $@-prev
+	mv $@{,-prev} 2>/dev/null || touch $@-prev
 	( test -e .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
 	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
 	sed -i -e '/rm -f/s/ core / /' configure aclocal.m4 ||:
@@ -134,9 +136,8 @@ REGRESSIONSCRIPT := ./tests/regressions.pl
 LOCALTESTFONTS := FONTCONFIG_FILE=$(PWD)/fontconfig.conf
 SILEFLAGS ?= -m $(DEPDIR)/$(basename $@).d -d versions -f fontconfig
 
-TESTSRCS  ?= $(wildcard tests/*.sil tests/*.xml)
 TESTPDFS   = $(addsuffix      .pdf,$(basename $(TESTSRCS)))
-EXPECTEDS ?= $(filter $(addsuffix .expected,$(basename $(TESTSRCS))),$(wildcard tests/*.expected))
+EXPECTEDS ?= $(filter $(addsuffix .expected,$(basename $(TESTSRCS))),$(TESTEXPECTS))
 ACTUALS    = $(addsuffix   .actual,$(basename $(EXPECTEDS)))
 
 check: selfcheck
@@ -178,8 +179,7 @@ endif
 .PHONY: docs
 docs: $(MANUAL)
 
-EXAMPLESSRCS = $(basename $(wildcard examples/*.sil) examples/docbook/article-template.xml)
-EXAMPLES = $(addsuffix .pdf,$(EXAMPLESSRCS))
+EXAMPLES = $(addsuffix .pdf,$(basename $(EXAMPLESSRCS)))
 
 .PHONY: examples
 examples: $(EXAMPLES)
@@ -361,7 +361,7 @@ include $(wildcard $(DEPFILES))
 # Actual rules for downloading test fonts are in a separate file
 include Makefile-fonts
 
-CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL)
+CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles
 
 .PHONY: docker
 docker: Dockerfile build-aux/docker-entrypoint.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,8 @@ if [ ! -f "libtexpdf/configure.ac" ] && [ -e ".git" ]; then
     git submodule update --init --recursive --remote
 fi
 
+touch -d @0 Makefile-distfiles
+
 autoreconf --install -W none
 
 # See discussion in https://github.com/sile-typesetter/sile/issues/82 and

--- a/build-aux/list-dist-files.sh
+++ b/build-aux/list-dist-files.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo -n "nobase_dist_pkgdata_DATA ="
+find core classes languages packages lua-libraries -type f -name '*.lua' -printf ' %p'
+find classes -type f -name '*.sil' -printf ' %p'
+
+echo -ne "\nextra_dist ="
+find lua_modules_dist -type f -printf ' %p' ||:
+
+echo -e "\nif !SYSTEM_LUAROCKS"
+echo -n "nobase_nodist_pkgdata_DATA ="
+find lua_modules -type f -printf ' %p' ||:
+echo -ne "\nendif"
+
+echo -ne "\nTESTSRCS ?="
+find tests -maxdepth 1 -type f -name '*.sil' -printf ' %p'
+find tests -maxdepth 1 -type f -name '*.xml' -printf ' %p'
+
+echo -ne "\nTESTEXPECTS ?="
+find tests -maxdepth 1 -type f -name '*.expected' -printf ' %p'
+
+echo -ne "\nEXAMPLESSRCS ="
+find examples -maxdepth 1 -type f -name '*.sil' -printf ' %p'
+find examples/docbook -maxdepth 1 -type f -name '*.xml' -printf ' %p'

--- a/build-aux/list-dist-files.sh
+++ b/build-aux/list-dist-files.sh
@@ -6,11 +6,11 @@ echo -n "nobase_dist_pkgdata_DATA ="
 find core classes languages packages lua-libraries -type f -name '*.lua' -printf ' %p'
 find classes -type f -name '*.sil' -printf ' %p'
 
-echo -ne "\nextra_dist ="
-find lua_modules_dist -type f -printf ' %p' ||:
+echo -ne "\nLUAMODULES ="
+find lua_modules -type f -not -name '*~' -printf ' %p' ||:
 
-echo -ne "\nLUADISTFILES ="
-find lua_modules -type f -printf ' %p' ||:
+echo -ne "\nLUAMODULESDIST ="
+find lua_modules_dist -type f -not -name '*~' -printf ' %p' ||:
 
 echo -ne "\nTESTSRCS ?="
 find tests -maxdepth 1 -type f -name '*.sil' -printf ' %p'

--- a/build-aux/list-dist-files.sh
+++ b/build-aux/list-dist-files.sh
@@ -9,10 +9,8 @@ find classes -type f -name '*.sil' -printf ' %p'
 echo -ne "\nextra_dist ="
 find lua_modules_dist -type f -printf ' %p' ||:
 
-echo -e "\nif !SYSTEM_LUAROCKS"
-echo -n "nobase_nodist_pkgdata_DATA ="
+echo -ne "\nLUADISTFILES ="
 find lua_modules -type f -printf ' %p' ||:
-echo -ne "\nendif"
 
 echo -ne "\nTESTSRCS ?="
 find tests -maxdepth 1 -type f -name '*.sil' -printf ' %p'


### PR DESCRIPTION
Closes #951.

This is a bit awkward, but I've been thinking about this now and then for years and nothing better has occurred to me. Fighting automake is not fun, using it as intended is actually not too bad. This punts most of the ways we were trying to be too smart for it to a shell script.

The biggest downside is currently you can't skip straight from `./configure` to `make dist`, you have to `make` in between. Working on that bit, maybe...