### PR TITLE
Update Homebrew install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Just run `brew install sile` for the latest stable release or `brew install sile
 Note the Homebrew package does not automatically install the [default font](#default-font).
 The easiest way to install Gentium Plus is through the [Homebrew Fonts caskroom][brewfonts]:
 
-    $ brew tap caskroom/fonts
-    $ brew cask install font-gentium-plus
+    $ brew tap homebrew/cask-fonts
+    $ brew install --cask font-gentium-plus
 
 ### For Linux
 


### PR DESCRIPTION
2 changes have been made to Homebrew since this was originally written:

1. The location of caskroom/fonts has changed: 
    ```
    Error: caskroom/fonts was moved. Tap homebrew/cask-fonts instead.
    ```
2. Home-brew casks are installed using the flag `--cask` now
    ```
    Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
    ```