### PR TITLE
fix(build): Ship blank lua_modules install list in source packges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           ./configure --with-manual --with-examples
           echo "::set-env name=DISTDIR::sile-$(./build-aux/git-version-gen .tarball-version)"
           echo "::set-env name=MAKEFLAGS::-j$(nproc) -Otarget"
+      - name: Make
+        run: |
+          make
       - name: Make package
         run: |
           make dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /src
 
 RUN mkdir /pkgdir
 
-RUN git clean -dxf ||:
+RUN git clean -dxf -e .fonts -e .sources ||:
 RUN git fetch --unshallow ||:
 RUN git fetch --tags ||:
 

--- a/Makefile-fonts
+++ b/Makefile-fonts
@@ -101,6 +101,7 @@ TESTFONTFILES += SBL_Hbrw.ttf
 
 .fonts/Cormorant%: .sources/Cormorant_Install_v3.601.zip | .fonts
 	bsdtar -x -f $< -C $(dir $@) --strip-components 2 "Cormorant_Install_v3.601/1. TrueType Font Files/$(notdir $@)"
+	touch $@
 
 .fonts/CrimsonPro%: .sources/CrimsonPro.zip | .fonts
 	bsdtar -x -f $< -C $(dir $@) --strip-components 1 static/$(notdir $@)

--- a/Makefile-luarocks
+++ b/Makefile-luarocks
@@ -16,5 +16,5 @@ lua_modules: $(LUAMODSPEC) $(shell $(rocksmatch) || echo force)
 $(LUAMODLOCK): lua_modules $(LUAMODSPEC)
 	$(genrockslock) > $@
 
-sile: installrocks
+sile: $(LUAMODLOCK)
 endif

--- a/Makefile-luarocks
+++ b/Makefile-luarocks
@@ -1,10 +1,9 @@
 .PHONY: installrocks
 if !SYSTEM_LUAROCKS
-_INSTALLROCKS = installrocks
-LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
-
-LUAMODLOCK := sile-dev-1.rockslock
 LUAMODSPEC := sile-dev-1.rockspec
+LUAMODLOCK := sile-dev-1.rockslock
+
+LUAROCKS := luarocks --tree lua_modules --lua-version $(LUA_VERSION)
 genrockslock := $(LUAROCKS) $(LUAROCKSARGS) list --porcelain | awk '{print $$1 " " $$2}'
 rocksmatch := cmp -s $(LUAMODLOCK) <($(genrockslock))
 
@@ -15,6 +14,6 @@ lua_modules: $(LUAMODSPEC) $(shell $(rocksmatch) || echo force)
 
 $(LUAMODLOCK): lua_modules $(LUAMODSPEC)
 	$(genrockslock) > $@
-
-sile: $(LUAMODLOCK)
+else
+LUAMODLOCK :=
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,13 @@ EXTRA_DIST += .version Makefile-distfiles
 EXTRA_DIST += build-aux/decore-automake.sh build-aux/git-version-gen build-aux/list-dist-files.sh
 EXTRA_DIST += $(MANUAL) $(EXAMPLES)
 
+if MANUAL
+pdf_DATA = $(MANUAL)
+endif
+if EXAMPLES
+nobase_pdf_DATA = $(EXAMPLES)
+endif
+
 SHELL = bash
 .ONESHELL:
 .SECONDARY:
@@ -46,24 +53,7 @@ dist-hook: $(MANUAL) $(EXAMPLES)
 	build-aux/decore-automake.sh
 	sed -i -e '/^LUAMODULES/d;/^\tlua_modules/d' Makefile.in
 
-_DATA_HOOK_DEPS =
-if MANUAL
-_DATA_HOOK_DEPS += $(MANUAL)
-endif
-
-if EXAMPLES
-_DATA_HOOK_DEPS += $(EXAMPLES)
-endif
-
-install-data-hook: Makefile-distfiles $(_DATA_HOOK_DEPS)
-	:
-if MANUAL
-	rm -f "$(DESTDIR)/$(datarootdir)/$<"
-	install -Dm644 -t "$(DESTDIR)$(docdir)" $(MANUAL)
-endif
-if EXAMPLES
-	install -Dm644 -t "$(DESTDIR)$(docdir)/examples" $(EXAMPLES)
-endif
+install-data-hook: Makefile-distfiles
 
 # Whether to force tests to run from scratch
 CLEAN ?=

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ dist_doc_DATA = README.md CHANGELOG.md
 bin_SCRIPTS = sile
 EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec fontconfig.conf
 EXTRA_DIST += .version Makefile-distfiles
