### PR TITLE
Don't abuse libtool internals

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,7 @@ endif
 if SYSTEM_LIBTEXPDF
 LIBTEXPDF_LIB=-ltexpdf
 else
-LIBTEXPDF_LIB=../libtexpdf/.libs/libtexpdf.la
+LIBTEXPDF_LIB=../libtexpdf/libtexpdf.la
 endif
 
 pkglib_LTLIBRARIES = justenoughharfbuzz.la justenoughlibtexpdf.la justenoughfontconfig.la fontmetrics.la svg.la


### PR DESCRIPTION
The whole internals of .libs are an implementation detail of libtool. I'm leaving the whole `to_copy` mess for now as it doesn't actually break something for pkgsrc, but the dependency certainly does.