### PR TITLE
Lint using Lua 5.4

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup ‘lua’
       uses: leafo/gh-actions-lua@v8
       with:
-        luaVersion: 5.3
+        luaVersion: 5.4
     - name: Setup ‘luarocks’
       uses: leafo/gh-actions-luarocks@v4
     - name: Setup ‘luacheck’

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "http://sile-typesetter.org",
   "devDependencies": {
-    "@commitlint/cli": "^16.0.2",
+    "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
-    "@commitlint/prompt": "^16.0.0",
+    "@commitlint/prompt": "^16.1.0",
     "commitizen": "^4.2.4",
     "conventional-changelog-cli": "^2.2.2",
     "husky": "^7.0.4",

--- a/spec/opentype_spec.lua
+++ b/spec/opentype_spec.lua
@@ -2,6 +2,14 @@ SILE = require("core/sile")
 SILE.backend = "debug"
 SILE.init()
 
+-- These tests depend on loading specific fonts from our test fixtures. Running
+-- plain `busted` is sometimes useful (e.g. for IDEs) but will not support this
+-- test because fontconfig hasn't been preloaded with the font paths it would
+-- need. If that's the case, just skip even defining these tests and call it
+-- good. To test a complete set of tests use `make busted`.
+local fcf = os.getenv("FONTCONFIG_FILE")
+if not fcf then return end
+
 describe("The OpenType loader/parser", function()
   local ot = SILE.require("core/opentype-parser")
   local face = SILE.shaper:getFace({ family = "Libertinus Serif" })


### PR DESCRIPTION
- ci(actions): Use Lua 5.4 to run Luacheck
- chore(tooling): Enable direct invocation of busted with limit tests
