### PR TITLE
refactor(utilities)!: Change breadcrumbs:contains() to return <bool, index>

### DIFF
--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -573,9 +573,9 @@ utilities.breadcrumbs = function ()
 
   function breadcrumbs:contains (needle)
     for i, command in ipairs(self) do
-      if command == needle then return #self - i end
+      if command == needle then return true, #self - i end
     end
-    return -1
+    return false, -1
   end
 
   return breadcrumbs


### PR DESCRIPTION
BREAKING CHANGE: Previous return value for breadcrumbs:contains() was
just an depth index with -1 indicating no match. This made sense when
I wrote it, but coming back to it for a new project I expected a boolean
return value. Returning two values seems like the best option, but given
the function naming it seemed to make sense to return the boolean first,
hence the API breakage.
