### PR TITLE
Cleanup autotools usage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,9 +81,9 @@ RELTYPE ?=
 
 .PHONY: tagrelease
 tagrelease:
-	test -z $$(git tag --points-at HEAD) || exit 0 # end if we are already on a release tag
-	git diff-index --quiet --cached HEAD || exit 1 # die if anything staged but not committed
-	git diff-files --quiet || exit 1 # die if any tracked files have unstagged changes
+	test -z $$($(GIT) tag --points-at HEAD) || exit 0 # end if we are already on a release tag
+	$(GIT) diff-index --quiet --cached HEAD || exit 1 # die if anything staged but not committed
+	$(GIT) diff-files --quiet || exit 1 # die if any tracked files have unstagged changes
 	npm run release -- $(and $(RELTYPE),--release-as $(RELTYPE))
 
 .PHONY: prerelease
@@ -107,13 +107,13 @@ sile-%.md: CHANGELOG.md
 
 .PHONY: update_libtexpdf
 update_libtexpdf:
-	git diff-index --quiet --cached HEAD || exit 1 # die if anything already staged
-	git submodule update --init --remote -- libtexpdf
-	git add -- libtexpdf
-	git diff-index --quiet --cached HEAD || git commit -m "chore(build): Pin latest libtexpdf library submodule"
+	$(GIT) diff-index --quiet --cached HEAD || exit 1 # die if anything already staged
+	$(GIT) submodule update --init --remote -- libtexpdf
+	$(GIT) add -- libtexpdf
+	$(GIT) diff-index --quiet --cached HEAD || $(GIT) commit -m "chore(build): Pin latest libtexpdf library submodule"
 
 gh-pages:
-	git worktree add -f $@ $@
+	$(GIT) worktree add -f $@ $@
 
 DEPDIR := .deps
 REGRESSIONSCRIPT := ./tests/regressions.pl
@@ -216,9 +216,9 @@ coverage: export SILE_COVERAGE=1
 coverage: regression_previews busted
 
 HEADSHA ?= HEAD
-_HEADSHA ?= $(shell test -e .git && git rev-parse --short=7 $(HEADSHA))
+_HEADSHA ?= $(shell test -e .git && $(GIT) rev-parse --short=7 $(HEADSHA))
 BASESHA ?= $(HEADSHA)^
-_BASESHA ?= $(shell test -e .git && git rev-parse --short=7 $(BASESHA))
+_BASESHA ?= $(shell test -e .git && $(GIT) rev-parse --short=7 $(BASESHA))
 
 clean-recursive: clean-tests
 
@@ -241,21 +241,21 @@ clean-recursive: clean-worktrees
 .PHONY: clean-worktrees
 clean-worktrees:
 	if test -e .git; then \
-		git worktree list --porcelain | \
+		$(GIT) worktree list --porcelain | \
 			$(AWK) 'BEGIN { FS = "/" }; /^worktree .*-[0-9a-f]{7}/ { print $$(NF) }' | \
 			while read worktree; do \
-				git worktree remove --force $${worktree} ; \
+				$(GIT) worktree remove --force $${worktree} ; \
 			done ; \
 	fi
 
 time_action ?= ./sile documentation/sile.sil -o /dev/null
-make_worktree_rules = $(eval $(foreach SHA,$(_HEADSHA) $(_BASESHA),$(call worktree_sha,$(1),$(shell git rev-parse --short=7 $(SHA)))))
+make_worktree_rules = $(eval $(foreach SHA,$(_HEADSHA) $(_BASESHA),$(call worktree_sha,$(1),$(shell $(GIT) rev-parse --short=7 $(SHA)))))
 
 define worktree_sha =
 
 .PRECIOUS: $(1)-$(2)
 $(1)-$(2):
-	[ -d $$@ ] || git worktree add --detach $$@ $(2)
+	[ -d $$@ ] || $(GIT) worktree add --detach $$@ $(2)
 	cd $$@
 	[ -d libtexpdf ] && rm -r libtexpdf ||:
 	[ -h libtexpdf ] || ln -s ../libtexpdf
@@ -376,7 +376,7 @@ docker-build-push: docker
 gource.webm:
 	mkdir -p /tmp/gravatars
 	convert examples/docbook/images/sile-logo.jpg -negate -resize 50% /tmp/sile-logo.jpg
-	git log --pretty=format:"%an—%ae" | \
+	$(GIT) log --pretty=format:"%an—%ae" | \
 		sort -u | \
 		while IFS=— read name email; do \
 			test -f "/tmp/gravatars/$$name.jpg" || \

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ BUILT_SOURCES = .version Makefile-distfiles
 .version: $(shell $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null ||:)
 	[ -e "$@" ] && mv "$@" "$@-prev" || $(if $<,touch,cp "$(srcdir)/.tarball-version") "$@-prev"
 	$(if $<,./build-aux/git-version-gen "$(srcdir)/.tarball-version",printf "$(VERSION)") > "$@"
