### PR TITLE
fix(packages): Combine unichar output with existing unshaped node

### DIFF
--- a/packages/unichar.lua
+++ b/packages/unichar.lua
@@ -1,7 +1,13 @@
 SILE.registerCommand("unichar", function(_, content)
   local cp = content[1]
   if type(cp) ~= "string" then SU.error("Bad argument to \\unicode") end
-  SILE.typesetter:typeset(SU.utf8charfromcodepoint(cp))
+  local hlist = SILE.typesetter.state.nodes
+  local char = SU.utf8charfromcodepoint(cp)
+  if #hlist > 1 and hlist[#hlist].is_unshaped then
+    hlist[#hlist].text = hlist[#hlist].text .. char
+  else
+    SILE.typesetter:typeset(char)
+  end
 end)
 
 return { documentation = [[\begin{document}

--- a/tests/bug-979.expected
+++ b/tests/bug-979.expected
@@ -1,0 +1,10 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	14.8819
+My 	28.1492
+Set font 	Symbola;10;400;;normal;;LTR
+T	164	(â)
+My 	40.1492
+T	164	(â)
+End page
+Finish

--- a/tests/bug-979.sil
+++ b/tests/bug-979.sil
@@ -1,0 +1,10 @@
+\begin[papersize=a6]{document}
+\nofolios
+\noindent
+\script[src=packages/unichar]
+\font[family=Symbola]
+\raggedright{
+â\break
+a\unichar{0x302}
+}
+\end{document}


### PR DESCRIPTION
Fixes #979.