### PR TITLE
Multi-line links and underlined contents conditional support

### DIFF
--- a/packages/pdf/init.lua
+++ b/packages/pdf/init.lua
@@ -82,38 +82,27 @@ function package:registerCommands ()
     })
   end)
 
-  self:registerCommand("pdf:link", function (options, content)
+  SILE.multiliner:register("pdf:link", function(x0, y0, x1, y1, height, _, options)
     local dest = SU.required(options, "dest", "pdf:link")
     local target = options.external and "/Type/Action/S/URI/URI" or "/S/GoTo/D"
     local borderwidth = options.borderwidth and SU.cast("measurement", options.borderwidth):tonumber() or 0
     local bordercolor = borderColor(SILE.color(options.bordercolor or "blue"))
     local borderoffset = SU.cast("measurement", options.borderoffset or "1pt"):tonumber()
     local borderstyle = borderStyle(options.borderstyle, borderwidth)
-    local llx, lly
-    SILE.typesetter:pushHbox({
-      value = nil,
-      height = SILE.measurement(0),
-      width = SILE.measurement(0),
-      depth = SILE.measurement(0),
-      outputYourself = function (_, typesetter, _)
-        llx = typesetter.frame.state.cursorX:tonumber()
-        lly = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY):tonumber()
-        pdf.begin_annotation()
-      end
-    })
-    local hbox = SILE.call("hbox", {}, content) -- hack
-    SILE.typesetter:pushHbox({
-      value = nil,
-      height = SILE.measurement(0),
-      width = SILE.measurement(0),
-      depth = SILE.measurement(0),
-      outputYourself = function (_, typesetter, _)
-        local d = "<</Type/Annot/Subtype/Link" .. borderstyle .. bordercolor .. "/A<<" .. target .. "(" .. dest .. ")>>>>"
-        local x = typesetter.frame.state.cursorX:tonumber()
-        local y = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + hbox.height):tonumber()
-        pdf.end_annotation(d, llx , lly - borderoffset, x, y + borderoffset)
-      end
-    })
+
+    local llx = x0:tonumber()
+    local lly = (SILE.documentState.paperSize[2] - y0):tonumber()
+    pdf.begin_annotation()
+    local d = "<</Type/Annot/Subtype/Link" .. borderstyle .. bordercolor .. "/A<<" .. target .. "(" .. dest .. ")>>>>"
+    local x = x1:tonumber()
+    local y = (SILE.documentState.paperSize[2] - y1 + height):tonumber()
+    pdf.end_annotation(d, llx , lly - borderoffset, x, y + borderoffset)
+  end)
+
+  self:registerCommand("pdf:link", function (options, content)
+    SILE.typesetter:enterMultiliner("pdf:link", options)
+    SILE.process(content)
+    SILE.typesetter:leaveMultiliner("pdf:link")
   end)
 
   self:registerCommand("pdf:metadata", function (options, _)

--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -728,7 +728,7 @@ function SILE.defaultTypesetter.addmarks (_, slice)
   end
   if endp then
     -- end of content marker
-    table.insert(slice, endp, SILE.nodefactory.hbox({
+    table.insert(slice, endp, SILE.nodefactory.zerohbox({
       outputYourself = function (_, typesetter, line)
         local x = typesetter.frame.state.cursorX
         local y = typesetter.frame.state.cursorY


### PR DESCRIPTION
This PR is a proposal for supporting multi-line PDF links #1239 and multi-line text underlining. It is split in three commits:
- Actual support in the `typesetter` (core)
- Use in the `rules` package (= `\underline`)
- Use in the `pdf` package (= `\pdf:link`, therefore the `\href` command from the `url` package automatically inherits the feature too).
  - Closes #1239,
  - Closes #424

The idea follows my early experiments mentioned in discussion #1292 but on other grounds and a different approach: start and end of contents in lines are "marked" with specific boxes, and unterminated links/underlines are repeated on each line until the termination is met. So technically, each line is a different link annotation (etc.)

While a cool feature, I consider it (a) still experimental and (b) somehow as a breaking change, so the feature is disabled by default (= behind a `typesetter.support.multiline` setting wihich is false by default). As it is, it SHOULD be transparent for users, and only enabled on-demand. My idea is that this setting could be removed or reversed to true in a subsequent feature-breaking release, while still being able to be checked and used cautiously.

Why would it be a breaking change? 
1. A moot point, but maybe some people were used to hbox'es overflowing the line.. :roll_eyes: 
2. For links with (rectangle) borders enabled, it will use the line height rather than the former hbox'd content height so it might be looking _slightly_ different... (though in a way more consistent)
3. It would likely need to be checked for the RTL and BTT cases... :shark: I am not able to do it properly.

Other than that, the result is pretty cool IMHO.

![image](https://user-images.githubusercontent.com/18075640/156803718-716167af-5dda-4c9e-9426-369b438957ea.png)

(blue underlines are `\href`'s annotations, regular black line are `\underline`'s, showing various cases and even nested at the end.)