-	$(CMP) -s "$@" "$@-prev" ||
+	$(CMP) -s "$@" "$@-prev" || \
 		( autoreconf configure.ac --force && build-aux/decore-automake.sh )
 
 dist-hook: $(MANUAL) $(EXAMPLES)
@@ -102,7 +102,7 @@ sile-$(VERSION).pdf: $(MANUAL)
 	cp $< $@
 
 sile-%.md: CHANGELOG.md
-	$(SED) -e '/\.\.\.v$*/,/\.\.\.v/!d' $< |
+	$(SED) -e '/\.\.\.v$*/,/\.\.\.v/!d' $< | \
 		$(SED) -e '1,3d;N;$$!P;$$!D;$$d' > $@
 
 .PHONY: update_libtexpdf
@@ -240,12 +240,12 @@ clean-recursive: clean-worktrees
 
 .PHONY: clean-worktrees
 clean-worktrees:
-	if test -e .git; then
-		git worktree list --porcelain |
-			$(AWK) 'BEGIN { FS = "/" }; /^worktree .*-[0-9a-f]{7}/ { print $$(NF) }' |
-			while read worktree; do
-				git worktree remove --force $${worktree}
-			done
+	if test -e .git; then \
+		git worktree list --porcelain | \
+			$(AWK) 'BEGIN { FS = "/" }; /^worktree .*-[0-9a-f]{7}/ { print $$(NF) }' | \
+			while read worktree; do \
+				git worktree remove --force $${worktree} ; \
+			done ; \
 	fi
 
 time_action ?= ./sile documentation/sile.sil -o /dev/null
@@ -366,20 +366,21 @@ docker-build-push: docker
 		docker login https://$(DOCKER_REGISTRY) -u $(DOCKER_USERNAME) -p $(DOCKER_PAT)
 	docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO):$(DOCKER_TAG)
 	if [[ "$(DOCKER_TAG)" == v*.*.* ]]; then \