-EXTRA_DIST += build-aux/git-version-gen build-aux/list-dist-files.sh
+EXTRA_DIST += build-aux/decore-automake.sh build-aux/git-version-gen build-aux/list-dist-files.sh
 EXTRA_DIST += $(MANUAL) $(EXAMPLES)
 
 SHELL = bash

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,44 +1,60 @@
 ACLOCAL_AMFLAGS = -I m4
 AUTOMAKE_OPTIONS = foreign
 
-if SYSTEM_LIBTEXPDF
-SUBDIRS = src
-else
-SUBDIRS = libtexpdf src
-endif
-
-MANUAL = documentation/sile.pdf
-
-Makefile-distfiles: build-aux/list-dist-files.sh $(wildcard .version .tarball-version sile-dev-1.rockslock)
-	$< 2>/dev/null > $@
-
-include Makefile-luarocks
-
-include Makefile-distfiles
-
-nobase_nodist_pkgdata_DATA = $(LUAMODULES)
-dist_man_MANS = sile.1
-dist_doc_DATA = README.md CHANGELOG.md
-bin_SCRIPTS = sile
-EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec fontconfig.conf
-EXTRA_DIST += .version Makefile-distfiles
-EXTRA_DIST += build-aux/decore-automake.sh build-aux/git-version-gen build-aux/list-dist-files.sh
-EXTRA_DIST += $(MANUAL) $(EXAMPLES)
-
-if MANUAL
-pdf_DATA = $(MANUAL)
-endif
-if EXAMPLES
-nobase_pdf_DATA = $(EXAMPLES)
-endif
-
 SHELL = bash
 .ONESHELL:
 .SECONDARY:
 .SECONDEXPANSION:
 .DELETE_ON_ERROR:
 
-BUILT_SOURCES = .version
+if SYSTEM_LIBTEXPDF
+SUBDIRS = src
+else
+SUBDIRS = libtexpdf src
+endif
+
+# Rules for installing LuaRocks locally as pkgdata_DATA
+include Makefile-luarocks
+
+# Actual rules for downloading test fonts are in a separate file
+include Makefile-fonts
+
+# Since we can't use $(wildcard ...) in automake file lists, we generate a file
+# with a script that builds our dynamic file lists instead. This is tricky,
+# because if we just include the file automake will flatten this include. By
+# using $(wildcard ...) to include it (the very function we couldn't use because
+# of the race condition it creates) we actually keep it from being flattened and
+# hence evaluated when we want it to be. Since the file always exists (see
+# BUILT_SOURCES and EXTRA_DIST) this doesn't induce a race.
+include $(wildcard Makefile-distfiles)
+
+MANUAL = documentation/sile.pdf
+EXAMPLES = $(addsuffix .pdf,$(basename $(EXAMPLESSRCS)))
+
+if MANUAL
+_MANUAL = $(MANUAL)
+endif
+
+if EXAMPLES
+_EXAMPLES = $(EXAMPLES)
+endif
+
+nobase_dist_pkgdata_DATA = $(SILEDATA) $(LUALIBRARIES)
+nobase_nodist_pkgdata_DATA = $(LUAMODULES)
+dist_man_MANS = sile.1
+dist_doc_DATA = README.md CHANGELOG.md
+dist_pdf_DATA = $(_MANUAL)
+nobase_dist_pdf_DATA = $(_EXAMPLES)
+bin_SCRIPTS = sile
+EXTRA_DIST = LICENSE spec tests examples documentation sile-dev-1.rockspec fontconfig.conf
+EXTRA_DIST += .version Makefile-distfiles
+EXTRA_DIST += build-aux/decore-automake.sh build-aux/git-version-gen build-aux/list-dist-files.sh
+EXTRA_DIST += $(MANUAL) $(EXAMPLES)
+
+Makefile-distfiles: build-aux/list-dist-files.sh $(wildcard .version .tarball-version) | $(LUAMODLOCK)
+	$< 2>/dev/null > $@
+
+BUILT_SOURCES = .version Makefile-distfiles $(dist_pdf_DATA) $(nobase_dist_pdf_DATA) $(LUAMODLOCK)
 
 .version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
 	mv $@{,-prev} 2>/dev/null || touch $@-prev
@@ -53,7 +69,7 @@ dist-hook: $(MANUAL) $(EXAMPLES)
 	build-aux/decore-automake.sh
 	sed -i -e '/^LUAMODULES/d;/^\tlua_modules/d' Makefile.in
 
