### PR TITLE
feat(packages): URLs are allowed many more breakpoints

### DIFF
--- a/packages/url.lua
+++ b/packages/url.lua
@@ -5,22 +5,76 @@ if pdf then SILE.require("packages/pdf") end
 
 local inputfilter = SILE.require("packages/inputfilter").exports
 
-local urlFilter = function (node, content, breakpat)
+-- URL escape sequence, URL fragment:
+local preferBreakBefore = "%#"
+-- URL path elements, URL query arguments, acceptable extras:
+local preferBreakAfter = ":/.;?&=!_-"
+-- URL scheme:
+local alwaysBreakAfter = ":" -- Must have only one character here!
+
+local escapeRegExpMinimal = function (str)
+  -- Minimalist = just what's needed for the above strings
+  return string.gsub(str, '([%.%?%-%%])', '%%%1')
+end
+
+local breakPattern = "["..escapeRegExpMinimal(preferBreakBefore..preferBreakAfter..alwaysBreakAfter).."]"
+
+local urlFilter = function (node, content, options)
   if type(node) == "table" then return node end
+
   local result = {}
-  for token in SU.gtoke(node, breakpat) do
+  for token in SU.gtoke(node, breakPattern) do
     if token.string then
       result[#result+1] = token.string
     else
-      result[#result+1] = token.separator
-      result[#result+1] = inputfilter.createCommand(
-        content.pos, content.col, content.line,
-        "penalty", { penalty = 100 }, nil
-      )
+      if string.find(preferBreakBefore, escapeRegExpMinimal(token.separator)) then
+        -- Accepts breaking before, and at the extreme worst after.
+        result[#result+1] = inputfilter.createCommand(
+          content.pos, content.col, content.line,
+          "penalty", { penalty = options.primaryPenalty }, nil
+        )
+        result[#result+1] = token.separator
+        result[#result+1] = inputfilter.createCommand(
+          content.pos, content.col, content.line,
+          "penalty", { penalty = options.worsePenalty }, nil
+        )
+      elseif token.separator == alwaysBreakAfter then
+        -- Accept breaking after (only).
+        result[#result+1] = token.separator
+        result[#result+1] = inputfilter.createCommand(
+          content.pos, content.col, content.line,
+          "penalty", { penalty = options.primaryPenalty }, nil
+        )
+      else
+        -- Accept breaking after, but tolerate breaking before.
+        result[#result+1] = inputfilter.createCommand(
+          content.pos, content.col, content.line,
+          "penalty", { penalty = options.secondaryPenalty }, nil
+        )
+        result[#result+1] = token.separator
+        result[#result+1] = inputfilter.createCommand(
+          content.pos, content.col, content.line,
+          "penalty", { penalty = options.primaryPenalty }, nil
+        )
+      end
     end
   end
   return result
 end
+
+SILE.settings.declare({
+  parameter = "url.linebreak.primaryPenalty",
+  type = "integer",
+  default = 100,
+  help = "Penalty for breaking lines in URLs at preferred breakpoints"
+})
+
+SILE.settings.declare({
+  parameter = "url.linebreak.secondaryPenalty",
+  type = "integer",
+  default = 200,
+  help = "Penalty for breaking lines in URLs at tolerable breakpoints (should be higher than url.linebreak.primaryPenalty)"
+})
 
 SILE.registerCommand("href", function (options, content)
   if not pdf then return SILE.process(content) end
@@ -33,24 +87,48 @@ SILE.registerCommand("href", function (options, content)
       content)
   else
     options.src = content[1]
-    local breakpat = options.breakpat or "/"
-    content = inputfilter.transformContent(content, urlFilter, breakpat)
     SILE.call("pdf:link", { dest = options.src, external = true,
       borderwidth = options.borderwidth,
       borderstyle = options.borderstyle,
       bordercolor = options.bordercolor,
       borderoffset = options.borderoffset },
       function (_, _)
-        SILE.call("code", {}, content)
+        SILE.call("url", { language = options.language }, content)
       end)
   end
-end)
+end, "Inserts a PDF hyperlink.")
 
 SILE.registerCommand("url", function (options, content)
-  local breakpat = options.breakpat or "/"
-  local result = inputfilter.transformContent(content, urlFilter, breakpat)
-  SILE.call("code", {}, result)
-end)
+  SILE.settings.temporarily(function ()
+    local primaryPenalty = SILE.settings.get("url.linebreak.primaryPenalty")
+    local secondaryPenalty = SILE.settings.get("url.linebreak.secondaryPenalty")
+    local worsePenalty = primaryPenalty + secondaryPenalty
+
+    if options.language then
+      SILE.languageSupport.loadLanguage(options.language)
+      if options.language == "fr" then
+        -- Trick the engine by declaring a "fake"" language that doesn't apply
+        -- the typographic rules for punctuations
+        SILE.hyphenator.languages["_fr_noSpacingRules"] = SILE.hyphenator.languages.fr
+        -- Not needed (the engine already defaults to SILE.nodeMakers.unicode if
+        -- the language is not found):
+        -- SILE.nodeMakers._fr_noSpacingRules = SILE.nodeMakers.unicode
+        SILE.settings.set("document.language", "_fr_noSpacingRules")
+      else
+        SILE.settings.set("document.language", options.language)
+      end
+    else
+      SILE.settings.set("document.language", 'und')
+    end
+
+    local result = inputfilter.transformContent(content, urlFilter, {
+      primaryPenalty = primaryPenalty,
+      secondaryPenalty = secondaryPenalty,
+      worsePenalty = worsePenalty
+    })
+    SILE.call("code", {}, result)
+  end)
+end, "Inserts penalties in an URL so it can be broken over multiple lines at appropriate places.")
 
 SILE.registerCommand("code", function(options, content)
   SILE.call("verbatim:font", options, content)
@@ -58,18 +136,41 @@ end)
 
 return {
   documentation = [[\begin{document}
-This package enhances the typesetting of URLs in two ways.
-First, the \code{\\url} command will automatically insert breakpoints into unwieldy
-URLs like \url{https://github.com/simoncozens/sile/tree/master/examples/packages}
-so that they can be broken up over multiple lines.
+  This package enhances the typesetting of URLs in two ways.
+  First, it provides the \code{\\href[src=...]\{\}} command which
+  inserts PDF hyperlinks,
+    \href[src=http://www.sile-typesetter.org/]{like this}.
 
-It also provides the
-\code{\\href[src=...]\{\}} command which inserts PDF hyperlinks,
-\href[src=http://www.sile-typesetter.org/]{like this}.
+  The \code{\\href} command accepts the same \code{borderwidth},
+  \code{bordercolor}, \code{borderstyle} and \code{borderoffset} styling
+  options as the \code{\\pdf:link} command from the \code{pdf} package,
+  for instance
+  \href[src=http://www.sile-typesetter.org/, borderwidth=0.4pt,
+    bordercolor=blue, borderstyle=underline]{like this}.
 
-The \code{\\href} command accepts the same \code{borderwidth}, \code{bordercolor},
-\code{borderstyle} and \code{borderoffset} styling options as the \code{\\pdf:link} command
-from the \code{pdf} package, for instance
-\href[src=http://www.sile-typesetter.org/, borderwidth=0.4pt, bordercolor=blue, borderstyle=underline]{like this}.
+  Nowadays, it is a common practice to have URLs in print articles
+  (whether it is a good practice or not is yet \em{another} topic).
+  Therefore, the package also provides the \code{\\url} command, which will
+  automatically insert breakpoints into unwieldy
+  URLs like \url{https://github.com/simoncozens/sile/tree/master/examples/packages}
+  so that they can be broken up over multiple lines.
+
+  It allows line breaks after the colon, and before or after appropriate
+  segments of an URL (path elements, query parts, fragments, etc.).
+  By default, the \code{\\url} command ignores the current language,
+  as one would not want hyphenation to occur in URL segments. If you have no
+  other choice, however, you can pass it a \code{language} option
+  to enforce a language to be applied. Note that if French (\code{fr})
+  is selected, the special typographic rules applying to punctuations
+  in this language are disabled.
+
+  To typeset an URL and at the same type have it as active hyperlink,
+  one can use the \code{\\href} command without the \code{src} option,
+  but with the URL passed as argument.
+
+  The breaks are controlled by two penalty settings, \code{url.linebreak.primaryPenalty}
+  for preferred breakpoints and, for less acceptable but still tolerable breakpoints,
+  \code{url.linebreak.secondaryPenalty} – its value should
+  logically be higher than the previous one.
 \end{document}]]
 }


### PR DESCRIPTION
Here is my proposal for #1229 - Compared to the ticket, I have ended up adding a bit more flexibility. Sounds good to me in all my tests so far (but I can't have a test submitted, as the url package needs the pdf package which needs the libtexpdf backend, not the debug backend - If I am not mistaken).

Besides a brute force test (see below), looks decent too in my "test" article:

![image](https://user-images.githubusercontent.com/18075640/133884316-76fcdd44-cea6-469a-8e0f-46ffd466d32a.png)

(I would have preferred the `_` tto have a break after it, not before, but toying with the penalty settings, it was not much better with a very dense line, so I think they are quite OK finally... But of course the default penalties are at best a wild guess)

The brute force test, if one wants to play with it - 12 pages of URLs :smile_cat: - the decent scenario being of course the last.

```
\begin[papersize=6in x 9in]{document}
\script[src=packages/url]

\language[main=en]

1. Check the undocumented href is not broken

\href{https://my.site.org/proposition;2021/sile/test_url?name=Jack&age=50#hash-my-anchor}

2. Test url without language (default)

\script{
    local url = "https://my.site.org/proposition;2021/sile/test_url?name=John%20Doe&age=50#hash-my-anchor"
    for i = 7, 74 do
      SILE.typesetter:leaveHmode()
      for j = 1, i do
         SILE.typesetter:typeset("x")
      end 
      SILE.typesetter:typeset(" ")
      SILE.call("url", {}, { url }) 
    end
}

3a. test url with a language (English)

\script{
    local url = "https://my.site.org/proposition;2021/sile/test_url?name=John%20Doe&age=50#hash-my-anchor"
    for i = 7, 74 do
      SILE.typesetter:leaveHmode()
      for j = 1, i do
         SILE.typesetter:typeset("x")
      end 
      SILE.typesetter:typeset(" ")
      SILE.call("url", { language = "en" }, { url }) 
    end
}

\language[main=fr]

3b. test url with French: punctuation spacing rules should be disabled; except in this line!

\script{
    local url = "https://my.site.org/proposition;2021/sile/test_url?name=John%20Doe&age=50#hash-my-anchor"
    for i = 7, 74 do
      SILE.typesetter:leaveHmode()
      for j = 1, i do
         SILE.typesetter:typeset("x")
      end 
      SILE.typesetter:typeset(" ")
      SILE.call("url", { language = "fr" }, { url }) 
    end
}

\language[main=en]

4. test url with some flexible text content

\script{
    local url = "https://my.site.org/proposition;2021/sile/test_url?name=John%20Doe&age=50#hash-my-anchor"
    for i = 4, 44 do
      SILE.typesetter:leaveHmode()
      for j = 1, i do
         SILE.typesetter:typeset("x ")
      end 
      SILE.typesetter:typeset(" ")
      SILE.call("url", {}, { url }) 
    end
}

\end{document}
```
