### PR TITLE
Assumes that fractions have both a numerator and denominator

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -965,35 +965,20 @@ elements.fraction = pl.class({
     elements.mbox._init(self)
     self.numerator = numerator
     self.denominator = denominator
-    if self.numerator then table.insert(self.children, self.numerator)
-    end
-    if self.denominator then table.insert(self.children, self.denominator)
-    end
+    table.insert(self.children, numerator)
+    table.insert(self.children, denominator)
   end,
   styleChildren = function(self)
-    if not (self.numerator or self.denominator) then
-      SU.error("Fraction cannot have both no numerator and no denominator")
-    end
-    if self.numerator then
-      self.numerator.mode = getNumeratorMode(self.mode)
-    end
-    if self.denominator then
-      self.denominator.mode = getDenominatorMode(self.mode)
-    end
+    self.numerator.mode = getNumeratorMode(self.mode)
+    self.denominator.mode = getDenominatorMode(self.mode)
   end,
   shape = function(self)
     -- Determine relative abscissas and width
     local widest, other
-    if self.numerator and self.denominator then
-      if self.denominator.width > self.numerator.width then
-        widest, other = self.denominator, self.numerator
-      else
-        widest, other = self.numerator, self.denominator
-      end
-    elseif self.numerator then widest, other = self.numerator, nil
-    elseif self.denominator then widest, other = self.denominator, nil
+    if self.denominator.width > self.numerator.width then
+      widest, other = self.denominator, self.numerator
     else
-      error("Fraction cannot have both no numerator and no denominator")
+      widest, other = self.numerator, self.denominator
     end
     widest.relX = SILE.length(0)
     other.relX = (widest.width - other.width) / 2
@@ -1004,44 +989,34 @@ elements.fraction = pl.class({
     local scaleDown = self:getScaleDown()
     self.axisHeight = constants.axisHeight * scaleDown
     self.ruleThickness = constants.fractionRuleThickness * scaleDown
-    if self.numerator then
-      if isDisplayMode(self.mode) then
-        self.numerator.relY = -self.axisHeight - self.ruleThickness/2 - SILE.length(math.max(
-          (constants.fractionNumDisplayStyleGapMin*scaleDown + self.numerator.depth):tonumber(),
-          constants.fractionNumeratorDisplayStyleShiftUp * scaleDown
-            - self.axisHeight - self.ruleThickness/2))
-      else
-        self.numerator.relY = -self.axisHeight - self.ruleThickness/2 - SILE.length(math.max(
-          (constants.fractionNumeratorGapMin*scaleDown + self.numerator.depth):tonumber(),
-          constants.fractionNumeratorShiftUp * scaleDown - self.axisHeight
-            - self.ruleThickness/2))
-      end
-    end
-    if self.denominator then
-      if isDisplayMode(self.mode) then
-        self.denominator.relY = -self.axisHeight + self.ruleThickness/2 + SILE.length(math.max(
-          (constants.fractionDenomDisplayStyleGapMin * scaleDown
-            + self.denominator.height):tonumber(),
-          constants.fractionDenominatorDisplayStyleShiftDown * scaleDown
-            + self.axisHeight - self.ruleThickness/2))
-      else
-        self.denominator.relY = -self.axisHeight + self.ruleThickness/2 + SILE.length(math.max(
-          (constants.fractionDenominatorGapMin * scaleDown
-            + self.denominator.height):tonumber(),
-          constants.fractionDenominatorShiftDown * scaleDown
-           + self.axisHeight - self.ruleThickness/2))
-      end
-    end
-    if self.numerator then
-      self.height = 0 - self.numerator.relY + self.numerator.height
+    if isDisplayMode(self.mode) then
+      self.numerator.relY = -self.axisHeight - self.ruleThickness/2 - SILE.length(math.max(
+        (constants.fractionNumDisplayStyleGapMin*scaleDown + self.numerator.depth):tonumber(),
+        constants.fractionNumeratorDisplayStyleShiftUp * scaleDown
+          - self.axisHeight - self.ruleThickness/2))
     else
-      self.height = self.axisHeight + self.ruleThickness / 2
+      self.numerator.relY = -self.axisHeight - self.ruleThickness/2 - SILE.length(math.max(
+        (constants.fractionNumeratorGapMin*scaleDown + self.numerator.depth):tonumber(),
+        constants.fractionNumeratorShiftUp * scaleDown - self.axisHeight
+          - self.ruleThickness/2))
     end
-    if self.denominator then
-      self.depth = self.denominator.relY + self.denominator.depth
+
+    if isDisplayMode(self.mode) then
+      self.denominator.relY = -self.axisHeight + self.ruleThickness/2 + SILE.length(math.max(
+        (constants.fractionDenomDisplayStyleGapMin * scaleDown
+          + self.denominator.height):tonumber(),
+        constants.fractionDenominatorDisplayStyleShiftDown * scaleDown
+          + self.axisHeight - self.ruleThickness/2))
     else
-      self.depth = SILE.length(0)
+      self.denominator.relY = -self.axisHeight + self.ruleThickness/2 + SILE.length(math.max(
+        (constants.fractionDenominatorGapMin * scaleDown
+          + self.denominator.height):tonumber(),
+        constants.fractionDenominatorShiftDown * scaleDown
+         + self.axisHeight - self.ruleThickness/2))
     end
+
+    self.height = self.numerator.height - self.numerator.relY
+    self.depth = self.denominator.relY + self.denominator.depth
   end,
   output = function(self, x, y, line)
     SILE.outputter:drawRule(

--- a/tests/math-fractions.expected
+++ b/tests/math-fractions.expected
@@ -260,6 +260,23 @@ My 	194.3421
 T	18 w=4.6500	(nil)
 My 	207.1421
 T	19 w=4.6500	(nil)
+Draw line	49.7638	240.4851	10.7360	0.6500
+Mx 	49.7638
+My 	238.6101
+Set font 	Libertinus Math;8;400;;normal;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	51.5958
+T	12 w=5.1840	(nil)
+Mx 	56.7798
+T	18 w=3.7200	(nil)
+Draw line	49.7638	250.0851	10.7360	0.6500
+Mx 	49.7638
+My 	257.8101
+T	2720 w=1.8320	(nil)
+Mx 	51.5958
+T	12 w=5.1840	(nil)
+Mx 	56.7798
+T	18 w=3.7200	(nil)
 Mx 	295.2916
 My 	780.6177
 Set font 	Gentium Plus;10;400;;normal;;LTR

--- a/tests/math-fractions.xml
+++ b/tests/math-fractions.xml
@@ -73,4 +73,9 @@ Fractions, display, TeX:
   + \frac{1}{2}
 </math>
 
+<math>
+  \frac{i+1}{}
+  \frac{}{i+1}
+</math>
+
 </sile>


### PR DESCRIPTION
In math/base-elements.lua, elements.fraction is written to support not receiving a numerator or denominator. The support is incorrect/doesn't function, though; in shape, if the numerator or denominator is missing, shape will set other to nil, then crash on trying to access other.width and trying to set other.relx.

This doesn't matter *in practice*, because the only caller to elements.fraction is math/typesetter.lua, which fails earlier if there's a missing numerator or denominator:

```
    local children = convertChildren(content)
    if #children ~= 2 then SU.error('Wrong number of children in mfrac: '
      ..#children)
    end
    return b.fraction(children[1], children[2])
```