### PR TITLE
Make docs match actual CLI behavior

### DIFF
--- a/core/sile.lua
+++ b/core/sile.lua
@@ -65,6 +65,7 @@ SILE.linebreak = require("core/break")
 require("core/frame")
 
 SILE.init = function ()
+  -- Set by def
   if not SILE.backend then
     if pcall(function () require("justenoughharfbuzz") end) then
       SILE.backend = "libtexpdf"
@@ -126,9 +127,9 @@ SILE.parseArguments = function ()
   cli:option("-d, --debug=VALUE", "show debug information for tagged aspects of SILE’s operation", {})
   cli:option("-e, --evaluate=VALUE", "evaluate some Lua code before processing file", {})
   cli:option("-f, --fontmanager=VALUE", "choose an alternative font manager")
-  cli:option("-m, --makedeps=[FILE]", "generate a list of dependencies in Makefile format")
-  cli:option("-o, --output=[FILE]", "explicitly set output file name")
-  cli:option("-I, --include=[FILE]", "include a class or SILE file before processing input", {})
+  cli:option("-m, --makedeps=FILE", "generate a list of dependencies in Makefile format")
+  cli:option("-o, --output=FILE", "explicitly set output file name")
+  cli:option("-I, --include=FILE", "include a class or SILE file before processing input", {})
   cli:flag("-t, --traceback", "display detailed location trace on errors and warnings")
   cli:flag("-h, --help", "display this help, then exit")
   cli:flag("-v, --version", "display version information, then exit", print_version)

--- a/sile.1.in
+++ b/sile.1.in
@@ -28,8 +28,10 @@ The default backend for producing PDF files is \fIlibtexpdf\fR.
 Other available backends include \fIcairo\fR, \fIdebug\fR, \fItext\fR, and \fIdummy\fR.
 .TP
 .BR \-d ", " \-\-debug= \fIvalue\fR[,\fIvalue\fR]
-Debug SILE's operation. Debug flags are comma separated.
+Debug SILE's operation.
+Multiple debug flags may be given as a comma separated list.
 While packages may define their own debug flags, the most commonly used ones are \fItypesetter\fR, \fIpagebuilder\fR, \fIvboxes\fR, \fIbreak\fR, \fIframes\fR, \fIprofile\fR, and \fIversions\fR.
+May be specified more than once.
 .TP
 .BR \-e ", " \-\-evaluate= \fIvalue\fR
 Evaluate some Lua code before processing the input file.
@@ -40,9 +42,8 @@ Choose an alternative font manager.
 The font manager is responsible for discovering the locations on font files on the system given a font name.
 The default font manager is \fIfontconfig\fR on non-Mac systems and \fImacfonts\fR on OS X.
 .TP
-.BR \-m ", " \-\-makedeps [\fB=\fIfile\fR]
+.BR \-m ", " \-\-makedeps \fIfile\fR
 Generate a list of dependencies in Makefile format.
-If no filename is specified, the input filename with .d appended will be used.
 .TP
 .BR \-o ", " \-\-output= \fIfile\fR
 Explicitly set the output file name.


### PR DESCRIPTION
See #1224.

This does not correct the problem, only documents the actual behavior. Since most of our proposed solutions actually involve a change from this anyway, at least aligning the documentation with what we're actually doing should be a place to start. This is especially important since a release is immanent and any changes to this behavior might not make the cut.
