### PR TITLE
chore(actions): Rename GH action to not match somebody's username

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: SILE
+name: 'SILE-Typesetter'
 description: Simon’s Improved Layout Engine
 runs:
   using: docker


### PR DESCRIPTION
It is not urgent to cut a release for this because the syntax we documented for usage as a GitHub Action actually works now, but we won't show up in the Marketplace with push-button installation options until this is fixed.