### PR TITLE
Turn off complex flag for items in \latin-in-tate

### DIFF
--- a/packages/tate.lua
+++ b/packages/tate.lua
@@ -91,6 +91,12 @@ SILE.registerCommand("latin-in-tate", function (_, content)
         SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes+1] = nodes[i]
       end)
       local n = SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes]
+      -- Turn off all complex flags.
+      for j = 1,#(n.value) do
+        for k = 1,#(n.value[j].nodes) do
+          n.value[j].nodes[k].value.complex = false
+        end
+      end
       n.oldOutputYourself = n.outputYourself
       n.outputYourself = outputLatinInTate
     end

--- a/tests/bug-1101.expected
+++ b/tests/bug-1101.expected
@@ -1,0 +1,20 @@
+Set paper size 	595.275597	841.8897729
+Begin page
+Mx 	539.9079
+My 	97.7650
+Set font 	Noto Sans CJK JP;10;400;;normal;;LTR
+T	52 42 45 38 w=20.2100	(SILE)
+Mx 	542.4079
+My 	122.9750
+Set font 	Noto Sans CJK JP;10;400;;normal;;TTB
+T	65196 w=10.0000	(と)
+Mx 	539.9079
+My 	133.0809
+Set font 	Noto Sans CJK JP;10;400;;normal;;LTR
+T	45 66 85 74 79 w=23.5500	(Latin)
+Mx 	542.4079
+My 	161.6309
+Set font 	Noto Sans CJK JP;10;400;;normal;;TTB
+T	58981 w=10.0000	(。)
+End page
+Finish

--- a/tests/bug-1101.sil
+++ b/tests/bug-1101.sil
@@ -1,0 +1,7 @@
+\begin[class=jplain,layout=tate,papersize=a4]{document}
+\script[src=packages/tate]
+\neverindent\nofolios
+\font[family=Noto Sans CJK JP,language=ja]
+
+\latin-in-tate{SILE}と\latin-in-tate{Latin}。
+\end{document}


### PR DESCRIPTION
Fixes #1101. Arguably breaks vertical Arabic in Japanese, but to be fair it was broken already.