### PR TITLE
Correct Armenian support to use ISO 639 code ‘hy’

### DIFF
--- a/core/languages.lua
+++ b/core/languages.lua
@@ -30,6 +30,7 @@ require("languages/unicode")
 
 -- The following languages neither have hyphenation nor specific
 -- language support at present. This code is here to suppress warnings.
+SILE.hyphenator.languages.ar = { patterns = {} }
 SILE.hyphenator.languages.bo = { patterns = {} }
 SILE.hyphenator.languages.ur = { patterns = {} }
 SILE.hyphenator.languages.sd = { patterns = {} }

--- a/languages/hy.lua
+++ b/languages/hy.lua
@@ -1,5 +1,5 @@
-SILE.hyphenator.languages["ar"] = {}
-SILE.hyphenator.languages["ar"].patterns = {
+SILE.hyphenator.languages["hy"] = {}
+SILE.hyphenator.languages["hy"].patterns = {
 "և1ա",
 "և1ե",
 "և1է",


### PR DESCRIPTION
Hey @simoncozens I'm not sure what bottle of good stuff you opened on August 16th, 2018 when you added 3c0dfe35 but if you have any more of it around feel free to invite me ;-)
