### PR TITLE
Overhaul Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/archlinux:base-devel-20210131.0.14634 AS builder
+ARG ARCHTAG
+
+FROM docker.io/library/archlinux:base-devel-$ARCHTAG AS builder
 
 # This is a hack to convince Docker Hub that its cache is behind the times.
 # This happens when the contents of our dependencies changes but the base
@@ -36,7 +38,7 @@ RUN make install DESTDIR=/pkgdir
 # Work around BuiltKit / buildx bug, they can’t copy to symlinks only dirs
 RUN mv /pkgdir/usr/local/{share/,}/man
 
-FROM docker.io/library/archlinux:base-20210131.0.14634 AS final
+FROM docker.io/library/archlinux:base-$ARCHTAG AS final
 
 # Same args as above, repeated because they went out of scope with FROM
 ARG VCS_REF=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN make
 RUN make check
 RUN make install DESTDIR=/pkgdir
 
+# Work around BuiltKit / buildx bug, they can’t copy to symlinks only dirs
+RUN mv /pkgdir/usr/local/{share/,}/man
+
 FROM docker.io/library/archlinux:base-20210131.0.14634 AS final
 
 # Same args as above, repeated because they went out of scope with FROM

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,8 @@ SHELL = bash
 .SECONDEXPANSION:
 .DELETE_ON_ERROR:
 
+_sile = $(program_prefix)$(shell sed -e "$(program_transform_name)" <<< sile)$(program_suffix)
+
 if SYSTEM_LIBTEXPDF
 SUBDIRS = src
 else

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,7 @@ bin_SCRIPTS = sile
 EXTRA_DIST = spec tests examples documentation sile-dev-1.rockspec fontconfig.conf
 EXTRA_DIST += .version Makefile-distfiles
 EXTRA_DIST += build-aux/decore-automake.sh build-aux/git-version-gen build-aux/list-dist-files.sh
+EXTRA_DIST += Dockerfile build-aux/bootstrap-docker.sh build-aux/docker-fontconfig.conf hooks/build
 EXTRA_DIST += $(MANUAL) $(EXAMPLES)
 
 Makefile-distfiles: build-aux/list-dist-files.sh $(wildcard .version .tarball-version) | $(LUAMODLOCK)
@@ -352,11 +353,8 @@ include $(wildcard $(DEPFILES))
 CLEANFILES = $(bin_SCRIPTS) $(dist_man_MANS) $(DEPFILES) $(ACTUALS) $(TESTPDFS) $(MANUAL) Makefile-distfiles $(_BUILT_SUBDIRS)
 
 .PHONY: docker
-docker: Dockerfile
-	docker build \
-		--build-arg VCS_REF="$(VERSION)" \
-		--tag siletypesetter/sile:HEAD \
-		./
+docker: Dockerfile hooks/build .version
+	IMAGE_NAME=siletypesetter/$(_sile):HEAD ./hooks/build $(VERSION)
 
 gource.webm:
 	mkdir -p /tmp/gravatars

--- a/build-aux/bootstrap-docker.sh
+++ b/build-aux/bootstrap-docker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -e
+
+# GitHub Actions runner gives us jack squat
+if [ ! -e ".git" ]; then
+    jq -Mer '.version + "-unknown"' package.json > .tarball-version
+
+# Docker Hub gives us a Git working directory, but with depth=1
+else
+    git fetch --unshallow ||:
+    git fetch --tags ||:
+fi

--- a/hooks/build
+++ b/hooks/build
@@ -6,6 +6,9 @@ DESC=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
 RUNTIME_DEPS='fontconfig freetype2 gentium-plus-font harfbuzz icu lua'
 BUILD_DEPS='git libpng luarocks poppler zlib'
 
+: "${DOCKER_BUILDKIT:=1}"
+export DOCKER_BUILDKIT
+
 docker build \
 	--build-arg VCS_REF="${1:-$DESC}" \
 	--build-arg RUNTIME_DEPS="$RUNTIME_DEPS" \

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -e
+
+DESC=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
+
+RUNTIME_DEPS='fontconfig freetype2 gentium-plus-font harfbuzz icu lua'
+BUILD_DEPS='git libpng luarocks poppler zlib'
+
+docker build \
+	--build-arg VCS_REF="${1:-$DESC}" \
+	--build-arg RUNTIME_DEPS="$RUNTIME_DEPS" \
+	--build-arg BUILD_DEPS="$BUILD_DEPS" \
+	--tag $IMAGE_NAME \
+	./

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -e
 
+: "${ARCHTAG:=20210207.0.15200}"
+
 DESC=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
 
 RUNTIME_DEPS='fontconfig freetype2 gentium-plus-font harfbuzz icu lua'
@@ -10,6 +12,7 @@ BUILD_DEPS='git libpng luarocks poppler zlib'
 export DOCKER_BUILDKIT
 
 docker build \
+	--build-arg ARCHTAG="$ARCHTAG" \
 	--build-arg VCS_REF="${1:-$DESC}" \
 	--build-arg RUNTIME_DEPS="$RUNTIME_DEPS" \
 	--build-arg BUILD_DEPS="$BUILD_DEPS" \


### PR DESCRIPTION
* Update base image and switch to tagged releases
* Move dependency list to place it doesn't have to be repeated
* Use hook to build so Docker Hub and locally built containers match
* Work around new GitHub Actions limitations
* Reuse utility scripts from Fontship & CaSILE
* Normalize intermediate container names for easier cross-project diffs
* Rewrite container tags based on autoconf binary renaming
* Package everything necessary to build Docker container in source dist