### PR TITLE
Document better stair logo and \kern command

### DIFF
--- a/documentation/c03-input.sil
+++ b/documentation/c03-input.sil
@@ -150,8 +150,8 @@ like: ‘\examplefont{affluent fishing}.’ If you specifically want to break up
 the ligatures, then insert empty groups (using the grouping characters
 \code{\{} and \code{\}}) in the middle of the possible ligatures: \code{af\{\}f\{\}luent
 f\{\}ishing}: \examplefont{af{}f{}luent f{}ishing}. See the section on
-\em{OpenType Features} for more information on how to control the display of
-ligatures and other font features.
+the \code{features} package for more information on how to control the display
+of ligatures and other font features.
 
 \section{Commands}
 

--- a/documentation/c06-macroscommands.sil
+++ b/documentation/c06-macroscommands.sil
@@ -14,32 +14,37 @@ that you need to keep entering again and again.
 
 \section{A simple macro}
 
-\define[command=SILE]{S\lower[height=0.5ex]{I}L\glue[width=-.2em]\raise[height=0.6ex]{\font[size=0.8em]{E}}}
+\define[command=SILE]{\font[family=Gentium Plus]{% Book Basic has no +smcp, but readers don't need to know, since we're only using Book Basic as a holdover from old SILE which did.
+S\lower[height=0.5ex]{I}L\kern[width=-.2em]\raise[height=0.6ex]{\font[features=+smcp]{e}}}}
 For instance, let’s suppose that we want to design a nice little
