### PR TITLE
fix(math): Fix underover error with sub wider than base but no sup

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -672,10 +672,14 @@ elements.underOver = pl.class({
         widest = self.sub
         a = self.base
         b = self.sup
-      else
+      elseif self.sup then
         widest = self.sup
         a = self.base
         b = self.sub
+      else
+        widest = self.sub
+        a = self.base
+        b = nil
       end
     else
       if self.sup and self.base.width > self.sup.width then


### PR DESCRIPTION
```
\begin[mode=display]{math}
	\munder{base}{subsubsubsub}
\end{math}
```

Using `\munder{base}{sub}` with sub wider than base (as in the above example) produces this error:

```
/usr/local/share/sile/packages/math/base-elements.lua:695: attempt to index a nil value (local 'widest')
```

This fixes that.