### PR TITLE
Refactor Lua bitwise operations using explicit shim

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -25,7 +25,6 @@ globals = {
   "SU",
   "std",
   "pl",
-  "bit",
   "SYSTEM_SILE_PATH",
   "SHARED_LIB_EXT",
   "ProFi"

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -25,7 +25,7 @@ globals = {
   "SU",
   "std",
   "pl",
-  "bit32",
+  "bit",
   "SYSTEM_SILE_PATH",
   "SHARED_LIB_EXT",
   "ProFi"

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,9 @@ AX_LUA_HEADERS
 AX_LUA_LIBS
 
 AS_IF([test "x$with_system_luarocks" = "xyes"], [
-    AX_LUA_MODULE([bit32], [bit32])
+    AS_IF([test "$LUA_SHORT_VERSION" -lt 52],
+        AX_LUA_MODULE([bit32], [bit32])
+    )
     AX_LUA_MODULE([lpeg], [lpeg])
     AX_LUA_MODULE([cassowary], [cassowary])
     AS_IF([test "$LUA_SHORT_VERSION" -lt 53],

--- a/core/harfbuzz-shaper.lua
+++ b/core/harfbuzz-shaper.lua
@@ -1,6 +1,8 @@
-if not SILE.shapers then SILE.shapers = { } end
 local hb = require("justenoughharfbuzz")
 local icu = require("justenoughicu")
+local bitshim = require("bitshim")
+
+if not SILE.shapers then SILE.shapers = { } end
 
 SILE.settings.declare({
   name = "harfbuzz.subshapers",
@@ -62,9 +64,9 @@ SILE.shapers.harfbuzz = pl.class({
       SU.debug("fonts", "Resolved font family '"..opts.family.."' -> "..(face and face.filename))
       if not face or not face.filename then SU.error("Couldn't find face '"..opts.family.."'") end
       if SILE.makeDeps then SILE.makeDeps:add(face.filename) end
-      if bit32.rshift(face.index, 16) ~= 0 then
+      if bitshim.rshift(face.index, 16) ~= 0 then
         SU.warn("GX feature in '"..opts.family.."' is not supported, fallback to regular font face.")
-        face.index = bit32.band(face.index, 0xff)
+        face.index = bitshim.band(face.index, 0xff)
       end
       local fh, err = io.open(face.filename, "rb")
       if err then SU.error("Can't open font file '"..face.filename.."': "..err) end

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -1,7 +1,6 @@
 -- Initialize Lua environment and global utilities
 local lua_version = _VERSION:sub(-3)
 if lua_version < "5.3" then require("compat53") end -- Backport of lots of Lua 5.3 features to Lua 5.[12]
-bit32 = bit32 or require("bit32") -- Backport of Lua 5.2+ bitwise functions to Lua 5.1
 pl = require("pl.import_into")() -- Penlight on-demand module loader
 if (os.getenv("SILE_COVERAGE")) then require("luacov") end
 

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -1,3 +1,4 @@
+local bitshim = require("bitshim")
 local utilities = {}
 
 local epsilon = 1E-12
@@ -314,9 +315,9 @@ utilities.codepoint = function (uchar)
       seq = c < 0x80 and 1 or c < 0xE0 and 2 or c < 0xF0 and 3 or
             c < 0xF8 and 4 or --c < 0xFC and 5 or c < 0xFE and 6 or
           error("invalid UTF-8 character sequence")
-      val = bit32.band(c, 2^(8-seq) - 1)
+      val = bitshim.band(c, 2^(8-seq) - 1)
     else
-      val = bit32.bor(bit32.lshift(val, 6), bit32.band(c, 0x3F))
+      val = bitshim.bor(bitshim.lshift(val, 6), bitshim.band(c, 0x3F))
     end
     seq = seq - 1
   end
@@ -403,10 +404,10 @@ utilities.splitUtf8 = function (str) -- Return an array of UTF8 strings each rep
       seq = c < 0x80 and 1 or c < 0xE0 and 2 or c < 0xF0 and 3 or
             c < 0xF8 and 4 or --c < 0xFC and 5 or c < 0xFE and 6 or
           error("invalid UTF-8 character sequence")
-      val = bit32.band(c, 2^(8-seq) - 1)
+      val = bitshim.band(c, 2^(8-seq) - 1)
       this = this .. str[i]
     else
-      val = bit32.bor(bit32.lshift(val, 6), bit32.band(c, 0x3F))
+      val = bitshim.bor(bitshim.lshift(val, 6), bitshim.band(c, 0x3F))
       this = this .. str[i]
     end
     seq = seq - 1

--- a/lua-libraries/bitshim.lua
+++ b/lua-libraries/bitshim.lua
@@ -1,0 +1,44 @@
+--[[ This module smooths over all the various Lua bit libraries
+
+Sourced from:
+https://github.com/daurnimator/lua-http/blob/v0.3/http/bit.lua
+
+Note using these functions one must me careful to do bit operations only:
+  - on bytes (8 bits),
+  - with quantities <= LONG_MAX (0x7fffffff)
+  - band with 0x80000000 that is subsequently compared with 0
+]]
+
+-- Lua 5.3 has built-in bit operators, wrap them in a function.
+if _VERSION == "Lua 5.3" then
+	-- Use debug.getinfo to get correct file+line numbers for loaded snippet
+	local info = debug.getinfo(1, "Sl")
+	return assert(load(("\n"):rep(info.currentline+1)..[[return {
+		band = function(a, b) return a & b end;
+		bor = function(a, b) return a | b end;
+		bxor = function(a, b) return a ~ b end;
+	}]], info.source))()
+end
+
+-- The "bit" library that comes with luajit
+-- also available for lua 5.1 as "luabitop": http://bitop.luajit.org/
+local has_bit, bit = pcall(require, "bit")
+if has_bit then
+	return {
+		band = bit.band;
+		bor = bit.bor;
+		bxor = bit.bxor;
+	}
+end
+
+-- The "bit32" library shipped with lua 5.2
+local has_bit32, bit32 = pcall(require, "bit32")
+if has_bit32 then
+	return {
+		band = bit32.band;
+		bor = bit32.bor;
+		bxor = bit32.bxor;
+	}
+end
+
+error("Please install a bit library")

--- a/lua-libraries/bitshim.lua
+++ b/lua-libraries/bitshim.lua
@@ -17,6 +17,8 @@ if _VERSION == "Lua 5.3" then
 		band = function(a, b) return a & b end;
 		bor = function(a, b) return a | b end;
 		bxor = function(a, b) return a ~ b end;
+		lshift = function(a, b) return a << b end;
+		rshift = function(a, b) return a >> b end;
 	}]], info.source))()
 end
 
@@ -28,6 +30,8 @@ if has_bit then
 		band = bit.band;
 		bor = bit.bor;
 		bxor = bit.bxor;
+		lshift = bit.lshift;
+		rshift = bit.rshift;
 	}
 end
 
@@ -38,6 +42,8 @@ if has_bit32 then
 		band = bit32.band;
 		bor = bit32.bor;
 		bxor = bit32.bxor;
+		lshift = bit32.lshift;
+		rshift = bit32.rshift;
 	}
 end
 


### PR DESCRIPTION
This is to smooth the way for Lua 5.4 support (see #668 and #929), inspired by [discussion here](https://github.com/keplerproject/lua-compat-5.3/issues/48). The `bit32` Lua Rock actually tries to be a shim providing Lua 5.2-like functions to Lua 5.1, but it is problematic on newer Lua's that subsequently deprecated that module. It isn't that easy to supply a module when the VM is lying to you about whether the module is already builtin or not.

This explicitly moves all out usage to a shim where we can handle how to shim each version on our own. This will now use `bit32` to shim Lua 5.1, but use the built in language operators in Lua 5.3+. These operations aren't technically 100% equivalent, but they work for what we are doing with them.