### PR TITLE
Overhaul dependency tracking

### DIFF
--- a/build-aux/list-dist-files.sh
+++ b/build-aux/list-dist-files.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 finder () {
     echo -n ' '
-    find $@ -type f | sort -bdi | xargs echo -n ||:
+    find "$@" -type f | sort -bdi | xargs echo -n ||:
 }
 
 echo -n "SILEDATA ="

--- a/core/makedeps.lua
+++ b/core/makedeps.lua
@@ -1,34 +1,48 @@
 local makeDeps = {
   _deps = {},
-  add = function (self, file)
-    if not file and file ~= "nil" then return end
-    self._deps[file] = true
+
+  add = function (self, filename)
+    SU.debug("makedeps", "Adding:", filename)
+    local resolvedFile, msg = package.searchpath(filename:gsub("^%./", ""), "?;"..package.path, "/")
+    if not resolvedFile then
+      SU.error("Cannot resolve file '" .. filename .. "' as a dependency:" .. msg)
+    end
+    self._deps[resolvedFile] = true
   end,
+
+  add_modules = function (self)
+    for dep, _ in pairs(package.loaded) do
+      if dep ~= "_G" then
+        SU.debug("makedeps", "Adding if module is loadable file:", dep)
+        local resolvedFile = package.searchpath(dep:gsub("%.", "/"), package.path, "/")
+        if resolvedFile then
+          self._deps[resolvedFile] = true
+        end
+      end
+    end
+  end,
+
   write = function (self)
+    self:add_modules()
     if type(self.filename) ~= "string" then
       self.filename = SILE.masterFilename .. ".d"
     end
-    for dep, _ in pairs(package.loaded) do
-      if dep ~= "_G" then
-        self:add(dep:gsub("%.", "/"))
-      end
-    end
-    local deps = {}
-    for dep, _ in pairs(self._deps) do
-      local resolvedFile = package.searchpath(dep, package.path, "/")
-      if resolvedFile then
-        SU.debug("makedeps", "Resolved required file path", resolvedFile)
-        deps[#deps+1] = resolvedFile
-      -- else
-        -- SU.warn("Could not resolve dependency path for required file "..dep)
-      end
-    end
-    table.sort(deps, function (a, b) return a < b end)
     local depfile, err = io.open(self.filename, "w")
     if not depfile then return SU.error(err) end
-    depfile:write(SILE.outputFilename..": "..table.concat(deps, " ").."\n")
+    depfile:write(SILE.outputFilename .. ": " .. self._deps .. "\n")
     depfile:close()
   end
 }
+
+setmetatable(makeDeps._deps, {
+    __tostring = function(self)
+      local deps = {}
+      for dep, _ in pairs(self) do
+        deps[#deps+1] = dep
+      end
+      table.sort(deps, function (a, b) return a < b end)
+      return table.concat(deps, " ")
+    end
+  })
 
 return makeDeps

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -222,6 +222,9 @@ function SILE.readFile(filename)
     if mode ~= "file" and mode ~= "named pipe" then
       SU.error(filename.." isn't a file or named pipe, it's a ".. mode .."!")
     end
+    if SILE.makeDeps then
+      SILE.makeDeps:add(filename)
+    end
     local file, err = io.open(filename)
     if not file then
       print("Could not open "..filename..": "..err)


### PR DESCRIPTION
When the manual split into sections per chapter I noticed `make docs` wasn't rebuilding the manual when only a chapter changed and not the main source document. It turns out we were collecting all sorts of dependencies from font files to Lua modules, but `\include` was falling through the cracks.

On review we were not throwing any errors when asked to add dependencies that couldn't actually be found, we just weren't adding them. That means when the path resolver was failing (as was the case for `*.sil` includes) they just weren't getting marked.

I dealt with the case where we can ignore the failures (Lua modules provided by the VM) separately and refactored the path handling code so it covers our own bases more effectively.