### PR TITLE
Add Symbola as fallback for math in code samples

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -173,15 +173,16 @@ examples: $(EXAMPLES)
 # garantee the TOC is up to date, simplify when #230 is fixed.
 hastoc = [ -f $(subst .pdf,.toc,$@) ] && echo true || echo false
 pages = $(PDFINFO) $@ | $(AWK) '$$1 == "Pages:" {print $$2}' || echo 0
-silepass = $(LOCALTESTFONTS) ./sile $(SILEFLAGS) $< -o $@ && pg0=$${pg} pg=$$($(pages))
+silepass = $(LOCALTESTFONTS) ./sile $(SILEFLAGS) $< -o $@ && pg0=$${pg} pg=$$($(pages)) || false
 define runsile =
-	pg0=$$($(pages)) hadtoc=$$($(hastoc))
+	set -e
+	pg=$$($(pages)) hadtoc=$$($(hastoc))
 	mkdir -p $(DEPDIR)/$$(dirname $@)
 	$(silepass)
 	export -n SILE_COVERAGE
 	if $(hastoc); then
 		$${hadtoc} || $(silepass)
-		[ "$${pg}" -eq "$${pg0}" ] || $(silepass)
+		[ "$${pg}" == "$${pg0}" ] || $(silepass)
 	fi
 endef
 

