### PR TITLE
Use cluacov instead of just luacov for coverage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile.in
 /config.status
 /.version
 /.version-prev
+/.built-subdirs
 
 m4/libtool.m4
 m4/ltoptions.m4
@@ -52,6 +53,7 @@ gh-pages
 sile-[0-9\.]*
 *.rockslock
 .dockerignore
+luacov.*.out
 
 # Test artifacts
 tests/*.actual

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
  - fold_unless_fail "Setup HarfBuzz" "harfbuzz" setup_harfbuzz.sh $HARFBUZZ
 install:
  - luarocks install busted
- - $COVERAGE && luarocks install luacov || true
+ - $COVERAGE && luarocks install cluacov || true
  - $COVERAGE && luarocks install luacov-coveralls || true
 before_script:
  - eval $(luarocks --tree lua_modules --local path)


### PR DESCRIPTION
In my local testing this is 4× to 5× faster generating coverage stats over our busted and regression tests. That should help out Travis just a bit.