### PR TITLE
ci(travis): Revert double fix that broke regular Lua

### DIFF
--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -10,12 +10,12 @@ if [[ $1 == 2* ]]; then
     LUAJIT=true
     BASE="LuaJIT-$1"
     URL=https://github.com/LuaJIT/LuaJIT/archive/v$1.tar.gz
-    BIN=luajit-$1
+    BINNAME=luajit
 else
     LUAJIT=false
     BASE="lua-$1"
     URL=https://www.lua.org/ftp/$BASE.tar.gz
-    BIN=lua-$1
+    BINNAME=lua
 fi
 
 mkdir -p "$HOME/.lua"
@@ -42,10 +42,10 @@ else
   make install INSTALL_TOP="$LUA_HOME_DIR"
 fi
 
-ln -sf $LUA_HOME_DIR/bin/$BIN $HOME/.lua/$BIN
+ln -sf $LUA_HOME_DIR/bin/$BINNAME $HOME/.lua/$BINNAME
 
 popd
-$BIN -v
+$BINNAME -v
 
 LUAROCKS_BASE=luarocks-$2
 


### PR DESCRIPTION
Fixing the same problem two ways makes it broken again. We can't both
use full version paths *and* tell the build system to only install
non version suffixed binaries. That worked for LuaJIT because the
Makefile tries to do both anyway, but for regular Lua we need one
solution or the other.