### PR TITLE
Fix Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,8 @@ LABEL maintainer="Caleb Maclennan <caleb@alerque.com>"
 LABEL version="$sile_tag"
 
 COPY build-aux/docker-fontconfig.conf /etc/fonts/conf.d/99-docker.conf
-COPY build-aux/docker-entrypoint.sh /usr/local/bin
 
 COPY --from=sile-builder /pkgdir /
 
 WORKDIR /data
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["sile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN git fetch --tags ||:
 RUN ./bootstrap.sh
 RUN ./configure
 RUN make
+RUN make check
 RUN make install DESTDIR=/pkgdir
 
 FROM sile-base AS sile
@@ -32,6 +33,7 @@ LABEL version="$sile_tag"
 COPY build-aux/docker-fontconfig.conf /etc/fonts/conf.d/99-docker.conf
 
 COPY --from=sile-builder /pkgdir /
+RUN sile --version
 
 WORKDIR /data
 ENTRYPOINT ["sile"]

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ endif
 
 MANUAL = documentation/sile.pdf
 
-Makefile-distfiles: build-aux/list-dist-files.sh .version
+Makefile-distfiles: build-aux/list-dist-files.sh .version sile-dev-1.rockslock
 	$< 2>/dev/null > $@
 
 include Makefile-distfiles
@@ -51,7 +51,7 @@ if EXAMPLES
 _DATA_HOOK_DEPS += $(EXAMPLES)
 endif
 
-install-data-hook: $(_DATA_HOOK_DEPS)
+install-data-hook: Makefile-distfiles $(_DATA_HOOK_DEPS)
 	:
 if MANUAL
 	rm -f "$(DESTDIR)/$(datarootdir)/$<"

--- a/Makefile.am
+++ b/Makefile.am
@@ -337,7 +337,7 @@ include Makefile-luarocks
 CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles
 
 .PHONY: docker
-docker: Dockerfile build-aux/docker-entrypoint.sh
+docker: Dockerfile
 	docker build --tag siletypesetter/sile:HEAD ./
 
 gource.webm:

--- a/README.md
+++ b/README.md
@@ -73,18 +73,12 @@ Users of WSL (Windows Subsytem for Linux) may use the package manager of their c
 
 Docker images are available as [siletypesetter/sile](https://hub.docker.com/repository/docker/siletypesetter/sile). Released versions are tagged to match (e.g. `v.0.10.0`), the latest release will be tagged `latest`, and a `master` tag is also available with the freshest development build. In order to be useful you need to tell the Docker run command how to connect your source documents (and hence give it place to write the output) as well as tell it who you are on the host machine so the output is generated inside the container with the expected ownership. You may find it easiest to run with an alias like this:
 
-    $ alias sile-docker='docker run --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/sile:latest sile'
-    $ sile-docker input.sil
-
-If you wish to connect to the SILE interactive readline interface using Docker:
-
-    $ docker run -it siletypesetter/sile:latest
+    $ alias sile='docker run -it --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/sile:latest'
+    $ sile input.sil
 
 One notable issue with using SILE from a Docker contaner is that it will not have access to your system's fonts by default. You can map a folder of fonts (any tree usable by fontconfig) into the container. This could be your system's default font directory, your user one, a project specific folder, or anything of your choosing. You can see where fonts are found on your system using `fc-list`. The path of your choosing from the host system should be passed as a volume mounted on `/fonts` inside the container like this:
 
-    $ docker run --volume "/usr/share/fonts:/fonts" --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/sile:master
-
-*(Note this feature is not currently in the latest released version, hence the use of `master` in this example.)*
+    $ docker run -it --volume "/usr/share/fonts:/fonts" --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/sile:latest
 
 #### Nix
 

--- a/build-aux/docker-entrypoint.sh
+++ b/build-aux/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
-  set -- sile "$@"
-fi
-
-exec "$@"


### PR DESCRIPTION
...because they were borked in the last releases. Turns out SILE built fine, but the install step didn't always get everything in place. This could have affected some other builds toe (specifically ones that bundled Lua libraries instead of using system ones and didn't do anything extra between configure and `make install`. Any extra things (`make check` or a second `make` pass or whatever) was making the problem go away, which made it hard to spot in development. Running `make check` even was masking the fact that there was a problem before the second invocation of `make`.

Closes #955.