-install-data-hook: Makefile-distfiles
+install-exec-hook: all
 
 # Whether to force tests to run from scratch
 CLEAN ?=
@@ -133,7 +149,7 @@ luacheck:
 	luacheck -j$(shell nproc) -q .
 
 .PHONY: busted
-busted: | $(_INSTALLROCKS) all
+busted: sile
 	set -f; IFS=';'
 if SYSTEM_LUAROCKS
 	packagecpath=(./{,core/}?.$(SHARED_LIB_EXT))
@@ -147,8 +163,6 @@ endif
 .PHONY: docs
 docs: $(MANUAL)
 
-EXAMPLES = $(addsuffix .pdf,$(basename $(EXAMPLESSRCS)))
-
 .PHONY: examples
 examples: $(EXAMPLES)
 
@@ -159,7 +173,7 @@ pages = pdfinfo $@ | awk '$$1 == "Pages:" {print $$2}' || echo 0
 silepass = $(LOCALTESTFONTS) ./sile $(SILEFLAGS) $< -o $@ && pg0=$${pg} pg=$$($(pages))
 define runsile =
 	pg0=$$($(pages)) hadtoc=$$($(hastoc))
-	mkdir -p $(DEPDIR)
+	mkdir -p $(DEPDIR)/$$(dirname $@)
 	$(silepass)
 	export -n SILE_COVERAGE
 	if $(hastoc); then
@@ -168,12 +182,11 @@ define runsile =
 	fi
 endef
 
-
 _FORCED = $(and $(SILE_COVERAGE)$(CLEAN),force)
 _TEST_DEPS = $(and $(filter tests/%,$@),$(addprefix .fonts/,$(TESTFONTFILES)))
 _DOCS_DEPS = $(and $(filter docs/%,$@),$(addprefix .fonts/,$(DOCSFONTFILES)))
 _EXAM_DEPS = $(and $(filter examples/%,$@),$(addprefix .fonts/,$(EXAMFONTFILES)))
-patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) sile | $(DEPDIRS) $(_INSTALLROCKS) all
+patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) sile | $(DEPDIRS) $(LUAMODLOCK)
 
 %.pdf: %.sil $$(patterndeps)
 	$(runsile)
@@ -308,7 +321,7 @@ tests/%.actual: tests/%.xml $$(patterndeps)
 DEPFILES = $(addsuffix .d,$(addprefix $(DEPDIR)/,$(basename $(TESTSRCS) $(MANUAL) $(EXAMPLES))))
 DEPDIRS = $(sort $(dir $(DEPFILES)))
 
-$(DEPDIRS):
+$(DEPDIRS): Makefile-distfiles
 	mkdir -p $@
 
 $(DEPFILES): | $(DEPDIRS)
@@ -320,9 +333,6 @@ include $(wildcard $(DEPFILES))
 
 .sources:
 	[[ -h .sources ]] || mkdir -p $@
-
-# Actual rules for downloading test fonts are in a separate file
-include Makefile-fonts
 
 CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ endif
 
 MANUAL = documentation/sile.pdf
 
-Makefile-distfiles: build-aux/list-dist-files.sh $(wildcard .version sile-dev-1.rockslock)
+Makefile-distfiles: build-aux/list-dist-files.sh $(wildcard .version .tarball-version sile-dev-1.rockslock)
 	$< 2>/dev/null > $@
 
 include Makefile-luarocks
@@ -40,8 +40,11 @@ BUILT_SOURCES = .version
 	build-aux/decore-automake.sh
 
 dist-hook: $(MANUAL) $(EXAMPLES)
-	echo $(VERSION) > $(distdir)/.tarball-version
-	cd $(distdir) && build-aux/decore-automake.sh
+	cd $(distdir)
+	sed -i -e '/^LUAMODULES =/s/=.*/=/' Makefile-distfiles
+	echo $(VERSION) > .tarball-version
+	build-aux/decore-automake.sh
+	sed -i -e '/^LUAMODULES/d;/^\tlua_modules/d' Makefile.in
 
 _DATA_HOOK_DEPS =
 if MANUAL

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,7 +54,7 @@ EXTRA_DIST += $(MANUAL) $(EXAMPLES)
 Makefile-distfiles: build-aux/list-dist-files.sh $(wildcard .version .tarball-version) | $(LUAMODLOCK)
 	$< 2>/dev/null > $@
 
-BUILT_SOURCES = .version Makefile-distfiles $(dist_pdf_DATA) $(nobase_dist_pdf_DATA) $(LUAMODLOCK)
+BUILT_SOURCES = .version Makefile-distfiles
 
 .version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
 	mv $@{,-prev} 2>/dev/null || touch $@-prev