-		tag=$(DOCKER_TAG) ;\
-		docker tag $(DOCKER_REPO):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_REPO):latest ;\
-		docker tag $(DOCKER_REPO):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_REPO):$${tag//.*} ;\
-		docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO):latest ;\
-		docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO):$${tag//.*} ;\
+		tag=$(DOCKER_TAG) ; \
+		docker tag $(DOCKER_REPO):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_REPO):latest ; \
+		docker tag $(DOCKER_REPO):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_REPO):$${tag//.*} ; \
+		docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO):latest ; \
+		docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO):$${tag//.*} ; \
 	fi
 
 gource.webm:
 	mkdir -p /tmp/gravatars
 	convert examples/docbook/images/sile-logo.jpg -negate -resize 50% /tmp/sile-logo.jpg
-	git log --pretty=format:"%an—%ae" |
-		sort -u |
-		while IFS=— read name email; do
-			test -f "/tmp/gravatars/$$name.jpg" || curl -S "https://www.gravatar.com/avatar/$$(echo -n $$email | md5sum | cut -d\  -f1)?d=identicon&s=256" -o "/tmp/gravatars/$$name.jpg"
-		done
-	gource -a 0.2 -s 0.2 -i 0 --logo /tmp/sile-logo.jpg -b 000000 --max-file-lag 5 --hide filenames --date-format '%Y-%m-%d' --user-image-dir /tmp/gravatars --user-filter simoncozens --key -1920x1080 -o - |
+	git log --pretty=format:"%an—%ae" | \
+		sort -u | \
+		while IFS=— read name email; do \
+			test -f "/tmp/gravatars/$$name.jpg" || \
+				curl -S "https://www.gravatar.com/avatar/$$(echo -n $$email | md5sum | cut -d\  -f1)?d=identicon&s=256" -o "/tmp/gravatars/$$name.jpg" ; \
+		done ;\
+	gource -a 0.2 -s 0.2 -i 0 --logo /tmp/sile-logo.jpg -b 000000 --max-file-lag 5 --hide filenames --date-format '%Y-%m-%d' --user-image-dir /tmp/gravatars --user-filter simoncozens --key -1920x1080 -o - | \
 		ffmpeg -y -r 60 -f image2pipe -vcodec ppm -i - -vcodec libvpx -b 10000K $@

--- a/configure.ac
+++ b/configure.ac
@@ -7,11 +7,12 @@ AM_SILENT_RULES([yes])
 LT_PREREQ([2.2])
 LT_INIT([dlopen])
 
-AC_DEFUN([AX_PROGVAR],
-		 [
-		  test -n "$m4_toupper($1)" || { AC_PATH_PROG(m4_toupper($1), m4_default($2,$1)) }
-		  test -n "$m4_toupper($1)" || AC_MSG_ERROR([m4_default($2,$1) is required])
-		 ])
+AM_CONDITIONAL([IS_SDIST], [test ! -e .gitignore])
+
+AC_DEFUN([AX_PROGVAR], [
+          test -n "$m4_toupper($1)" || { AC_PATH_PROG(m4_toupper($1), m4_default($2,$1)) }
+          test -n "$m4_toupper($1)" || AC_MSG_ERROR([m4_default($2,$1) is required])
+         ])
 
 AC_PROG_AWK
 AC_PROG_GREP
@@ -19,15 +20,19 @@ AC_PROG_SED
 
 AX_PROGVAR([cmp])
 
-if [[ -d .git ]]; then
-    MAN_DATE=$(git log -1 --format="%cd" --date=format:"%d %B %Y" -- sile.1.in)
-else
-    MAN_DATE=$(date "+%d %B %Y")
-fi
+AM_COND_IF([IS_SDIST],
+           [
+            AX_PROGVAR([date])
+            MAN_DATE=$($DATE "+%d %B %Y")
+           ], [
+            AX_PROGVAR([git])
+            MAN_DATE=$($GIT log -1 --format="%cd" --date=format:"%d %B %Y" -- sile.1.in)
+           ])
 AC_SUBST([MAN_DATE])
 
 AC_ARG_ENABLE([dependency-checks],
               AS_HELP_STRING([--disable-dependency-checks], [Disable dependency checks]))
+AM_CONDITIONAL([DEPENDENCY_CHECKS], [test "x$enable_dependency_checks" != "xno"])
 
 AC_CANONICAL_HOST
 
@@ -52,14 +57,13 @@ AC_ARG_WITH([examples],
             AS_HELP_STRING([--with-examples], [Rebuild examples and install to system’s PDF documentation directory]))
 AM_CONDITIONAL([EXAMPLES], [test "x$with_examples" = "xyes"])
 
-AS_IF([test "x$with_system_libtexpdf" != "xyes"],
-    [ AC_CONFIG_SUBDIRS([libtexpdf]) ],
-    [ AC_CHECK_LIB([texpdf],[texpdf_doc_set_verbose],[],
-        [AC_MSG_FAILURE([--with-system-libtexpdf was given, but test for libtexpdf failed])]
-    )]
-)
+AM_COND_IF([SYSTEM_LIBTEXPDF],
+           [AC_CHECK_LIB([texpdf],[texpdf_doc_set_verbose],
+                         [],
+                         [AC_MSG_FAILURE([--with-system-libtexpdf was given, but test for libtexpdf failed])]) ],
+           [AC_CONFIG_SUBDIRS([libtexpdf])])
 
-AS_IF([test "x$enable_dependency_checks" != "xno"], [
+AM_COND_IF([DEPENDENCY_CHECKS], [
 
     # Checks for programs.
     AC_PROG_CC
@@ -132,7 +136,7 @@ AS_IF([test "x$enable_dependency_checks" != "xno"], [
     AX_LUA_HEADERS
     AX_LUA_LIBS
 
-    AS_IF([test "x$with_system_luarocks" = "xyes"], [
+    AM_COND_IF([SYSTEM_LUAROCKS], [
         AS_IF([test "$LUA_SHORT_VERSION" -lt 52],
             AX_LUA_MODULE([bit32], [bit32])
         )

--- a/configure.ac
+++ b/configure.ac
@@ -19,13 +19,13 @@ AC_PROG_GREP
 AC_PROG_SED
 
 AX_PROGVAR([cmp])
+AX_PROGVAR([git])
 
 AM_COND_IF([IS_SDIST],
            [
             AX_PROGVAR([date])
             MAN_DATE=$($DATE "+%d %B %Y")
            ], [
-            AX_PROGVAR([git])
             MAN_DATE=$($GIT log -1 --format="%cd" --date=format:"%d %B %Y" -- sile.1.in)
            ])
 AC_SUBST([MAN_DATE])


### PR DESCRIPTION
We didn't change anything in our configure, but with the v0.11.0 release cycle Homebrew is having issues building --- notably on the ARM architecture. Something about the POSIX mode shell is different there. This isn't actually figuring out what the deal is, but it does tone things down on our end to a more tried and true path. Even if what we were doing *should* have worked, for our part as an upstream it is easier if we don't rock the boat and make things hard downstream.
