### PR TITLE
Add font hooks, auto-load color-fonts

### DIFF
--- a/core/font.lua
+++ b/core/font.lua
@@ -42,6 +42,11 @@ SILE.registerCommand("font", function (options, content)
     SILE.settings.set("font.hyphenchar", SU.utf8charfromcodepoint(options.hyphenchar))
   end
 
+  -- We must *actually* load the font here, because by the time we're inside
+  -- SILE.shaper.shapeToken, it's too late to respond appropriately to things
+  -- that the post-load hook might want to do.
+  SILE.font.cache(SILE.font.loadDefaults({}), SILE.shaper.getFace)
+
   if type(content) == "function" or content[1] then
     SILE.process(content)
     SILE.settings.popState()
@@ -95,9 +100,19 @@ SILE.font = {
     local key = _key(options)
     if not SILE.fontCache[key] then
       SU.debug("fonts", "Looking for "..key)
-      SILE.fontCache[key] = callback(options)
+      local face = callback(options)
+      SILE.font.postLoadHook(face)
+      SILE.fontCache[key] = face
     end
     return SILE.fontCache[key]
+  end,
+
+  postLoadHook = function(face)
+    local ot = SILE.require("core/opentype-parser")
+    local font = ot.parseFont(face)
+    if font.cpal then
+      SILE.require("packages/color-fonts")
+    end
   end,
 
   _key = _key

--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -82,9 +82,6 @@ path to them.}
 \section{chordmode}
 \package-documentation[src=packages/chordmode]
 
-\section{color-fonts}
-\package-documentation[src=packages/color-fonts]
-
 \section{converters}
 \package-documentation[src=packages/converters]
 
@@ -121,6 +118,9 @@ basic functionality to other packages and classes. Classes such as the
 
 \subsection{footnotes}
 \package-documentation[src=packages/footnotes]
+
+\section{color-fonts}
+\package-documentation[src=packages/color-fonts]
 
 \subsection{counters}
 \package-documentation[src=packages/counters]

--- a/packages/color-fonts.lua
+++ b/packages/color-fonts.lua
@@ -89,8 +89,8 @@ return {
   documentation = [[
 \begin{document}
   The \code{color-fonts} package adds support for fonts with a \code{COLR}
-  OpenType table. Just loading the package will allow for fonts which
-  define their own colors to be rendered in color.
+  OpenType table. This package is automatically loaded when such a font is
+  detected.
 \end{document}
 ]]
 }

--- a/tests/bug-1142.expected
+++ b/tests/bug-1142.expected
@@ -1,0 +1,20 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	14.8819
+My 	28.9764
+Set font 	;10;400;;normal;;LTR;tests/TestCLR-Regular.ttf
+T	3 w=10.0000	(a)
+Push color	1.0000	0.8784	0.5412
+Mx 	24.8819
+T	7 a=10.0000	()
+Pop color
+Push color	0.8980	0.6078	0.1451
+T	8 a=10.0000	()
+Pop color
+Push color	0.5176	0.2196	0.0510
+T	9 w=10.0000	(☺)
+Pop color
+Mx 	34.8819
+T	3 w=10.0000	(a)
+End page
+Finish

--- a/tests/bug-1142.sil
+++ b/tests/bug-1142.sil
@@ -1,0 +1,6 @@
+\begin[papersize=a6]{document}
+\noindent
+\nofolios
+\font[filename=tests/TestCLR-Regular.ttf]
+a☺a
+\end{document}


### PR DESCRIPTION
This adds a post-load hook which is called on a font the first time it is loaded. So far the hook parses the OpenType tables, and loads the `color-fonts` package if a COLR table is found. This PR will fix #1142.