@@ -68,8 +68,6 @@ dist-hook: $(MANUAL) $(EXAMPLES)
 	echo $(VERSION) > .tarball-version
 	build-aux/decore-automake.sh
 	sed -i -e '/^LUAMODULES/d;/^\tlua_modules/d' Makefile.in
-
-install-exec-hook: all
 
 # Whether to force tests to run from scratch
 CLEAN ?=
@@ -124,7 +122,7 @@ ACTUALS    = $(addsuffix   .actual,$(basename $(EXPECTEDS)))
 check: selfcheck
 
 .PHONY: selfcheck
-selfcheck: all
+selfcheck: | $(_BUILT_SUBDIRS)
 	output=$$(mktemp --suffix=.pdf)
 	trap 'rm -f $$output' EXIT SIGHUP SIGTERM
 	./sile -o $$output - <<< "<sile>foo</sile>"
@@ -186,7 +184,19 @@ _FORCED = $(and $(SILE_COVERAGE)$(CLEAN),force)
 _TEST_DEPS = $(and $(filter tests/%,$@),$(addprefix .fonts/,$(TESTFONTFILES)))
 _DOCS_DEPS = $(and $(filter documentation/%,$@),$(addprefix .fonts/,$(DOCSFONTFILES)))
 _EXAM_DEPS = $(and $(filter examples/%,$@),$(addprefix .fonts/,$(EXAMFONTFILES)))
-patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) sile | $(DEPDIRS) $(LUAMODLOCK)
+
+# TODO: remove _BUILT_SUBDIRS hack and replace it with something sensible when
+# these subdirs don't do crazy things like copying files outside of their own trees!
+_BUILT_SUBDIRS = .built-subdirs
+_SUBDIR_TELLS = core/justenoughharfbuzz.so libtexpdf/.libs/libtexpdf.so.0.0.0
+$(_BUILT_SUBDIRS): $(_SUBDIR_TELLS)
+	touch $@
+
+$(_SUBDIR_TELLS):
+	$(MAKE) $(AM_MAKEFLAGS) all-recursive
+#	$(error Running `make install`, `make dist`, or other end-game targets before `make all` unspported.)
+
+patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) | $(DEPDIRS) $(LUAMODLOCK) $(_BUILT_SUBDIRS)
 
 %.pdf: %.sil $$(patterndeps)
 	$(runsile)
@@ -278,7 +288,7 @@ time-%.json: benchmark-%/time.json
 	cp $< $@
 
 .PRECIOUS: time.json
-time.json: sile
+time.json: | $(_BUILT_SUBDIRS)
 	$(time_action)
 
 $(call make_worktree_rules,compare)
@@ -334,7 +344,7 @@ include $(wildcard $(DEPFILES))
 .sources:
 	[[ -h .sources ]] || mkdir -p $@
 
-CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles
+CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles $(_BUILT_SUBDIRS)
 
 .PHONY: docker
 docker: Dockerfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -243,11 +243,7 @@ clean-worktrees:
 			done
 	fi
 
-define time_action =
-	export TIMEFORMAT=$$'{ "real": "%R", "user": "%U", "sys": "%S" }'
-	{ time (./sile documentation/sile.sil > /dev/null 2>&1) } 2> time.json
-endef
-
+time_action ?= ./sile documentation/sile.sil
 make_worktree_rules = $(eval $(foreach SHA,$(_HEADSHA) $(_BASESHA),$(call worktree_sha,$(1),$(shell git rev-parse --short=7 $(SHA)))))
 
 define worktree_sha =
@@ -261,7 +257,9 @@ $(1)-$(2):
 	[[ -h lua_modules ]] || ln -s ../lua_modules
 	[[ -h node_modules ]] || ln -s ../node_modules
 	[[ -h .fonts ]] || ln -s ../.fonts
+	[[ -h .sources ]] || ln -s ../.sources
 	./bootstrap.sh
+	cp ../config.status .
 	./configure
 	make
 
@@ -271,9 +269,10 @@ $(1)-$(2)/%: $(1)-$(2)
 	make $$*
 
 .PRECIOUS: $(1)-$(2)/time.json
-$(1)-$(2)/time.json: $(1)-$(2) $(1)-$(2)/sile
+$(1)-$(2)/time.json: $(1)-$(2)
 	cd $$<
