### PR TITLE
Bump CI actions and developer deps

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -35,7 +35,6 @@ rules:
     - examples
     - fonts
     - frames
-    - github
     - images
     - inputs
     - installation
@@ -52,19 +51,18 @@ rules:
     - release
     - shaper
     - tooling
-    - travis
     - typesetter
     - utilities
 help: |
   **Possible types**:
   `chore`:        Improves existing functions or features
-                      (Not for new features, bug fixes, or refactoring)
+                      (Not for new features, fixes to bugs in releases, or refactoring)
   `ci`:           Changes CI configuration files and scripts
-                      (relevanat scopes: build, tooling, travis, azure, github)
+                      (relevanat scopes: build, deps, tooling, cirrus, azure, actions)
   `docs`:         Adds or alters documentation.
   `feat`:         Adds a new user facing feature.
   `fix`:          Solves a user facing bug in previously released code
-                      (Not for use if the bug isn't in master yet, clutters changelog)
+                      (Not for use if the bug isn't in a release yet, clutters changelog)
   `perf`:         Improves performance.
   `refactor`:     Rewrites code without feature, performance, or bug changes.
   `revert`:       Changes that reverting other changes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,8 @@ updates:
       - "todo"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "docker/build-push-action"
+        versions: [ "2.x" ]
+      - dependency-name: "actions/cache"
+        versions: [ "2.x" ]

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run ‘commitlint’ linter
-        uses: wagoid/commitlint-github-action@v2
+        uses: wagoid/commitlint-github-action@v3
         with:
           configFile: '.commitlintrc.yml'

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "homepage": "http://sile-typesetter.org",
   "devDependencies": {
-    "@commitlint/cli": "^11.0.0",
-    "@commitlint/config-conventional": "^11.0.0",
-    "@commitlint/prompt": "^11.0.0",
+    "@commitlint/cli": "^12.0.1",
+    "@commitlint/config-conventional": "^12.0.1",
+    "@commitlint/prompt": "^12.0.1",
     "commitizen": "^4.2.3",
     "conventional-changelog-cli": "^2.1.1",
     "github-release-cli": "^2.0.0",
-    "husky": "^4.3.8",
-    "standard-version": "^9.1.0"
+    "husky": "^5.1.3",
+    "standard-version": "^9.1.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
- ci(deps): Block dependabot notifications for rejected updates
- chore(deps): Bump developer-only tooling
- ci(actions): Bump commitlint action
- chore(tooling): Update commitlint scopes and help messages
