### PR TITLE
fix(utilities): Set language of roman numerals to Latin to avoid casing issues

### DIFF
--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -533,7 +533,7 @@ setmetatable (utilities.formatNumber, {
           case = "upper"
         end
       end
-      local lang = SILE.settings.get("document.language")
+      local lang = format:match("[Rr][Oo][Mm][Aa][Nn]") and "la" or SILE.settings.get("document.language")
       format = format:lower()
       local result
       if self[lang] and type(self[lang][format]) == "function" then


### PR DESCRIPTION
My lowercase roman numerals were showing up with undotted-i'ss in
Turkish. Oops. Any time we're converting an integer to roman numerals
the output text language needs to be Latin.
