### PR TITLE
Document SILE hitting the official Arch Linux repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,15 @@ $ brew install --cask font-gentium-plus
 
 #### Arch Linux
 
-Arch Linux packages are available in the [AUR][aur] that can be built manually or with an AUR helper (e.g. `yay -S sile`).
-Use [sile][aur-rel] for the latest stable release or [sile-git][aur-dev] to build from the latest git commit.
-Pre-built packages that may be directly installed with `pacman -S sile` are available in [@alerque’s package repository][alerque-arch].
+Arch Linux has a prebuilt [SILE package][arch-sile] in the official package repository:
+
+```console
+$ pacman -S sile
+```
+
+The official package uses Lua 5.4.
+Alternatively, a package that uses LuaJIT may be built manually from the [Arch User Repository][aur] using [sile-luajit][aur-sile-luajit].
+A VCS package is also available as [sile-git][aur-sile-git] to build from the latest Git commit.
 
 #### Ubuntu
 
@@ -253,9 +259,10 @@ SILE is distributed under the [MIT licence][license].
   [harfbuzz]: http://www.freedesktop.org/wiki/Software/HarfBuzz/
   [icu]: http://icu-project.org
   [libtexpdf]: https://github.com/sile-typesetter/libtexpdf
+  [arch-sile]: https://archlinux.org/packages/community/x86_64/sile/
   [aur]: https://wiki.archlinux.org/index.php/Arch_User_Repository
-  [aur-rel]: https://aur.archlinux.org/packages/sile/
-  [aur-dev]: https://aur.archlinux.org/packages/sile-git/
+  [aur-sile-luajit]: https://aur.archlinux.org/packages/sile-luajit/
+  [aur-sile-git]: https://aur.archlinux.org/packages/sile-git/
   [typesetting]: https://en.wikipedia.org/wiki/Typesetting
   [tex]: https://en.wikipedia.org/wiki/TeX
   [indesign]: https://en.wikipedia.org/wiki/Adobe_InDesign

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $ docker run -it --volume "/usr/share/fonts:/fonts" --volume "$(pwd):/data" --us
 
 #### Nix
 
-[Nix packages][nix] are available and can ben installed on several platforms.
+[Nix packages][nix] are available and can be installed on several platforms, including NixOS, other Linux distros, and even macOS.
 
 ### From Source
 

--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -117,7 +117,7 @@ For most shells, a single alias can be created to hide that complexity and make 
 $ alias sile='docker run -it --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/sile:latest'
 \end{terminal}
 
-Docker images are tagged to match releases (e.g. \code{v.0.10.0}).
+Docker images are tagged to match releases (e.g. \code{v0.10.0}).
 Additionally the latest release will be tagged \code{latest}, and a \code{master} tag is also available with the freshest development build.
 You can substitute \code{latest} in the alias above to run a specific version.
 

--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -44,9 +44,13 @@ number (1) centered at the bottom. How are we going to get to that PDF?
 \section{Installing}
 
 First of all, we need to get ahold of SILE and get it running on our computer.
-Downloads of SILE can be obtained from the home page at \silehp.
+Ready to use packages are available for macOS and many Linux distributions.
+Details for those we know about are listed in the sections below.
+Many other Linux distros without native packages can also take advantage of either Linuxbrew or Nix packaging.
+For all other systems you will need to follow the steps to download and compile the source yourself.
+Alternatively Docker containers are also available for use on any system that can run them.
 
