### PR TITLE
docs: Remove superfluous } in c10-classdesign.sil

### DIFF
--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -114,7 +114,6 @@ bringhurst:defineMaster(\{
     folio = \{ ... as before ... \},
     footnotes = \{ ... as before ... \},
     runningHead = \{ ... as before ... \},
-    \},
   \}
 \})
 bringhurst:mirrorMaster("right", "left")


### PR DESCRIPTION
The brace was already closed the line before. Copying this from the PDF into a text editor will result in unbalanced braces.