### PR TITLE
Add some smaller units

### DIFF
--- a/core/units.lua
+++ b/core/units.lua
@@ -41,6 +41,10 @@ SILE.registerUnit = function (unit, spec)
   units[unit] = spec
 end
 
+units["twip"] = {
+  definition = "0.05pt"
+}
+
 units["mm"] = {
   definition = "2.8346457pt"
 }

--- a/core/units.lua
+++ b/core/units.lua
@@ -57,6 +57,10 @@ units["m"] = {
   definition = "100cm"
 }
 
+units["hm"] = {
+  definition = "0.01mm"
+}
+
 units["in"] = {
   definition = "72pt"
 }


### PR DESCRIPTION
I ran into "twip" as a unit converting some other document formats. It would be easy enough to do the math during format conversion, but I don't see any downside to SILE having out of the box support for standardized units.
