### PR TITLE
ci(azure): Disable Windows CI until somebody actually works on it

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
-trigger:
-  - master
-  - devel
+trigger: none
+  # Disable Windows CI builds until somebody is actually working on fixing them
+  # - master
+  # - devel
 jobs:
 - job: Windows
   pool:


### PR DESCRIPTION
I'm tired of seeing a red X for something we're not currently bothering to even look at, much less expect to work. Also it takes time to even fail and wastes electrons.

As soon as anybody works on the Windows build we can enable this again.