### PR TITLE
Redo CLI arg parsing without stdlib

### DIFF
--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -12,15 +12,6 @@ SILE.inputs.common = {
     -- Prepend the dirname of the input file to the Lua search path
     local dirname = SILE.masterFilename:match("(.-)[^%/]+$")
     package.path = dirname.."?;"..dirname.."?.lua;"..package.path
-    if not SILE.outputFilename and SILE.masterFilename then
-      -- TODO: This hack works on *nix systems because /dev/stdout is usable as
-      -- a filename to refer to STDOUT. Libtexpdf works fine with this, but it's
-      -- not going to work on Windows quite the same way. Normal filnames will
-      -- still work but explicitly using piped streams won't.
-      if SILE.masterFilename == "-" then
-        SILE.outputFilename = "/dev/stdout"
-      end
-    end
     local ff = SILE.documentState.documentClass:init()
     SILE.typesetter:init(ff)
   end

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -96,7 +96,7 @@ end
 SILE.require = function (dependency, pathprefix)
   dependency = dependency:gsub(".lua$", "")
   if pathprefix then
-    local status, lib = pcall(require, std.io.catfile(pathprefix, dependency))
+    local status, lib = pcall(require, pl.path.join(pathprefix, dependency))
     if status then return lib end
   end
   local dep = require(dependency)
@@ -271,7 +271,7 @@ end
 function SILE.resolveFile(filename, pathprefix)
   local candidates = {}
   -- Start with the raw file name as given prefixed with a path if requested
-  if pathprefix then candidates[#candidates+1] = std.io.catfile(pathprefix, "?") end
+  if pathprefix then candidates[#candidates+1] = pl.path.join(pathprefix, "?") end
   -- Also check the raw file name without a path
   candidates[#candidates+1] = "?"
   -- Iterate through the directory of the master file, the SILE_PATH variable, and the current directory
@@ -279,8 +279,8 @@ function SILE.resolveFile(filename, pathprefix)
   if SILE.masterFilename then
     for path in SU.gtoke(SILE.masterDir..";"..tostring(os.getenv("SILE_PATH")), ";") do
       if path.string and path.string ~= "nil" then
-        if pathprefix then candidates[#candidates+1] = std.io.catfile(path.string, pathprefix, "?") end
-        candidates[#candidates+1] = std.io.catfile(path.string, "?")
+        if pathprefix then candidates[#candidates+1] = pl.path.join(path.string, pathprefix, "?") end
+        candidates[#candidates+1] = pl.path.join(path.string, "?")
       end
     end
   end

--- a/sile.in
+++ b/sile.in
@@ -44,15 +44,13 @@ if SILE.makeDeps then SILE.makeDeps:add(executable) end
 SILE.init()
 if SILE.masterFilename then
   extendPath(SILE.masterDir)
-  if SILE.preamble then
-    for _, preamble in pairs(SILE.preamble) do
-      io.stderr:write("Loading "..preamble.."\n")
-      local c = SILE.resolveFile(preamble, "classes")
-      if c then
-        SILE.readFile(c)
-      else
-        SILE.require(preamble, "classes")
-      end
+  for _, preamble in pairs(SILE.preamble) do
+    io.stderr:write("Loading "..preamble.."\n")
+    local c = SILE.resolveFile(preamble, "classes")
+    if c then
+      SILE.readFile(c)
+    else
+      SILE.require(preamble, "classes")
     end
   end
   if SU.debugging("profile") and pcall(function () require("ProFi") end) then


### PR DESCRIPTION
- refactor(cli): Swap stdlib opts parser for cliargs
- chore(cli): Work around parsing limitation in cliargs
