### PR TITLE
Remove deprecated syntax in French language settings

### DIFF
--- a/core/settings.lua
+++ b/core/settings.lua
@@ -13,8 +13,6 @@ SILE.settings = {
   declare = function(spec)
     if spec.name then
       SU.deprecated("'name' argument of SILE.settings.declare", "'parameter' argument of SILE.settings.declare", "0.10.10", "0.11.0")
-      spec.parameter = spec.name
-      spec.name = nil
     end
     SILE.settings.declarations[spec.parameter] = spec
     SILE.settings.set(spec.parameter, spec.default, true)

--- a/languages/fr.lua
+++ b/languages/fr.lua
@@ -1,5 +1,5 @@
 SILE.settings.declare({
-    name = "languages.fr.punctuationspace",
+    parameter = "languages.fr.punctuationspace",
     type = "kern",
     default = SILE.nodefactory.kern("0.2en"),
     help = "The amount of space before a punctuation"
@@ -11,7 +11,7 @@ SILE.settings.declare({
 -- for everything and need our language-specific typesetting
 -- processors.
 SILE.settings.declare({
-    name = "languages.fr.highpunctuation",
+    parameter = "languages.fr.highpunctuation",
     type = "string",
     default = "?:;!",
     help = "A list of punctuation marks which should be preceded by a punctuationspace"


### PR DESCRIPTION
I tested everything *before* tagging v0.11.0, but it started failing tests *after* tagging leaving a release that doesn't pass its own test suite. This is because we were using an interface we deprecated.
