### PR TITLE
Refine placement of PDF‌ bookmarks

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -95,9 +95,9 @@ end, "Text to appear on the top of the right page")
 
 SILE.registerCommand("book:sectioning", function (options, content)
   local level = SU.required(options, "level", "book:sectioning")
-  SILE.call("increment-multilevel-counter", {id = "sectioning", level = level})
+  SILE.call("increment-multilevel-counter", { id = "sectioning", level = level })
   if SU.boolean(options.toc, true) then
-    SILE.call("tocentry", {level = level}, SU.subContent(content))
+    SILE.call("tocentry", { level = level }, SU.subContent(content))
   end
   local lang = SILE.settings.get("document.language")
   if options.numbering == nil or options.numbering == "yes" then
@@ -107,7 +107,7 @@ SILE.registerCommand("book:sectioning", function (options, content)
       end
       SILE.call(options.prenumber)
     end
-    SILE.call("show-multilevel-counter", {id="sectioning"})
+    SILE.call("show-multilevel-counter", { id = "sectioning" })
     if options.postnumber then
       if SILE.Commands[options.postnumber .. ":" .. lang] then
         options.postnumber = options.postnumber .. ":" .. lang
@@ -133,7 +133,7 @@ SILE.registerCommand("chapter", function (options, content)
   SILE.call("open-double-page")
   SILE.call("noindent")
   SILE.scratch.headers.right = nil
-  SILE.call("set-counter", {id = "footnote", value = 1})
+  SILE.call("set-counter", { id = "footnote", value = 1 })
   SILE.call("book:chapterfont", {}, function ()
     SILE.call("book:sectioning", {
       numbering = options.numbering,

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -9,8 +9,11 @@ SILE.registerCommand("pdf:destination", function (options, _)
     outputYourself = function (_, typesetter, line)
       SILE.outputters.libtexpdf._init()
       local state = typesetter.frame.state
-      local y = SILE.documentState.paperSize[2] - state.cursorY + line.height
-      pdf.destination(name, state.cursorX:tonumber(), y:tonumber())
+      typesetter.frame:advancePageDirection(-line.height)
+      local x, y = state.cursorX, state.cursorY
+      typesetter.frame:advancePageDirection(line.height)
+      local _y = SILE.documentState.paperSize[2] - y
+      pdf.destination(name, x:tonumber(), _y:tonumber())
     end
   })
 end)

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -6,10 +6,10 @@ local pdf = require("justenoughlibtexpdf")
 SILE.registerCommand("pdf:destination", function (options, _)
   local name = SU.required(options, "name", "pdf:bookmark")
   SILE.typesetter:pushHbox({
-    outputYourself = function (_, typesetter, _)
+    outputYourself = function (_, typesetter, line)
       SILE.outputters.libtexpdf._init()
       local state = typesetter.frame.state
-      local y = SILE.documentState.paperSize[2] - state.cursorY
+      local y = SILE.documentState.paperSize[2] - state.cursorY + line.height
       pdf.destination(name, state.cursorX:tonumber(), y:tonumber())
     end
   })


### PR DESCRIPTION
Closes #1030

I can think of at least ~~two~~ three problems with this solution:

1. It finds the exact height of the line, but the user might *expect* some white space.
2. ~~It will backfire if the page advance direction is BTT.~~ (fixed)
3. In the case of ... I don't know ... drawing rules or some other manual output routine this might *not* be what you want. The current cursor location on the baseline might be what is actually called for in some cases.

For most cases this is probably better than the default, but long term it probably needs revisiting.