### PR TITLE
fix(packages): Apply OpenType x and y offsets to color fonts

### DIFF
--- a/packages/color-fonts.lua
+++ b/packages/color-fonts.lua
@@ -32,6 +32,8 @@ SILE.shapers.harfbuzzWithColor = pl.class({
                 height = height,
                 depth = item.depth,
                 index = item.index,
+                x_offset = item.x_offset,
+                y_offset = item.y_offset,
                 text = text,
                 color = color,
               }


### PR DESCRIPTION
Closes #1147.

I had been struggling with this bothersome bug for quite a while, it really was hampering development of FRB American Cursive. I tried to fix it scores of times, but my attempts were way too complicated. Reading over the code again this fine evening, I discovered the error to be extremely elementary. :-D Hooray!

![image](https://user-images.githubusercontent.com/838783/147399835-a27f6263-bace-41f9-acef-feab1dbe18b5.png)