-“bumpy road” logo for SILE. (Afficionados of T\glue[width=-.1667em]\lower[height=0.5ex]{E}\glue[width=-.125em]X and friends will be familar with the concept of
+“bumpy road” logo for SILE. (Afficionados of T\kern[width=-.1667em]\lower[height=0.5ex]{E}\kern[width=-.125em]X and friends will be familar with the concept of
 bumpy road logos.) Our logo will look like this: \SILE. It’s not a great
 logo, but we’ll use it as \SILE’s logo for the purposes of this section.
 
 To typeset
 this logo, we need to ask \SILE to: typeset an ‘S’; typeset an ‘I’ lowered by
 a certain amount (half an ex, as it happens); typeset an ‘L’; walk backwards
-along the line a tiny bit; typeset a smaller-sized ‘E’ raised by a certain amount.
+along the line a tiny bit; typeset a smaller-sized ‘E’ raised by a certain
+amount, using the \code{features} package to choose a small capital ‘E’.
 
 In \SILE code, that looks like:
 
 \begin{verbatim}
 \line
-S\\lower[height=0.5ex]\{I\}L\\glue[width=-.2em]\\raise[height=0.6ex]\{\\font[size=0.8em]\{E\}\}
+S\%
+\\lower[height=0.5ex]\{I\}\%
+L\%
+\\kern[width=-.2em]\\raise[height=0.6ex]\{\\font[features=+smcp]\{e\}\}\%
 \line
 \end{verbatim}
 
-(Don‘t worry about the \code{\\glue} command for the moment; we’ll come back
-to that later.)
+(Don‘t worry about the \code{\\kern} command for the moment; we’ll come back
+to that later. The \code{\%}'s prevent newlines from becoming spaces.)
 
 We’ve used our logo four times already in this chapter, and we don‘t want to
 have to input that whole monstrosity each time we do so. What we would like
 to do is tell the computer “this is \SILE’s logo; each time I enter \code{\\SILE},
-I want you to interpret that as \code{S\\lower[height=0.5ex]\{I\}L\\glue[\goodbreak{}width=-.2em]\\raise[height=0.6ex]\{\\font[size=0.8em]\{E\}\}}”.
+I want you to interpret that as \code{S\\lower[height=0.5ex]\{I\}L\\kern[\goodbreak{}width=-.2em]\\raise[height=0.6ex]\{\\font[features=+smcp]\{e\}\}}”.
 
 In other words, we want to define our own commands.
 
@@ -54,8 +59,11 @@ very file, we entered:
 
 \begin{verbatim}
 \line
-\\define[command=SILE]\{
-S\\lower[height=0.5ex]\{I\}L\\glue[width=-.2em]\\raise[height=0.6ex]\{\\font[size=0.8em]\{E\}\}
+\\define[command=SILE]\{\%
+S\%
+\\lower[height=0.5ex]\{I\}\%
+L\%
+\\kern[width=-.2em]\\raise[height=0.6ex]\{\\font[features=+smcp]\{e\}\}\%
 \}
 \line
 \end{verbatim}

--- a/documentation/c06-macroscommands.sil
+++ b/documentation/c06-macroscommands.sil
@@ -38,8 +38,8 @@ L\%
 \line
 \end{verbatim}
 
-(Don‘t worry about the \code{\\kern} command for the moment; we’ll come back
-to that later. The \code{\%}'s prevent newlines from becoming spaces.)
+(Don’t worry about the \code{\\kern} command for the moment; we’ll come back
+to that later. The \code{\%}’s prevent newlines from becoming spaces.)
 
 We’ve used our logo four times already in this chapter, and we don‘t want to
 have to input that whole monstrosity each time we do so. What we would like

--- a/documentation/c09-concepts.sil
+++ b/documentation/c09-concepts.sil
@@ -1,4 +1,5 @@
-\begin{document}
+\begin[class=book]{document}
+\include[src=documentation/macros.sil]
 \chapter{The Nitty Gritty}
 
 \noindent{}We are finally at the bottom of our delve into SILE’s commands
@@ -121,6 +122,62 @@ end\});
 Adding horizontal and vertical penalties to the typesetter’s queues is similarly
 done with the \code{SILE.typesetter:pushPenalty(\{penalty = x\})} and
 \code{SILE.typesetter:pushVpenalty(\{penalty = y\})} methods.
+
+\subsection{Kerns}
+
+\define[command=SILEkern]{\font[family=Gentium Plus]{% Book Basic has no +smcp, but readers don't need to know, since we're only using Book Basic as a holdover from old SILE which did.
+S\lower[height=0.5ex]{I}L\kern[width=-.2em]\raise[height=0.6ex]{\font[features=+smcp]{e}}}}
+\define[command=SILEglue]{\font[family=Gentium Plus]{%
+S\lower[height=0.5ex]{I}L\glue[width=-.2em]\raise[height=0.6ex]{\font[features=+smcp]{e}}}}
+\code{\\kern}’s are a type of \code{\\glue}. The difference between the two is
+that, while a \code{\\glue} can be broken at the end of a line, a \code{\\kern}
+can’t be. Hearkening back to our \SILEkern example from the \em{Macros and
+Commands} chapter, consider that example, repeated enough times to cause a
+linebreak, but with \code{\\glue}’s everywhere \code{\\kern}’s are used
+instead:
+
+\line
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\SILEglue\SILEglue\color[color=#dd0000]{\SILEglue}\SILEglue\SILEglue%
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue\SILEglue%
+\line
+
+The 27\sup{th} of the 60 \SILEglue’s, in \color[color=#dd0000]{red}, is broken
+between its ‘L’ and ‘\raise[height=0.6ex]{\font[family=Gentium Plus,features=+smcp]{e}}’.
+Meanwhile, if we typeset the same line, except using \code{\\kern}’s as we had
+originally instead…
+
+\line
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\SILEkern\SILEkern\color[color=#dd0000]{\SILEkern}\SILEkern\SILEkern%
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern\SILEkern%
+\line
+
+The line just continues on right off the page. Why this is a useful feature is
+more obvious if there are spaces between them:
+
+\line
+Glues:
+
+\SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \color[color=#dd0000]{\SILEglue} \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue \SILEglue
+\line
+
+\line
+Kerns:
+
+\SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \color[color=#dd0000]{\SILEkern} \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern \SILEkern
+\line
+
 
 \section{Frames}
 

--- a/documentation/macros.sil
+++ b/documentation/macros.sil
@@ -36,6 +36,7 @@
 \define[command=changed]{
 \note{\bf{The material in this section has changed significantly since the previous release of SILE.}}
 }
+\define[command=sup]{\raise[height=0.3em]{\font[size=0.8em]{\process}}}
 \script{
 -- Well, this is a hack
 local simpletable = SILE.require("packages/simpletable")

--- a/documentation/macros.sil
+++ b/documentation/macros.sil
@@ -36,7 +36,7 @@
 \define[command=changed]{
 \note{\bf{The material in this section has changed significantly since the previous release of SILE.}}
 }
-\define[command=sup]{\raise[height=0.3em]{\font[size=0.8em]{\process}}}
+\define[command=sup]{\raise[height=0.6ex]{\font[size=0.8em]{\process}}}
 \script{
 -- Well, this is a hack
 local simpletable = SILE.require("packages/simpletable")


### PR DESCRIPTION
Closes #1016.

# Stair ("bumpy road") logo
![image](https://user-images.githubusercontent.com/838783/89577481-bb2a5480-d7fe-11ea-9cbd-a31c82324610.png)
![image](https://user-images.githubusercontent.com/838783/89577505-c5e4e980-d7fe-11ea-9ab2-f762ed24ae40.png)

# `\kern`
![image](https://user-images.githubusercontent.com/838783/89577623-f75db500-d7fe-11ea-8cec-1fa910b165d3.png)
![image](https://user-images.githubusercontent.com/838783/89577660-02184a00-d7ff-11ea-892d-32e177d7fdbc.png)
