### PR TITLE
grid.lua: Don't add a full gridSpacing where none would suffice

### DIFF
--- a/packages/grid.lua
+++ b/packages/grid.lua
@@ -2,7 +2,7 @@
 local gridSpacing = SILE.measurement()
 
 local function makeUp (totals)
-  local toadd = gridSpacing - SILE.measurement(totals.gridCursor) % gridSpacing
+  local toadd = (gridSpacing - SILE.measurement(totals.gridCursor)) % gridSpacing
   totals.gridCursor = totals.gridCursor + toadd
   SU.debug("typesetter", "Makeup height = " .. toadd)
   return SILE.nodefactory.vglue(toadd)


### PR DESCRIPTION
Previously when calculating the space toadd in makeUp, a cursor positioned exactly at a multiple of the gridSpacing would insert a full gridSpacing vglue, even when a zero vglue would also maintain proper spacing.  In other words, the range of possible values of toadd was (0, gridSpacing].

This change modifies the range of toadd to instead be [0, gridSpacing), which prevents the addition of unnecessary space.