### PR TITLE
chore(packages): Handle Pandoc's space hacks

### DIFF
--- a/packages/pandoc.lua
+++ b/packages/pandoc.lua
@@ -189,6 +189,10 @@ SILE.registerCommand("Link", function (options, content)
   end)
 end, "Creates a link inline element, usually a hyperlink.")
 
+SILE.registerCommand("Nbsp", function (_, _)
+  SILE.typesetter:typeset(" ")
+end, "Output a non-breaking space.")
+
 SILE.registerCommand("Math", function (options, content)
   SU.debug("pandoc", options)
   -- TODO options is math type


### PR DESCRIPTION
This is a cheap hack to work around space hacks in non-Unicode document
formats. Long term getting the Pandoc Writer to output good Unicode
would be a better option, but there are some barriers to that happening
easily and working in all the places this hack is expected to work.