--- a/classes/jplain.lua
+++ b/classes/jplain.lua
@@ -15,6 +15,8 @@ jplain.defaultFrameset.content = {
 
 function jplain:init ()
   SILE.call("bidi-off")
+  self:loadPackage("font-fallback")
+  SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
   SILE.languageSupport.loadLanguage("ja")
   self:loadPackage("hanmenkyoshi")
   self.defaultFrameset.content.tate = self.options.layout() == "tate"

--- a/classes/jplain.lua
+++ b/classes/jplain.lua
@@ -15,13 +15,12 @@ jplain.defaultFrameset.content = {
 
 function jplain:init ()
   SILE.call("bidi-off")
+  SILE.languageSupport.loadLanguage("ja")
   self:loadPackage("hanmenkyoshi")
   self.defaultFrameset.content.tate = self.options.layout() == "tate"
   self.defaultFrameset.content = self:declareHanmenFrame("content", self.defaultFrameset.content)
   SILE.settings.set("document.parindent", SILE.nodefactory.glue("10pt"))
   return plain.init(self)
 end
-
-SILE.languageSupport.loadLanguage("ja")
 
 return jplain

--- a/core/base-shaper.lua
+++ b/core/base-shaper.lua
@@ -60,7 +60,11 @@ SILE.shapers.base = pl.class({
       local options = SILE.font.loadDefaults({})
       options.tracking = SILE.settings.get("shaper.tracking")
       local items = self:shapeToken(char, options)
-      return { height = items[1].height, width = items[1].width }
+      if #items > 0 then
+        return { height = items[1].height, width = items[1].width }
+      else
+        SU.error("Unable to measure character", char)
+      end
     end,
 
     -- Given a text and some font options, return a bunch of boxes

--- a/core/baseclass.lua
+++ b/core/baseclass.lua
@@ -104,7 +104,10 @@ SILE.baseClass = std.object {
 
     SILE.registerCommand("script", function (options, content)
       if (options["src"]) then
-        require(options["src"])
+        local script, _ = require(options["src"])
+        if type(script) == "table" and script.init then
+          script.init()
+        end
       else
         local func, err = load(content[1])
         if not func then SU.error(err) end

--- a/core/languages.lua
+++ b/core/languages.lua
@@ -4,11 +4,14 @@ SILE.languageSupport = {
     if SILE.languageSupport.languages[language] then return end
     if SILE.hyphenator.languages[language] then return end
     if not(language) or language == "" then language = "en" end
-    local _, fail = pcall(function () SILE.require("languages/" .. language) end)
+    local lang, fail = pcall(function () SILE.require("languages/" .. language) end)
     if fail then
       if fail:match("not found") then fail = "no support for this language" end
       SU.warn("Error loading language " .. language .. ": " .. fail)
       SILE.languageSupport.languages[language] = {} -- Don't try again
+    end
+    if type(lang) == "table" and lang.init then
+      lang.init()
     end
   end
 }

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -163,6 +163,9 @@ Japanese language. The easiest way to set up the other elements of Japanese
 typesetting such as the \em{hanmen} grid and optional vertical typesetting
 support is by using the \code{jplain} class.
 
+% See https://github.com/sile-typesetter/sile/issues/1245
+\script[src=packages/ruby]
+
 \package-documentation[src=packages/hanmenkyoshi]
 
 \package-documentation[src=packages/tate]

--- a/languages/ja.lua
+++ b/languages/ja.lua
@@ -1,17 +1,6 @@
 -- "jlreq" refers to http://www.w3.org/TR/jlreq/
 -- "JIS" refers to JIS X 4051
 
--- jlreq measures distances in units of 1em, but also assumes that an em is the
--- width of a full-width character. In SILE terms it isn't: measuring an "m" in
--- a 10pt Japanese font gets you 5 points. So we measure a full-width character
--- and use that as a unit. We call it zw following ptex (zenkaku width)
-SILE.units["zw"] = {
-  relative = true,
-  definition = function (v)
-    return v * SILE.shaper:measureChar("あ").width
-  end
-}
-
 local hiragana = function (c) return c > 0x3040 and c <= 0x309f end
 local katakana = function (c) return c > 0x30a0 and c <= 0x30ff end
 local kanji = function (c) return c >= 0x4e00 and c <= 0x9fcc end
@@ -192,3 +181,18 @@ SILE.doTexlike([[%
 \define[command=book:chapter:pre:ja]{第\thinspace}%
 \define[command=book:chapter:post:ja]{\thinspace章 \medskip}%
 ]])
+
+return {
+  init = function ()
+    -- jlreq measures distances in units of 1em, but also assumes that an em is the
+    -- width of a full-width character. In SILE terms it isn't: measuring an "m" in
+    -- a 10pt Japanese font gets you 5 points. So we measure a full-width character
+    -- and use that as a unit. We call it zw following ptex (zenkaku width)
+    SILE.units["zw"] = {
+      relative = true,
+      definition = function (v)
+        return v * SILE.shaper:measureChar("あ").width
+      end
+    }
+  end
+}

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -1,18 +1,13 @@
 SILE.registerCommand("package-documentation", function (options, _)
   local package = SU.required(options, "src", "src for package documentation")
-  io.stderr:write("<"..package..">")
+  SU.debug("autodoc", package)
   local exports = require(package)
-  if type(exports) ~= "table" then
+  if type(exports) ~= "table" or not exports.documentation then
     SU.error("Undocumented package "..package)
   end
-  local doc = exports.documentation
-  if not doc then
-    SU.error("Undocumented package "..package)
-  end
-
   SILE.process(
     SILE.inputs.TeXlike.docToTree(
-      require(package).documentation
+      exports.documentation
     )
   )
 end)

--- a/packages/color-fonts.lua
+++ b/packages/color-fonts.lua
@@ -1,9 +1,8 @@
-local ot = SILE.require("core/opentype-parser")
-
 SILE.shapers.harfbuzzWithColor = pl.class({
     _base = SILE.shapers.harfbuzz,
 
     shapeToken = function (self, str, options)
+      local ot = SILE.require("core/opentype-parser")
       if not options.family then return {} end
       local face = SILE.font.cache(options, SILE.shaper.getFace)
       local font = ot.parseFont(face)
@@ -85,9 +84,10 @@ SILE.shapers.harfbuzzWithColor = pl.class({
     end
   })
 
-SILE.shaper = SILE.shapers.harfbuzzWithColor()
-
 return {
+  init = function (_, _)
+    SILE.shaper = SILE.shapers.harfbuzzWithColor()
+  end,
   documentation = [[
 \begin{document}
   The \code{color-fonts} package adds support for fonts with a \code{COLR}

--- a/packages/font-fallback.lua
+++ b/packages/font-fallback.lua
@@ -54,6 +54,10 @@ SILE.registerCommand("font:add-fallback", function (options, _)
   fontlist[#fontlist+1] = options
 end)
 
+SILE.registerCommand("font:remove-fallback", function ()
+  fontlist[#fontlist] = nil
+end, "Pop last added fallback from fallback stack")
+
 SILE.shapers.harfbuzzWithFallback = pl.class({
     _base = SILE.shapers.harfbuzz,
 
@@ -210,6 +214,9 @@ and SILE will produce:
 
 \command{\\font:clear-fallbacks} removes all font fallbacks from the list
 of fonts to try.
+
+\command{\\font:remove-fallback} removes the last added fallback from the
+list of fonts to try.
 
 \font:clear-fallbacks
 \end{document} ]]}

--- a/packages/font-fallback.lua
+++ b/packages/font-fallback.lua
@@ -204,6 +204,7 @@ Now we can say:
 
 \font:add-fallback[family=Symbola]
 \font:add-fallback[family=Noto Sans CJK JP]
+
 \begin{verbatim}
 あば x 😼 Hello world. あ
 \end{verbatim}
@@ -212,11 +213,13 @@ and SILE will produce:
 
 \examplefont{あば x 😼 Hello world. あ}
 
+\font:remove-fallback
+\font:remove-fallback
+
 \command{\\font:clear-fallbacks} removes all font fallbacks from the list
 of fonts to try.
 
 \command{\\font:remove-fallback} removes the last added fallback from the
 list of fonts to try.
 
-\font:clear-fallbacks
 \end{document} ]]}

--- a/packages/math.lua
+++ b/packages/math.lua
@@ -7,6 +7,10 @@ return {
 \set[parameter=math.font.family, value=Libertinus Math]
 \set[parameter=math.font.size, value=11]
 
+% Default verbatim font (Hack) is missing a few math symbols
+\script[src=packages/font-fallback]
+\font:add-fallback[family=Symbola]
+
 This package provides typesetting of formulas directly in a SILE document.
 
 \note{Mathematical typesetting in SILE is still in its infancy. As such, it
@@ -282,6 +286,7 @@ hopefully we’ll get there. Among unsupported constructs are: decorating symbol
 with so-called accents, such as arrows or hats, “over” or “under” braces, and
 line breaking inside a formula.
 
+\font:clear-fallbacks
 \end{document}
 ]]
 }

--- a/packages/math.lua
+++ b/packages/math.lua
@@ -286,7 +286,7 @@ hopefully we’ll get there. Among unsupported constructs are: decorating symbol
 with so-called accents, such as arrows or hats, “over” or “under” braces, and
 line breaking inside a formula.
 
-\font:clear-fallbacks
+\font:remove-fallback
 \end{document}
 ]]
 }

--- a/packages/ruby.lua
+++ b/packages/ruby.lua
@@ -1,23 +1,6 @@
--- Japaneese language support defines units which are useful here
-SILE.languageSupport.loadLanguage("ja")
-
 SILE.registerCommand("ruby:font", function (_, _)
   SILE.call("font", { size = "0.6zw", weight = 800 })
 end)
-
-SILE.settings.declare({
-    parameter = "ruby.height",
-    type = "measurement",
-    default = SILE.measurement("1zw"),
-    help = "Vertical offset between the ruby and the main text"
-  })
-
-SILE.settings.declare({
-    parameter = "ruby.latinspacer",
-    type = "glue",
-    default = SILE.nodefactory.glue("0.25em"),
-    help = "Glue added between consecutive Latin ruby"
-  })
 
 local isLatin = function (char)
   return (char > 0x20 and char <= 0x24F) or (char >= 0x300 and char <= 0x36F)
@@ -95,6 +78,24 @@ SILE.registerCommand("ruby", function (options, content)
 end)
 
 return {
+
+  init = function (_, _)
+    -- Japaneese language support defines units which are useful here
+    SILE.languageSupport.loadLanguage("ja")
+    SILE.settings.declare({
+      parameter = "ruby.height",
+      type = "measurement",
+      default = SILE.measurement("1zw"),
+      help = "Vertical offset between the ruby and the main text"
+    })
+    SILE.settings.declare({
+      parameter = "ruby.latinspacer",
+      type = "glue",
+      default = SILE.nodefactory.glue("0.25em"),
+      help = "Glue added between consecutive Latin ruby"
+    })
+  end,
+
   documentation = [[
 \begin{document}
 Japanese texts often contain pronunciation hints (called \em{furigana}) for
@@ -125,4 +126,5 @@ Produces:
 
 \end{document}
 ]]
+
 }

--- a/packages/ruby.lua
+++ b/packages/ruby.lua
@@ -1,7 +1,3 @@
-SILE.registerCommand("ruby:font", function (_, _)
-  SILE.call("font", { size = "0.6zw", weight = 800 })
-end)
-
 local isLatin = function (char)
   return (char > 0x20 and char <= 0x24F) or (char >= 0x300 and char <= 0x36F)
     or (char >= 0x1DC0 and char <= 0x1EFF) or (char >= 0x2C60 and char <= 0x2c7F)
@@ -26,76 +22,84 @@ local checkIfSpacerNeeded = function (reading)
   SILE.typesetter:pushGlue(SILE.settings.get("ruby.latinspacer"))
 end
 
-SILE.registerCommand("ruby", function (options, content)
-  local reading = SU.required(options, "reading", "\\ruby")
-  SILE.typesetter:setpar("")
-
-  checkIfSpacerNeeded(reading)
-
-  SILE.call("hbox", {}, function ()
-    SILE.settings.temporarily(function ()
-      SILE.call("noindent")
-      SILE.call("ruby:font")
-      SILE.typesetter:typeset(reading)
-    end)
-  end)
-  local rubybox = SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes]
-  rubybox.outputYourself = function (self, typesetter, line)
-    local ox = typesetter.frame.state.cursorX
-    local oy = typesetter.frame.state.cursorY
-    typesetter.frame:advanceWritingDirection(rubybox.width)
-    typesetter.frame:advancePageDirection(-SILE.settings.get("ruby.height"))
-    SILE.outputter:setCursor(typesetter.frame.state.cursorX, typesetter.frame.state.cursorY)
-    for i = 1, #(self.value) do
-      local node = self.value[i]
-      node:outputYourself(typesetter, line)
-    end
-    typesetter.frame.state.cursorX = ox
-    typesetter.frame.state.cursorY = oy
-  end
-  -- measure the content
-  SILE.call("hbox", {}, content)
-  local cbox = SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes]
-  SU.debug("ruby", "base box is " .. cbox)
-  SU.debug("ruby", "reading is  " .. rubybox)
-  if cbox:lineContribution() > rubybox:lineContribution() then
-    SU.debug("ruby", "Base is longer, offsetting ruby to fit")
-    -- This is actually the offset against the base
-    rubybox.width = SILE.length(cbox:lineContribution() - rubybox:lineContribution())/2
-  else
-    local diff = rubybox:lineContribution() - cbox:lineContribution()
-    local to_insert = SILE.length(diff / 2)
-    SU.debug("ruby", "Ruby is longer, inserting " .. to_insert .. " either side of base")
-    cbox.width = rubybox:lineContribution()
-    rubybox.height = 0
-    rubybox.width = 0
-    -- add spaces at beginning and end
-    table.insert(cbox.value, 1, SILE.nodefactory.glue(to_insert))
-    table.insert(cbox.value, SILE.nodefactory.glue(to_insert))
-  end
-  SILE.scratch.lastRubyBox = rubybox
-  SILE.scratch.lastRubyText = reading
-end)
-
 return {
 
   init = function (_, _)
     -- Japaneese language support defines units which are useful here
     SILE.require("packages/font-fallback.lua")
     SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
+
     SILE.languageSupport.loadLanguage("ja")
+
     SILE.settings.declare({
       parameter = "ruby.height",
       type = "measurement",
       default = SILE.measurement("1zw"),
       help = "Vertical offset between the ruby and the main text"
     })
+
     SILE.settings.declare({
       parameter = "ruby.latinspacer",
       type = "glue",
       default = SILE.nodefactory.glue("0.25em"),
       help = "Glue added between consecutive Latin ruby"
     })
+
+    SILE.registerCommand("ruby:font", function (_, _)
+      SILE.call("font", { size = "0.6zw", weight = 800 })
+    end)
+
+    SILE.registerCommand("ruby", function (options, content)
+      local reading = SU.required(options, "reading", "\\ruby")
+      SILE.typesetter:setpar("")
+
+      checkIfSpacerNeeded(reading)
+
+      SILE.call("hbox", {}, function ()
+        SILE.settings.temporarily(function ()
+          SILE.call("noindent")
+          SILE.call("ruby:font")
+          SILE.typesetter:typeset(reading)
+        end)
+      end)
+      local rubybox = SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes]
+      rubybox.outputYourself = function (self, typesetter, line)
+        local ox = typesetter.frame.state.cursorX
+        local oy = typesetter.frame.state.cursorY
+        typesetter.frame:advanceWritingDirection(rubybox.width)
+        typesetter.frame:advancePageDirection(-SILE.settings.get("ruby.height"))
+        SILE.outputter:setCursor(typesetter.frame.state.cursorX, typesetter.frame.state.cursorY)
+        for i = 1, #(self.value) do
+          local node = self.value[i]
+          node:outputYourself(typesetter, line)
+        end
+        typesetter.frame.state.cursorX = ox
+        typesetter.frame.state.cursorY = oy
+      end
+      -- measure the content
+      SILE.call("hbox", {}, content)
+      local cbox = SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes]
+      SU.debug("ruby", "base box is " .. cbox)
+      SU.debug("ruby", "reading is  " .. rubybox)
+      if cbox:lineContribution() > rubybox:lineContribution() then
+        SU.debug("ruby", "Base is longer, offsetting ruby to fit")
+        -- This is actually the offset against the base
+        rubybox.width = SILE.length(cbox:lineContribution() - rubybox:lineContribution())/2
+      else
+        local diff = rubybox:lineContribution() - cbox:lineContribution()
+        local to_insert = SILE.length(diff / 2)
+        SU.debug("ruby", "Ruby is longer, inserting " .. to_insert .. " either side of base")
+        cbox.width = rubybox:lineContribution()
+        rubybox.height = 0
+        rubybox.width = 0
+        -- add spaces at beginning and end
+        table.insert(cbox.value, 1, SILE.nodefactory.glue(to_insert))
+        table.insert(cbox.value, SILE.nodefactory.glue(to_insert))
+      end
+      SILE.scratch.lastRubyBox = rubybox
+      SILE.scratch.lastRubyText = reading
+    end)
+
   end,
 
   documentation = [[

--- a/packages/ruby.lua
+++ b/packages/ruby.lua
@@ -81,6 +81,8 @@ return {
 
   init = function (_, _)
     -- Japaneese language support defines units which are useful here
+    SILE.require("packages/font-fallback.lua")
+    SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
     SILE.languageSupport.loadLanguage("ja")
     SILE.settings.declare({
       parameter = "ruby.height",
@@ -106,24 +108,24 @@ that they explain. The typesetting term for these glosses is \em{ruby}.
 The \code{ruby} package provides the \code{\\ruby[reading=...]\{...\}} command
 which sets a piece of ruby above or beside the base text. For example:
 
-\set[parameter=ruby.height, value=12pt]
-\language[main=ja]{}
+% Unit zw throws errors if there is not way to shape あ
+\script[src=packages/font-fallback]
+\font:add-fallback[family=Noto Sans CJK JP]
 
-\define[command=ruby:font]{\font[family=Noto Sans CJK JP,size=6pt]}
+\set[parameter=ruby.height,value=12pt]
+\define[command=ja]{\font[family=Noto Sans CJK JP,language=ja]{\process}}
+
 \begin{verbatim}
 \line
-\\ruby[reading=\font[family=Noto Sans CJK JP]{れいわ}]\{\font[family=Noto Sans CJK JP]{令和}\}
+\\ruby[reading=\ja{れいわ}]\{\ja{令和}\}
 \line
 \end{verbatim}
 
 Produces:
 \medskip
-\font[family=Noto Sans CJK JP]{
-  \ruby[reading=れいわ]{令和}
-}
+\ja{\ruby[reading=れいわ]{令和}}
 
-\language[main=en]
-
+\font:remove-fallback
 \end{document}
 ]]
 

--- a/packages/tate.lua
+++ b/packages/tate.lua
@@ -133,6 +133,8 @@ end)
 return {
   init = function (_, _)
     -- Japaneese language support defines units which are useful here
+    SILE.require("packages/font-fallback.lua")
+    SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
     SILE.languageSupport.loadLanguage("ja")
   end,
   documentation = [[

--- a/packages/tate.lua
+++ b/packages/tate.lua
@@ -1,6 +1,3 @@
--- Japaneese language support defines units which are useful here
-SILE.languageSupport.loadLanguage("ja")
-
 SILE.tateFramePrototype = pl.class({
     _base = SILE.framePrototype,
     direction = "TTB-RTL",
@@ -132,7 +129,12 @@ SILE.registerCommand("tate-chu-yoko", function (_, content)
 
 end)
 
+
 return {
+  init = function (_, _)
+    -- Japaneese language support defines units which are useful here
+    SILE.languageSupport.loadLanguage("ja")
+  end,
   documentation = [[
 \begin{document}
 The \code{tate} package provides support for Japanese vertical typesetting.

--- a/tests/bug-244.expected
+++ b/tests/bug-244.expected
@@ -1,15 +1,16 @@
 Set paper size 	595.275597	841.8897729
 Begin page
-Mx 	543.8630
-My 	117.7320
-Set font 	Gentium Plus;10;400;;normal;;LTR
-T	43 72 79 79 82 w=21.6064	(Hello)
-My 	142.0279
-T	90 82 85 79 71 w=23.9600	(world)
-My 	165.9879
-T	17 w=2.2900	(.)
+Mx 	539.9079
+My 	117.7637
+Set font 	Noto Sans CJK JP;10;400;;normal;;LTR
+T	41 70 77 77 80 w=24.5800	(Hello)
+My 	145.0785
+T	88 80 83 77 69 w=26.9700	(world)
+My 	172.0485
+T	15 w=2.7800	(.)
 Mx 	298.5617
 My 	780.6177
+Set font 	Gentium Plus;10;400;;normal;;LTR
 T	20 w=4.6924	(1)
 End page
 Finish

--- a/tests/bug-244.sil
+++ b/tests/bug-244.sil
@@ -1,3 +1,4 @@
-\begin[papersize=a4,class=jplain,layout="tate"]{document}
+\begin[papersize=a4,class=jplain,layout=tate]{document}
+\font[family=Noto Sans CJK JP,lanaguage=jp]
 \latin-in-tate{Hello world.}
 \end{document}


### PR DESCRIPTION
Fixes #1214

The only problem right now is this doesn't actually work and I don't understand why. I tried adding it to the whole document verbatim:font command and also adding it inside the specific verbatim block in question, nothing is actually working.