### PR TITLE
ci(azure): Update to `windows-2019` before deprecation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ trigger: none
 jobs:
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
     - checkout: self
       submodules: true
@@ -15,7 +15,7 @@ jobs:
 
       displayName: Set git user name and email
 
-    - script: cmake -G "Visual Studio 15 2017" -A x64 "-DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)" -S $(Build.SourcesDirectory) -B $(Build.BinariesDirectory)
+    - script: cmake -G "Visual Studio 16 2019" -A x64 "-DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)" -S $(Build.SourcesDirectory) -B $(Build.BinariesDirectory)
       displayName: Configure solution with CMake script
 
     - script: cmake --build $(Build.BinariesDirectory) --config Release


### PR DESCRIPTION
I'm far from an expert on this…just couldn't figure out how to stop telling `cmake` an explicit version (seems impossible), so couldn't use `windows-latest`, so went with `windows-2019` so it doesn't randomly break in future.

Cf. https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software

Closes #1282.