### PR TITLE
Allow scaling SVG's by width, shorten registered command name

### DIFF
--- a/packages/svg.lua
+++ b/packages/svg.lua
@@ -52,23 +52,26 @@ SILE.registerCommand("svg-glyph", function(_, content)
 end)
 
 return {
-  documentation = [[\begin{document}
-This experimental package provides two commands.
 
-The first is \code{\\include-svg-file[src=...,height=...,[density=...]{}]}.
+  documentation = [[\begin{document}
+This package provides two commands.
+
+The first is \code{\\include-svg-file[src=...,[width=...,][height=...,][density=...]]}.
 This loads and parses an SVG file and attempts to render it in the current
-document with the given height and density (which defaults to 72 ppi). For
-example, the command \code{\\include-svg-file[src=examples/packages/smiley.svg,\goodbreak{}height=12pt]}
+document. Optional width or height options will scale the SVG canvas to the
+given size calculated at a given density option (which defaults to 72 ppi). For
+example, the command
+\code{\\include-svg-file[src=examples/packages/smiley.svg,\goodbreak{}height=12pt]}
 produces the following:
 
 \include-svg-file[src=examples/packages/smiley.svg,height=12pt]
 
-The second is \code{\\svg-glyph}. When the current font is set to an SVG font,
-SILE does not currently render the SVG glyphs automatically. This command is
-intended to be used as a means of eventually implementing SVG fonts; it retrieves
-the SVG glyph provided and renders it.
+The second is a more experimental \code{\\svg-glyph}. When the current font is
+set to an SVG font, SILE does not currently render the SVG glyphs
+automatically. This command is intended to be used as a means of eventually
+implementing SVG fonts; it retrieves the SVG glyph provided and renders it.
 
-The rendering is done with our own SVG drawing library; it is currently
+In both cases the rendering is done with our own SVG drawing library; it is currently
 very minimal, only handling lines, curves, strokes and fills. For a fuller
 implementation, consider using a \code{converters} registration to render
 your SVG file to PDF and include it on the fly.

--- a/packages/svg.lua
+++ b/packages/svg.lua
@@ -27,7 +27,7 @@ local _drawSVG = function (svgdata, width, height, density, drop)
     })
 end
 
-SILE.registerCommand("include-svg-file", function (options, _)
+SILE.registerCommand("svg", function (options, _)
   local fn = SU.required(options, "src", "filename")
   local width = options.width and SU.cast("measurement", options.width):absolute() or nil
   local height = options.height and SU.cast("measurement", options.height):absolute() or nil
@@ -35,6 +35,11 @@ SILE.registerCommand("include-svg-file", function (options, _)
   local svgfile = io.open(fn)
   local svgdata = svgfile:read("*all")
   _drawSVG(svgdata, width, height, density)
+end)
+
+SILE.registerCommand("include-svg-file", function (options, _)
+  SU.deprecated("include-svg-file", "svg", "0.10.10", "0.11.0")
+  SILE.call("svg", options)
 end)
 
 SILE.registerCommand("svg-glyph", function(_, content)
@@ -56,15 +61,15 @@ return {
   documentation = [[\begin{document}
 This package provides two commands.
 
-The first is \code{\\include-svg-file[src=...,[width=...,][height=...,][density=...]]}.
+The first is \code{\\svg[src=...,[width=...,]{}[height=...,]{}[density=...]{}]}.
 This loads and parses an SVG file and attempts to render it in the current
 document. Optional width or height options will scale the SVG canvas to the
 given size calculated at a given density option (which defaults to 72 ppi). For
 example, the command
-\code{\\include-svg-file[src=examples/packages/smiley.svg,\goodbreak{}height=12pt]}
+\code{\\svg[src=examples/packages/smiley.svg,\goodbreak{}height=12pt]}
 produces the following:
 
-\include-svg-file[src=examples/packages/smiley.svg,height=12pt]
+\svg[src=examples/packages/smiley.svg,height=12pt]
 
 The second is a more experimental \code{\\svg-glyph}. When the current font is
 set to an SVG font, SILE does not currently render the SVG glyphs


### PR DESCRIPTION
1. The previous incantation for including SVG files only allowed sizing them by height. This now allows calculating the scale factor by width as well. Somebody we should support both but that requires SVG manipulation I couldn't figure out yet. Also there are rotate and skew options we could handle as well someday, but this PR only adds the width feature.

2. I renamed `\include-svg-file` to just `\svg`. See commit message on 4837b06 for rational.