### PR TITLE
fix(packages): \verbatim:font can process text

### DIFF
--- a/classes/markdown.lua
+++ b/classes/markdown.lua
@@ -54,10 +54,7 @@ SILE.registerCommand("bulletlist", function (_, content)
 end)
 
 SILE.registerCommand("link", function (_, content)
-  -- SILE.settings.temporarily(function ()
-    -- SILE.call("verbatim:font")
-    SILE.process(content)
-  -- end)
+    SILE.call("verbatim:font", {}, content)
 end)
 
 SILE.registerCommand("image", function (_, content)

--- a/packages/verbatim.lua
+++ b/packages/verbatim.lua
@@ -1,6 +1,7 @@
-SILE.registerCommand("verbatim:font", function(_, _)
-    SILE.settings.set("font.family", "Hack")
-    SILE.settings.set("font.size", SILE.settings.get("font.size") - 3)
+SILE.registerCommand("verbatim:font", function(options, content)
+  options.family = options.family or "Hack"
+  options.size = options.size or SILE.settings.get("font.size") - 3
+  SILE.call("font", options, content)
 end, "The font chosen for the verbatim environment")
 
 SILE.registerCommand("verbatim", function(_, content)


### PR DESCRIPTION
This input:

```sile
\begin{document}
\script[src=packages/url]
Let’s try typesetting a URL: \url{https://sile-typesetter.com}.

And now a little bit of \code{inline code}.

And now a \verbatim{code block} inside normal text.
\end{document}
```

currently creates this output (using current master; zoomed in a bit):

![Bildschirmfoto von 2020-10-02 11-48-51](https://user-images.githubusercontent.com/3957164/94910842-8d335a80-04a5-11eb-99ea-13162f6b6188.png)

With this PR applied, the output looks like this:

![Bildschirmfoto von 2020-10-02 11-53-13](https://user-images.githubusercontent.com/3957164/94911095-e56a5c80-04a5-11eb-913b-f81062b676a8.png)
