### PR TITLE
Update license holder (and revert overly aggressive Javascript→Lua port)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Simon Cozens
+Copyright (c) 2012-2020 Simon Cozens, Caleb Maclennan.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -448,7 +448,7 @@ SILE.defaultTypesetter = std.object {
         end
       end
     end
-    SU.debug("pagebuilder", "Glues for self page adjusted by", adjustment, "drawn from", gTotal)
+    SU.debug("pagebuilder", "Glues for this page adjusted by", adjustment, "drawn from", gTotal)
   end,
 
   initNextFrame = function (self)


### PR DESCRIPTION
This is *probably* moot either way given my access to the GitHub org, but see the commit message for my reasoning. I'm dealing with a repository transfer situation right now using Github's [Deceased User Policy](https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-deceased-user-policy). Even though the repository owner was quite accepting of contributions and a number of people were involved during his lifetime, the lack on anything explicit naming other parties as being authorized to act on behalf of the project has made the whole process difficult.

@simoncozens if this sounds sane to you I think I'll leave you to merge this one so your name is on the merge commit.