-	$$(time_action)
+	export TIMEFORMAT=$$'{ "real": "%R", "user": "%U", "sys": "%S" }'
+	{ time ($$(time_action) > /dev/null 2>&1) } 2> time.json
 
 endef
 
@@ -289,7 +288,8 @@ time-%.json: benchmark-%/time.json
 
 .PRECIOUS: time.json
 time.json: | $(_BUILT_SUBDIRS)
-	$(time_action)
+	export TIMEFORMAT=$$'{ "real": "%R", "user": "%U", "sys": "%S" }'
+	{ time ($(time_action) > /dev/null 2>&1) } 2> time.json
 
 $(call make_worktree_rules,compare)
 
@@ -331,7 +331,7 @@ tests/%.actual: tests/%.xml $$(patterndeps)
 DEPFILES = $(addsuffix .d,$(addprefix $(DEPDIR)/,$(basename $(TESTSRCS) $(MANUAL) $(EXAMPLES))))
 DEPDIRS = $(sort $(dir $(DEPFILES)))
 
-$(DEPDIRS): Makefile-distfiles
+$(DEPDIRS): | Makefile-distfiles
 	mkdir -p $@
 
 $(DEPFILES): | $(DEPDIRS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ tagrelease:
 	npm run release -- $(and $(RELTYPE),--release-as $(RELTYPE))
 
 .PHONY: prerelease
-prerelease: all test busted examples docs update_libtexpdf
+prerelease: test examples docs update_libtexpdf
 
 .PHONY: release-preview
 release-preview:
@@ -91,7 +91,7 @@ release-preview:
 .PHONY: release
 release: tagrelease
 
-dist: examples docs all sile-$(VERSION).pdf sile-$(VERSION).md
+dist: sile-$(VERSION).pdf sile-$(VERSION).md
 
 sile-$(VERSION).pdf: $(MANUAL)
 	cp $< $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -184,7 +184,7 @@ endef
 
 _FORCED = $(and $(SILE_COVERAGE)$(CLEAN),force)
 _TEST_DEPS = $(and $(filter tests/%,$@),$(addprefix .fonts/,$(TESTFONTFILES)))
-_DOCS_DEPS = $(and $(filter docs/%,$@),$(addprefix .fonts/,$(DOCSFONTFILES)))
+_DOCS_DEPS = $(and $(filter documentation/%,$@),$(addprefix .fonts/,$(DOCSFONTFILES)))
 _EXAM_DEPS = $(and $(filter examples/%,$@),$(addprefix .fonts/,$(EXAMFONTFILES)))
 patterndeps = $(_FORCED) $(_TEST_DEPS) $(_EXAM_DEPS) $(_DOCS_DEPS) sile | $(DEPDIRS) $(LUAMODLOCK)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -35,8 +35,6 @@ else
     ./build-aux/git-version-gen .tarball-version > .version
 fi
 
-touch -t 197001010200 Makefile-distfiles
-
 autoreconf --install -W none
 
 # See discussion in https://github.com/sile-typesetter/sile/issues/82 and

--- a/build-aux/decore-automake.sh
+++ b/build-aux/decore-automake.sh
@@ -13,3 +13,9 @@ for f in configure aclocal.m4; do
         touch -r $TS $f
     fi
 done
+
+# Makefile.in being newer than aclocal.m4 at this point *is* important, this
+# point being both dist-hook and at configure time. The former is covered by a
+# side effect of a `sed` intervention, but to cover configure time changes we
+# need it here too.
+touch Makefile.in

--- a/build-aux/list-dist-files.sh
+++ b/build-aux/list-dist-files.sh
@@ -8,9 +8,10 @@ finder () {
     find $@ -type f | sort -bdi | xargs echo -n ||:
 }
 
-echo -n "nobase_dist_pkgdata_DATA = \$(LUALIBRARIES)"
+echo -n "SILEDATA ="
 finder core classes languages packages -name '*.lua'
 finder classes -name '*.sil'
+
 echo -ne "\nLUALIBRARIES ="
 finder lua-libraries -name '*.lua'
 


### PR DESCRIPTION
Closes #968.

...Is the *actual* fix for #961.

...Has been underlying various issues we've had for a long time, but was made a lot more obvious by the refactor done in #965 for #964 because the data that needed to be cleared was previously mixed in with another list of files that was otherwise valid.

...Started turning up in more scenarios because of the work in #953 to fix #951. This was the right thing to do, but our previous hackery before was keeping the problem from showing up by (accidentally) make reruns where the second pass was fixing what the first one broke. Cleaning that up just make the underlying problem surface in more places.