-\subsection{Installing Preconfigured Packages}
+\subsection{macOS}
 
 For macOS the recommended way to install SILE is through the Homebrew package manager.
 Once you have Homebrew running (see \url{http://brew.sh}), installing SILE is as easy as running:
@@ -61,25 +65,29 @@ To test the latest unreleased code you can install using:
 The \code{brew} package manager is also available as Linuxbrew for many Linux distributions.
 As an alternative, the \code{nix} package manager is also available for macOS, see below.
 
-For Linux users, preconfigured package build files are available for some distributions.
+\subsection{Arch Linux}
 
-Arch Linux has prebuilt packages in the official package repository:
+Arch Linux (and derivatives such as Manjaro, Parabola, and others) have prebuilt packages in the official package repository:
 
 \terminal{$ pacman -S sile}
 
-The official package uses Lua 5.4.
+The official package builds use Lua 5.4.
 Alternatively, a package that uses LuaJIT may be built manually from the Arch User Repository using \code{sile-luajit}.
 See the note about LuaJIT in the section \em{Installing From Source} for applicable caveats.
 A VCS package is also available as \code{sile-git} to build from the latest Git commit.
 These may be built and installed like any other AUR\footnote{\url{https://wiki.archlinux.org/title/Arch_User_Repository}} package.
 
-For Ubuntu an official PPA is available with precompiled packages:
+\subsection{Ubuntu}
+
+For Ubuntu an official PPA is available with precompiled packages for all currently supported releases since 18.04 (currently Bionic, Focal, Hirsute):
 
 \begin{terminal}
 sudo add-apt-repository ppa:sile-typesetter/sile
 sudo apt-get update
 sudo apt-get install sile
 \end{terminal}
+
+\subsection{NetBSD}
 
 For NetBSD, package sources are available in \code{print/sile}.
 Use the usual command \code{bmake install} to build and install.
@@ -89,17 +97,19 @@ A binary package can be installed using \code{pkgin}
 pkgin install sile
 \end{terminal}
 
+\subsection{NixOS}
+
 Packages are available for NixOS:
 
 \terminal{$ nix-env -i sile}
 
 The Nix package manager is also available on many other Linux distributions, as well as for macOS.
 
+\subsection{Void Linux}
+
 Void Linux packages are available in the default package manager.
 
 \terminal{$ xbps-install sile}
-
-For all other systems that either don’t have native packages and can’t use \code{nix} or \code{brew} you will need to follow the steps to download and compile the source yourself.
 
 \subsection{Running via Docker}
 
@@ -135,6 +145,8 @@ Armed with commands (or aliases) like these to take care of the actual invocatio
 Just be aware when it comes to things like fonts, images, or other resources about where your files are relative to the container.
 
 \subsection{Installing From Source}
+
+Downloads of SILE can be obtained from the home page at \silehp.
 
 SILE requires a number of other software packages to be installed on the
 computer before it can work—the Lua programming language, and the Harfbuzz text

--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -62,19 +62,15 @@ version. To test the latest unreleased code you can install using:
 For Linux users, preconfigured package build files are available for
 some distributions.
 
-On Arch Linux, the \code{sile} package in the AUR has the latest stable release
-while \code{sile-git} will build a package using the latest unreleased code
-from the Git repository. These may be built and installed like any other AUR
-package. Precompiled versions of these packages and all the dependencies are
-available in an unofficial repository
-\footnote{\url{https://wiki.archlinux.org/index.php/Unofficial_user_repositories#alerque}}
-that can be instaled using pacman after adding the repository to your system configuration:
+Arch Linux has prebuilt packages in the official package repository:
 
 \terminal{$ pacman -S sile}
 
-Alternate packages \code{sile-luajit} and \code{sile-luajit-git} are also
-available that are pre-configured to use LuaJIT instead of Lua. See the note
-about LuaJIT in the section \em{Installing From Source} for applicable caveats.
+The official package uses Lua 5.4.
+Alternatively, a package that uses LuaJIT may be built manually from the Arch User Repository using \code{sile-luajit}.
+See the note about LuaJIT in the section \em{Installing From Source} for applicable caveats.
+A VCS package is also available as \code{sile-git} to build from the latest Git commit.
+These may be built and installed like any other AUR\footnote{\url{https://wiki.archlinux.org/title/Arch_User_Repository}} package.
 
 For Ubuntu an official PPA is available with precompiled packages:
 

--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -95,6 +95,10 @@ Packages are available for NixOS:
 
 The Nix package manager is also available on many other Linux distributions, as well as for macOS.
 
+Void Linux packages are available in the default package manager.
+
+\terminal{$ xbps-install sile}
+
 For all other systems that either don’t have native packages and can’t use \code{nix} or \code{brew} you will need to follow the steps to download and compile the source yourself.
 
 \subsection{Running via Docker}

--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -48,19 +48,20 @@ Downloads of SILE can be obtained from the home page at \silehp.
 
 \subsection{Installing Preconfigured Packages}
 
-For macOS the recommended way to install SILE is through the Homebrew package
-manager. Once you have Homebrew running (see \url{http://brew.sh}), installing
-SILE is as easy as running:
+For macOS the recommended way to install SILE is through the Homebrew package manager.
+Once you have Homebrew running (see \url{http://brew.sh}), installing SILE is as easy as running:
 
 \terminal{$ brew install sile}
 
-The formula also has an option that can compile SILE from the current Git HEAD
-version. To test the latest unreleased code you can install using:
+The formula also has an option that can compile SILE from the current Git HEAD version.
+To test the latest unreleased code you can install using:
 
 \terminal{$ brew install sile --HEAD}
 
-For Linux users, preconfigured package build files are available for
-some distributions.
+The \code{brew} package manager is also available as Linuxbrew for many Linux distributions.
+As an alternative, the \code{nix} package manager is also available for macOS, see below.
+
+For Linux users, preconfigured package build files are available for some distributions.
 
 Arch Linux has prebuilt packages in the official package repository:
 
@@ -88,8 +89,13 @@ A binary package can be installed using \code{pkgin}
 pkgin install sile
 \end{terminal}
 
-For all other systems you will need to follow the steps to download and compile
-the source yourself.
+Packages are available for NixOS:
+
+\terminal{$ nix-env -i sile}
+
+The Nix package manager is also available on many other Linux distributions, as well as for macOS.
+
+For all other systems that either don’t have native packages and can’t use \code{nix} or \code{brew} you will need to follow the steps to download and compile the source yourself.
 
 \subsection{Running via Docker}
 


### PR DESCRIPTION
- docs(readme): Update Arch Linux info with official package
- docs(readme): Say a little more about Nix
- docs(manual): Update Arch Linux info with official package
- docs(manual): Document NixOS and Linuxbrew alternatives
- docs(manual): Add Void Linux installation note
- docs(manual): Fix typo in version taga syntax
