### PR TITLE
Patch Penlight usage for forward support

### DIFF
--- a/core/tracestack.lua
+++ b/core/tracestack.lua
@@ -66,7 +66,7 @@ traceStack.commandFrame = pl.class({
 traceStack.contentFrame = pl.class({
     _base = traceStack.commandFrame,
     _init = function (self, command, content)
-      self:super(command, content, content.options)
+      self._base._init(self, command, content, content.options)
     end
   })
 


### PR DESCRIPTION
Work continues on #1065 and elsewhere to actually port our code to proper Penlight class usage, but this is an emergency fix that needs to get rolled into a release ASAP. The idiosyncratic way I worked around issues with the bug in old versions of Penlight regarding class inheritance turns out to be even weirder than I imagined. I inadvertently sidestepped the 'parent constructor' issue by making everything a grand-parent with no true parent classes. Hence now that in Penlight 1.9.0 constructor inheritance actually works properly we aren't actually getting anything inherited.

A bigger set of changes that fixes the idiosyncratic usage will be upcoming, but this should allow distros that updated to Penlight 1.9.0 already to keep using SILE.