### PR TITLE
Use italic mathvariant for \mi only if the content is a single character

### DIFF
--- a/packages/math.lua
+++ b/packages/math.lua
@@ -144,12 +144,12 @@ In the \code{math} syntax, every individual letter is an identifier (MathML tag
 are operators (tag \code{mo}). If it does not suit you, you can explicitly use
 the \code{\\mi}, \code{\\mn} or \code{\\mo} tags. For instance, \code{sin(x)}
 will be rendered as \math{sin(x)}, because SILE considers the letters s, i and n
-to be individual identifiers, and identifiers are italicized by default. To
-avoid that, you can specify that \math{\mo{sin}} is actually an operator by
-writing \code{\\mo\{sin\}(x)} and get: \math{\mo{sin}(x)}. If you prefer it in
-“double struck” style, this is permitted by the \code{mathvariant} attribute:
-\code{\\mo[mathvariant=double-struck]\{sin\}(x)} renders as
-\math{\mo[mathvariant=double-struck]{sin}(x)}.
+to be individual identifiers, and identifiers made of one character are
+italicized by default. To avoid that, you can specify that \math{\mi{sin}} is an
+identifier by writing \code{\\mi\{sin\}(x)} and get: \math{\mi{sin}(x)}. If you
+prefer it in “double struck” style, this is permitted by the \code{mathvariant}
+attribute: \code{\\mi[mathvariant=double-struck]\{sin\}(x)} renders as
+\math{\mi[mathvariant=double-struck]{sin}(x)}.
 
 To save you some typing, the math syntax lets you define macros with the
 following syntax:

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -22,11 +22,13 @@ function ConvertMathML(content)
     return b.stackbox('H', convertChildren(content))
   elseif content.command == 'mi' then
     local script = content.options.mathvariant and
-      b.mathVariantToScriptType(content.options.mathvariant) or b.scriptType.italic
+      b.mathVariantToScriptType(content.options.mathvariant)
     local text = content[1]
     if type(text) ~= "string" then
       SU.error("mi command contains "..text..", which is not text")
     end
+    script = script or (luautf8.len(text) == 1
+      and b.scriptType.italic or b.scriptType.upright)
     return b.text('identifier', script, text)
   elseif content.command == 'mo' then
     local script = content.options.mathvariant and


### PR DESCRIPTION
This changes the default script style for `\mi` to upright when the content is more than one character, so `\mi{sin}(\mi{x})` is sin(*x*) instead of *sin*(*x*).

MathML considers function names to be identifiers and uses U+2061 to add a space between the function name and argument in cases like sin *x*.