### PR TITLE
fix(classes): Define \strong weight=700, not 600

### DIFF
--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -124,7 +124,7 @@ plain.registerCommands = function ()
 \define[command=justified]{\set[parameter=document.rskip]\set[parameter=document.spaceskip]{\process\par}}%
 \define[command=rightalign]{\raggedleft{\process\par}}%
 \define[command=em]{\font[style=Italic]{\process}}%
-\define[command=strong]{\font[weight=600]{\process}}%
+\define[command=strong]{\font[weight=700]{\process}}%
 \define[command=nohyphenation]{\font[language=und]{\process}}%
 \define[command=raggedright]{\ragged[right=true]{\process}}%
 \define[command=raggedleft]{\ragged[left=true]{\process}}%


### PR DESCRIPTION
600 weight is traditionally Semibold, Bold is 700. Since relatively few fonts have Semibold instances at all I think most people got what they were expecting to get out of \strong — the Bold as the nearest rounded up weight available. For fonts with actual Semibold faces this is just wrong.

----

See https://github.com/alerque/libertinus/pull/398

Embarrassingly I have nobody to blame but myself for this. It bisects to my commit 043572ad.