### PR TITLE
Tableofcontents leveraged

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -96,11 +96,13 @@ end, "Text to appear on the top of the right page")
 
 SILE.registerCommand("book:sectioning", function (options, content)
   local level = SU.required(options, "level", "book:sectioning")
+  local number
   if SU.boolean(options.numbering, true) then
     SILE.call("increment-multilevel-counter", { id = "sectioning", level = level })
+    number = SILE.formatMultilevelCounter(counters.getMultilevelCounter("sectioning"))
   end
   if SU.boolean(options.toc, true) then
-    SILE.call("tocentry", { level = level }, SU.subContent(content))
+    SILE.call("tocentry", { level = level, number = number }, SU.subContent(content))
   end
   local lang = SILE.settings.get("document.language")
   if SU.boolean(options.numbering, true) then

--- a/classes/book.lua
+++ b/classes/book.lua
@@ -1,6 +1,8 @@
 local plain = SILE.require("plain", "classes")
 local book = plain { id = "book" }
 
+local counters = SILE.require("packages/counters").exports
+
 book.defaultFrameset = {
   content = {
     left = "8.3%pw",
@@ -94,12 +96,14 @@ end, "Text to appear on the top of the right page")
 
 SILE.registerCommand("book:sectioning", function (options, content)
   local level = SU.required(options, "level", "book:sectioning")
-  SILE.call("increment-multilevel-counter", { id = "sectioning", level = level })
+  if SU.boolean(options.numbering, true) then
+    SILE.call("increment-multilevel-counter", { id = "sectioning", level = level })
+  end
   if SU.boolean(options.toc, true) then
     SILE.call("tocentry", { level = level }, SU.subContent(content))
   end
   local lang = SILE.settings.get("document.language")
-  if options.numbering == nil or options.numbering == "yes" then
+  if SU.boolean(options.numbering, true) then
     if options.prenumber then
       if SILE.Commands[options.prenumber .. ":"  .. lang] then
         options.prenumber = options.prenumber .. ":" .. lang

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -41,18 +41,6 @@ SILE.registerCommand("pdf:bookmark", function (options, _)
   })
 end)
 
-if SILE.Commands.tocentry then
-  SILE.scratch.pdf = { dests = {}, dc = 1 }
-  local oldtoc = SILE.Commands.tocentry
-  SILE.Commands.tocentry = function (options, content)
-    SILE.call("pdf:destination", { name = "dest" .. SILE.scratch.pdf.dc } )
-    local title = SU.contentToString(content)
-    SILE.call("pdf:bookmark", { title = title, dest = "dest" .. SILE.scratch.pdf.dc, level = options.level })
-    oldtoc(options, content)
-    SILE.scratch.pdf.dc = SILE.scratch.pdf.dc + 1
-  end
-end
-
 SILE.registerCommand("pdf:literal", function (_, content)
   SILE.typesetter:pushHbox({
       value = nil,
@@ -127,7 +115,4 @@ To set arbitrary key-value metadata, use something like \code{\\pdf:metadata[key
 value=J. Smith]}. The PDF metadata field names are case-sensitive. Common keys include
 \code{Title}, \code{Author}, \code{Subject}, \code{Keywords}, \code{CreationDate}, and
 \code{ModDate}.
-
-If the \code{pdf} package is loaded after the \code{tableofcontents} package (e.g.
-in a document with the \code{book} class), then a PDF document outline will be generated.
 \end{document}]] }

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -6,6 +6,7 @@
 --          moveTocNodes (call this in endPage)
 
 SILE.scratch.tableofcontents = {}
+local _tableofcontents = {}
 
 local moveNodes = function (_)
   local node = SILE.scratch.info.thispage.toc
@@ -23,6 +24,10 @@ local writeToc = function ()
   if not tocfile then return SU.error(err) end
   tocfile:write("return " .. tocdata)
   tocfile:close()
+
+  if not pl.tablex.deepcompare(SILE.scratch.tableofcontents, _tableofcontents) then
+    io.stderr:write("\n! Warning: table of contents has changed, please rerun SILE to update it.")
+  end
 end
 
 SILE.registerCommand("tableofcontents", function (options, _)
@@ -48,6 +53,7 @@ SILE.registerCommand("tableofcontents", function (options, _)
     end
   end
   SILE.call("tableofcontents:footer")
+  _tableofcontents = toc
 end)
 
 local linkWrapper = function (dest, func)


### PR DESCRIPTION
A proposal covering main aspects of #1054 

The distinct features are in separate commits:
1. Fix for the book class: unnumbered sections shouldn't increment the counters, so one can have, e.g. a "Prologue" and then a "Chapter 1")
2. The book class passes the section number to the `\tocentry`.
3. Table of contents support for:
    - depth control
    - configuration for showing the section numbers in TOC entries 
4. Table of contents support for:
    - option for TOC entries to be turned into links if the pdf package is loaded
5. Finally, output a warning to console if SILE needs to be rerun to update the TOC.