### PR TITLE
Leverage package documentation and manual (stage 0)

### DIFF
--- a/documentation/c03-input.sil
+++ b/documentation/c03-input.sil
@@ -173,11 +173,11 @@ a moment.}
 
 The parameters to a command are enclosed in square brackets and take the form
 \code{\em{key}=\em{value}};\break{}multiple parameters are separated by commas
-or semicolons, as in \code{[key1=value1,key2=value2,\dots]} Spaces around the
+or semicolons, as in \code{[key1=value1,key2=value2,…]} Spaces around the
 keys are not significant; we could equally write that as \code{[key1 = value1;
-key2 = value2; \dots]}. If you need to include a comma or semicolon within the
+key2 = value2; …]}. If you need to include a comma or semicolon within the
 value to a parameter, you can enclose the value in quotes: \code{[key1
-= "value1, still value 1", key2 = value2; \dots]}.
+= "value1, still value 1", key2 = value2; …]}.
 
 The optional argument (of which there can only be at most one) is enclosed in
 curly braces.\footnote{TeX users may forget this and try adding a command

--- a/documentation/c04-useful.sil
+++ b/documentation/c04-useful.sil
@@ -11,9 +11,9 @@ obscure corners as the documentation progresses.
 The most basic command for altering the look of the text is the \code{\\font}
 command; it takes two forms:
 
-\noindent{}• \code{\\font[\em{parameters\dots}]\{\em{argument}\}}
+\noindent{}• \code{\\font[\em{parameters…}]\{\em{argument}\}}
 
-\noindent{}• \code{\\font[\em{parameters\dots}]}
+\noindent{}• \code{\\font[\em{parameters…}]}
 
 The first form sets the given argument text in the specified font; the
 second form changes the font used to typeset text from this point on.
@@ -102,8 +102,8 @@ text. This will affect both font shaping and hyphenation.
 \medskip
 
 It’s quite fiddly to be always changing font specifications manually; later
-we’ll see some ways to automate the process. SILE provides the \code{\\em\{\dots\}}
-command as a shortcut for \code{\\font[style=italic]\{\dots\}}.
+we’ll see some ways to automate the process. SILE provides the \code{\\em\{…\}}
+command as a shortcut for \code{\\font[style=italic]\{…\}}.
 There is no shortcut for boldface, because boldface isn’t good typographic
 practice and so we don’t want to make it easy for you to make bad books.
 
@@ -123,8 +123,8 @@ for example, the document you are currently reading begins with the command
 \subsection{Chapters and Sections}
 
 If you choose the book class, you can divide your document into different
-sections using the commands \code{\\chapter\{\dots\}},
-\code{\\section\{\dots\}} and \code{\\subsection\{\dots\}}. The argument to
+sections using the commands \code{\\chapter\{…\}},
+\code{\\section\{…\}} and \code{\\subsection\{…\}}. The argument to
 each command is the name of the chapter or section respectively; chapters will
 be opened on a new right-hand page, and the chapter name will form the left
 running header. Additionally, the section name and number will form the right
@@ -139,7 +139,7 @@ This subsection begins with the command \code{\\subsection\{Chapters and Section
 
 \subsection{Footnotes}
 
-Footnotes can be added to a book with the \code{\\footnote\{\dots\}} command.\footnote{Like this: \code{\\footnote\{Like this.\}}} The
+Footnotes can be added to a book with the \code{\\footnote\{…\}} command.\footnote{Like this: \code{\\footnote\{Like this.\}}} The
 argument to the command will be set as a footnote at the bottom of the page;
 footnotes are automatically numbered from 1 at the start of each chapter.
 
@@ -166,7 +166,7 @@ the smallest to the largest, \code{\\thinspace} (1/6th of an em), \code{\\enspac
 
 \begin{center}
 You can center a paragraph of text by wrapping it in the \code{center} environment.
-(\code{\\begin\{center\} \dots \\end\{center\}}). This paragraph is centered on the
+(\code{\\begin\{center\} … \\end\{center\}}). This paragraph is centered on the
 page.
 \end{center}
 
@@ -235,7 +235,7 @@ for instance, you may wish to write a thesis like this:
 \\include[src=chap1.sil]
 \\include[src=chap2.sil]
 \\include[src=chap3.sil]
-\dots\par
+…\par
 \\include[src=endmatter.sil]
 \\end\{document\}
 \line
@@ -267,12 +267,12 @@ available at runtime. Just as one can run Javascript code from within a HTML
 document using a \code{<script>} tag, one can run Lua code from within a SILE
 document using a \code{\\script} command. (It looks better in XML-flavor.) This
 command has two forms: \code{\\script[src=\em{<filename>}]} which includes a Lua
-file, and \code{\\script\{\dots\}} which runs Lua code inline.
+file, and \code{\\script\{…\}} which runs Lua code inline.
 
 Doing anything interesting inline requires knowledge of the internals of SILE,
 (thankfully the code is not that hard to read)
-but to get you started, the Lua function \code{SILE.typesetter:typeset(\dots)}
-will add text to a page, \code{SILE.call("\dots")} will call a SILE command,
+but to get you started, the Lua function \code{SILE.typesetter:typeset(…)}
+will add text to a page, \code{SILE.call("…")} will call a SILE command,
 and \code{SILE.typesetter:leaveHmode()} ends the current paragraph and outputs the
 text. So, for example:
 

--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -172,6 +172,9 @@ basic functionality to other packages and classes. Classes such as the
 
 \section{Experimental packages}
 
+\subsection{autodoc}
+\package-documentation[src=packages/autodoc]
+
 \subsection{balanced-frames}
 \package-documentation[src=packages/balanced-frames]
 

--- a/documentation/c07-settings.sil
+++ b/documentation/c07-settings.sil
@@ -11,7 +11,7 @@ Settings in SILE are \em{namespaced} so that 1) the name of the setting gives yo
 some kind of clue as to what area of the system it will affect, and 2) packages
 can define their own settings without worrying that they will be interfering
 with other packages or the SILE internals. Namespacing of settings takes the
-form \code{\em{area.name}}—so for instance, \code{typesetter.orphanpenalty} is
+form \code{\em{area.name}}—so for instance, \autodoc:setting{typesetter.orphanpenalty} is
 the setting which changes how the typesetter penalizes orphan (end-of-paragraph)
 lines.
 
@@ -86,14 +86,14 @@ from the most obvious and moving towards the most subtle.
 
 \section{Spacing Settings}
 
-In our \code{\\note} example, we saw the setting \code{document.lskip}.
+In our \code{\\note} example, we saw the setting \autodoc:setting{document.lskip}.
 This is a \em{glue} parameter which is added to the left side of every line.
 Setting this to a positive length effectively increases the left margin of
-the text. Similarly, \code{document.rskip} adds some space to the right side of
+the text. Similarly, \autodoc:setting{document.rskip} adds some space to the right side of
 every line.
 
 Note that these skip settings are not the same as page margins. The
-\code{document.lskip} and \code{document.rskip} values are applied inside of the
+\autodoc:setting{document.lskip} and \autodoc:setting{document.rskip} values are applied inside of the
 current frame and are relative to the edge of the frame, not to the edge of the
 page. They are best used for temporary adjustments to the margins relative to the
 normal margins, such as to indent a pull-quote. They can also be negative,
@@ -145,23 +145,23 @@ paragraphs.\par
 \set[parameter=document.rskip,value=0pt]%
 \set[parameter=document.spaceskip]%
 The indentation at the start of each paragraph is controlled by the
-setting \code{document.parindent}; this is a glue parameter, and by default it’s
+setting \autodoc:setting{document.parindent}; this is a glue parameter, and by default it’s
 set to 20pt with no stretch and shrink. Actually, the amount added to the
-start of the paragraph is \code{current.parindent}. After each paragraph,
-\code{current.parindent} is reset to the value of \code{document.parindent}. The
-\code{\\noindent} command works by setting \code{current.parindent} to zero.
+start of the paragraph is \autodoc:setting{current.parindent}. After each paragraph,
+\autodoc:setting{current.parindent} is reset to the value of \autodoc:setting{document.parindent}. The
+\code{\\noindent} command works by setting \autodoc:setting{current.parindent} to zero.
 
 \medskip%
 \set[parameter=current.parindent,value=-20pt]%
 \set[parameter=document.lskip,value=20pt]%
 How would you make a paragraph like this with a ‘hanging’ indentation? We’ve
-set the \code{document.lskip} to 20 points, and the \code{current.parindent} to
+set the \autodoc:setting{document.lskip} to 20 points, and the \autodoc:setting{current.parindent} to
 \em{minus} 20 points. (In other words, we called:\break\code{\\set[parameter=document.lskip,value=20pt]} and \code{\\set[parameter=current.parindent,\break{}value=-20pt]}.)
 
 \medskip%
 \set[parameter=document.lskip,value=0pt]%
 The space between \em{paragraphs} is set with the glue parameter
-\code{document.parskip}. It’s normally set to five points with one point of stretchability.
+\autodoc:setting{document.parskip}. It’s normally set to five points with one point of stretchability.
 
 \subsection{Line spacing settings}
 
@@ -170,10 +170,11 @@ As we mentioned in the section on grid typesetting, the rules for spacing betwee
 rules. Let’s reiterate those rules now in terms of settings:
 
 \noindent• SILE tries to insert space between two successive lines to make their
-baselines exactly \code{document.baselineskip} apart.
+baselines exactly \autodoc:setting{document.baselineskip} apart.
 
 \noindent• If this first rule would mean that the bottom and the top of the lines are less
-than \code{document.lineskip} apart, then they are forced to be \code{document.lineskip} apart.
+than \autodoc:setting{document.lineskip} apart, then they are forced to be
+\autodoc:setting{document.lineskip} apart.
 
 \note{This linebreaking method is fiddly, and book designers may prefer to
 work with the tools provided by the \code{linespacing} package.}
@@ -190,23 +191,23 @@ between words is \code{<shaper.spaceenlargementfactor> * <space> plus
 \code{1.2 <space> plus 0.5 <space> minus 0.333 <space>}.
 
 If you want to set the word space width explicitly, you can set the
-\code{document.spaceskip} setting. You will also need to turn \em{off} the
-setting \code{shaper.variablespaces}, which allows the width of a space
+\autodoc:setting{document.spaceskip} setting. You will also need to turn \em{off} the
+setting \autodoc:setting{shaper.variablespaces}, which allows the width of a space
 to vary based on context (otherwise known as “space kerning”). If you want
 to go back to the default (measuring the space character of the font),
-then you need to turn on \code{shaper.variablespaces} (set it to a
-true value) and also \em{unset} the setting \code{document.spaceskip}. To
+then you need to turn on \autodoc:setting{shaper.variablespaces} (set it to a
+true value) and also \em{unset} the setting \autodoc:setting{document.spaceskip}. To
 unset it, just call \code{\\set} with no \code{value} parameter:
 \code{\\set[parameter=document.spaceskip]}.
 
 \subsection{Letter spacing settings}
 
-You can also put spaces in between \em{letters} with the \code{document.letterspaceglue} setting.
+You can also put spaces in between \em{letters} with the \autodoc:setting{document.letterspaceglue} setting.
 
 \set[parameter=document.letterspaceglue,value=0pt plus 4pt]
 
 This paragraph
-is set with \code{document.letterspaceglue} set to \code{0pt plus 4pt},
+is set with \autodoc:setting{document.letterspaceglue} set to \code{0pt plus 4pt},
 which allows the typesetter to insert tiny bits of spacing between the
 letters to improve the fitting of the paragraph, even though it would
 prefer to keep the letterspacing at zero points if possible. (Letter
@@ -216,7 +217,7 @@ spacing is not considered a preferable way to solve justification problems.)
 \set[parameter=document.letterspaceglue,value=0.3pt]
 
 This paragraph
-is set with \code{document.letterspaceglue} set to \code{0.3pt},
+is set with \autodoc:setting{document.letterspaceglue} set to \code{0.3pt},
 which \em{forces} the typesetter to insert tiny bits of
 spacing between the letters. Frederic Goudy is credited with
 saying that anyone who would letterspace lowercase would steal sheep.\footnote{He was probably talking about blackletter, but it’s still true.}
@@ -228,7 +229,7 @@ saying that anyone who would letterspace lowercase would steal sheep.\footnote{H
 The settings which affect SILE’s spacing controls have the most obvious effect
 on a document; the typesetter itself has some knobs that can be twiddled:
 
-\code{typesetter.widowpenalty} and \code{typesetter.orphanpenalty}\footnote{TeX
+\autodoc:setting{typesetter.widowpenalty} and \autodoc:setting{typesetter.orphanpenalty}\footnote{TeX
 users, please notice the renaming.} affect how strongly SILE is averse to
 leaving stray lines at the start and end of pages. A \em{widow} happens when
 a page is broken leaving one line at the bottom of a page; an \em{orphan} line
@@ -244,7 +245,7 @@ would apply justification to the entire paragraph, including the last line,
 and produce a fully justified paragraph. (Normally we want the last line of a justified paragraph to be
 left-aligned.)
 The size of this glue is defined in the setting
-\code{typesetter.parfillskip}. Its default value is \code{0pt plus 10000pt} but
+\autodoc:setting{typesetter.parfillskip}. Its default value is \code{0pt plus 10000pt} but
 for this current paragraph, we have unset it.
 
 Now we can finally complete our implementation of centering:
@@ -287,32 +288,32 @@ been adapted as appropriate. Here is a quick run-down of the settings
 applicable to the line-breaking algorithm. You are expected to know what you
 are doing with these.
 
-\noindent• \code{linebreak.tolerance}: How bad a breakpoint is before it is rejected
+\noindent• \autodoc:setting{linebreak.tolerance}: How bad a breakpoint is before it is rejected
 by the algorithm. (Default: 500)
 
-\noindent• \code{linebreak.parshape}: Whether to utilize a callback to \code{SILE.linebreak:parShape()} to get a customized shape for each line in a paragraph. (Default: false)
+\noindent• \autodoc:setting{linebreak.parShape}: Whether to utilize a callback to \code{SILE.linebreak:parShape()} to get a customized shape for each line in a paragraph. (Default: false)
 
-\noindent• \code{linebreak.pretolerance}: If there are no breakpoints better than
+\noindent• \autodoc:setting{linebreak.pretolerance}: If there are no breakpoints better than
 this, the paragraph is considered for hyphenation. (Default: 100)
 
-\noindent• \code{linebreak.hangIndent}: How far to indent initial line(s) of a paragraph. (Default: 0)
+\noindent• \autodoc:setting{linebreak.hangIndent}: How far to indent initial line(s) of a paragraph. (Default: 0)
 
-\noindent• \code{linebreak.hangAfter}: An integer count of how many lines should have \code{linebreak.hangIndent} applied. (Default: nil)
+\noindent• \autodoc:setting{linebreak.hangAfter}: An integer count of how many lines should have \autodoc:setting{linebreak.hangIndent} applied. (Default: nil)
 
-\noindent• \code{linebreak.adjdemerits}: Additional demerits which are accumulated in the course of paragraph building when two consecutive lines are visually incompatible. In these cases, one line is built with much space for justification, and the other one with little space. (Default: 10000)
+\noindent• \autodoc:setting{linebreak.adjdemerits}: Additional demerits which are accumulated in the course of paragraph building when two consecutive lines are visually incompatible. In these cases, one line is built with much space for justification, and the other one with little space. (Default: 10000)
 
-\noindent• \code{linebreak.looseness}: How many lines the current paragraph should
+\noindent• \autodoc:setting{linebreak.looseness}: How many lines the current paragraph should
 be made longer than normal. (Default: 0)
 
-\noindent• \code{linebreak.prevGraf}: The number of lines in the paragraph last added to the vertical list.
+\noindent• \autodoc:setting{linebreak.prevGraf}: The number of lines in the paragraph last added to the vertical list.
 
-\noindent• \code{linebreak.emergencyStretch}: Assumed extra stretchability in lines of a paragraph. (Default: 0)
+\noindent• \autodoc:setting{linebreak.emergencyStretch}: Assumed extra stretchability in lines of a paragraph. (Default: 0)
 
-\noindent• \code{linebreak.linePenalty}: Penalty value associated with each line break. (Default: 10)
+\noindent• \autodoc:setting{linebreak.linePenalty}: Penalty value associated with each line break. (Default: 10)
 
-\noindent• \code{linebreak.hyphenPenalty}: Penalty associated with break at a hyphen. (Default: 50)
+\noindent• \autodoc:setting{linebreak.hyphenPenalty}: Penalty associated with break at a hyphen. (Default: 50)
 
-\noindent• \code{linebreak.doubleHyphenDemerits}: Penalty for consecutive lines ending with a hyphen. (Default: 10000)
+\noindent• \autodoc:setting{linebreak.doubleHyphenDemerits}: Penalty for consecutive lines ending with a hyphen. (Default: 10000)
 
 \section{Shaper settings}
 
@@ -322,7 +323,7 @@ the process of selecting and positioning the glyphs from a font–turning
 the text that we type into the boxes that SILE puts together on a line.}
 The default shaping engine, Harfbuzz, can actually call out to other shaping
 engines instead of doing the shaping itself. SILE provides an interface
-(through the \code{harfbuzz.subshapers} setting) to select the shaping
+(through the \autodoc:setting{harfbuzz.subshapers} setting) to select the shaping
 engine in use. To get a list of the subshapers enabled in your build of
 Harfbuzz, run \code{sile --debug=versions} on any file:
 

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -107,8 +107,8 @@ in \code{[Uu]+<code>} or Hexadecimal \code{0[Xx]<code>} format – for instance
 
 SILE comes with a special “language” called \code{und}, which has no hyphenation
 patterns available. If you switch to this language, text will not be hyphenated.
-The command \code{\\nohyphenation\{\dots\}} is provided as a shortcut for
-\code{\\font[language=und]\{\dots\}}.
+The command \code{\\nohyphenation\{…\}} is provided as a shortcut for
+\code{\\font[language=und]\{…\}}.
 
 The hyphenator uses the same algorithm as TeX and can use TeX hyphenation
 pattern files if they are converted to Lua format. To implement hyphenation

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -127,7 +127,7 @@ selection:
 SILE inserts word break opportunities after Ethiopic word spaces and full
 stops. Amharic can be typeset in two styles: with space surrounding
 punctuation or space after punctuation. You can set the setting
-\code{languages.am.justification} to either \code{left} or \code{centered}
+\autodoc:setting[check=false]{languages.am.justification} to either \code{left} or \code{centered}
 to control which style is used. The default is \code{left}
 
 \begin{verbatim}
@@ -152,8 +152,9 @@ and “high” punctuation (a thin fixed space before question marks, exclamatio
 marks, semicolons and an inter-word space before colons), and also spaces
 within “guillemets” (quotation marks). SILE will automatically apply the
 correct space. The size of these spaces is determined by
-\code{languages.fr.thinspace}, \code{languages.fr.colonspace} and
-\code{languages.fr.guillspace}.
+\autodoc:setting[check=false]{languages.fr.thinspace},
+\autodoc:setting[check=false]{languages.fr.colonspace} and
+\autodoc:setting[check=false]{languages.fr.guillspace}.
 
 \subsection{Japanese / Chinese}
 
@@ -184,7 +185,7 @@ Uyghur is the only Arabic script based language which uses hyphenation,
 and SILE supports hyphenation. Because Arabic fonts aren’t normally designed
 with hyphenation in mind, you may need to tweak some settings to ensure that
 Uyghur is typeset correctly. As well as choosing the \code{hyphenchar} (see
-the hyphenation section above), the setting \code{languages.ug.hyphenoffset}
+the hyphenation section above), the setting \autodoc:setting[check=false]{languages.ug.hyphenoffset}
 inserts a space between the text and the hyphen.
 
 \end{document}

--- a/documentation/c09-concepts.sil
+++ b/documentation/c09-concepts.sil
@@ -128,8 +128,8 @@ and instructions to the output engine to display the image:
 \begin{verbatim}
 \line
 SILE.typesetter:pushHbox(\{
-  width= \dots,
-  height= \dots,
+  width= …,
+  height= …,
   depth= 0,
   value= options.src,
   outputYourself= function (this, typesetter, line)

--- a/documentation/c09-concepts.sil
+++ b/documentation/c09-concepts.sil
@@ -97,7 +97,7 @@ useful while writing a document). A related but higher level command,
 \code{\\par}, is more frequently used when writing a document and embeded in
 the content. The \code{\\par} command first calls
 \code{SILE.typesetter:leaveHmode()}, then inserts a vertical skip according to
-the \\code{document.parskip} setting, then goes on to reset a number of
+the \autodoc:setting{document.parskip} setting, then goes on to reset a number of
 settings that are typically paragraph related such as hanging indents.
 
 When writing a custom command, if you want to manually add a vertical space to

--- a/documentation/macros.sil
+++ b/documentation/macros.sil
@@ -12,7 +12,6 @@
 \script[src=packages/pdf]
 \script[src=packages/pullquote]
 \script[src=packages/rules]
-\define[command=dots]{…}
 \define[command=notehead]{\noindent\bf{\process}\par\medskip}
 \define[command=line]{\novbreak\skip[height=5pt]\noindent\hrule[width=450pt,height=0.3pt]\par\novbreak\skip[height=5pt]}
 \define[command=note]{\medskip

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -5,8 +5,8 @@
 \set[parameter=document.baselineskip,value=3ex]
 \font[size=11pt,family=Gentium Book Basic]
 \nofolios
-\pdf:metadata[key=Title, val=The SILE Book]
-\pdf:metadata[key=Author, val=Simon Cozens]
+\pdf:metadata[key=Title, value=The SILE Book]
+\pdf:metadata[key=Author, value=Simon Cozens]
 
 \begin[family=Roboto Condensed,weight=600,size=50pt]{font}
 \begin[parameter=document.baselineskip,value=1.5ex]{set}

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -63,23 +63,23 @@ end, "Outputs a settings name in code, ensuring good line breaks and possibly ch
 
 return {
   documentation = [[\begin{document}
-This package extracts documentation from other packages. It’s used to
-construct the SILE documentation. Doing this allows us to keep the
-documentation near the implementation, which (in theory) makes it easy
+This package extracts documentation information from other packages. It’s used to
+construct the SILE manual. Keeping package documentation in the package itself
+keeps the documentation near the implementation, which (in theory) makes it easy
 for documentation and implementation to be in sync.
 
-For that purpose, it provides the code{\\package-documentation[src=\em{package}]}
+For that purpose, it provides the \code{\\package-documentation[src=\em{package}]}
 command.
 
 Properly documented packages should export a \code{documentation} string
 containing their documentation, as a SILE document.
 
-For documenters and package designers, it also provides commands that can be used in their package
-documentations to present various pieces of information in a consistent way.
+For documenters and package authors, it also provides commands that can be used in their package
+documentation to present various pieces of information in a consistent way.
 
-Setting names can be fairly long (\em{namespace.area.some-stuff}).
+Setting names can be fairly long (e.g. \em{namespace.area.some-stuff}).
 The \code{\\autodoc:setting} command helps line-breaking them automatically at
-appropriate points, so that package designers do not have care about it
+appropriate points, so that package authors do not have care about them
 manually.
 
 \end{document}]]

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -77,14 +77,10 @@ containing their documentation, as a SILE document.
 For documenters and package designers, it also provides commands that can be used in their package
 documentations to present various pieces of information in a consistent way.
 
-Settings are usually namespaced and be fairly long (\em{namespace.area.some-stuff}).
+Setting names can be fairly long (\em{namespace.area.some-stuff}).
 The \code{\\autodoc:setting} command helps line-breaking them automatically at
 appropriate points, so that package designers do not have care about it
 manually.
-
-\note{
-  This is just a start. More helper commands are planned.
-}
 
 \end{document}]]
 }

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -1,3 +1,7 @@
+--
+-- Documentation tooling for package designers.
+--
+
 SILE.registerCommand("package-documentation", function (options, _)
   local package = SU.required(options, "src", "src for package documentation")
   SU.debug("autodoc", package)
@@ -12,12 +16,75 @@ SILE.registerCommand("package-documentation", function (options, _)
   )
 end)
 
+-- Styling hook
+
+SILE.registerCommand("autodoc:style", function (_, content)
+  -- options.type can be used to distinguish the type of item and style
+  -- it accordingly, redefining this command.
+  -- Here by default, though, just typeset it in \code.
+  SILE.call("code", {}, content)
+end)
+
+-- Documenting a setting with good line-breaks
+
+local inputfilter = SILE.require("packages/inputfilter").exports
+local settingFilter = function (node, content)
+  if type(node) == "table" then return node end
+  local result = {}
+  for token in SU.gtoke(node, "[%.]") do
+    if token.string then
+      result[#result+1] = token.string
+    else
+        result[#result+1] = token.separator
+        result[#result+1] = inputfilter.createCommand(
+          content.pos, content.col, content.line,
+          "penalty", { penalty = 100 }, nil
+        )
+    end
+  end
+  return result
+end
+
+SILE.registerCommand("autodoc:setting", function (options, content)
+  if type(content) ~= "table" then SU.error("Expected a table content") end
+  if #content ~= 1 then SU.error("Expected a single element") end
+  local name = type(content[1] == "string") and content[1]
+  if not name then SU.error("Unexpected setting '"..name.."'") end
+  -- Conditional existence check (can be disable is passing check=false), e.g.
+  -- for settings that would be define in another context.
+  if SU.boolean(options.check, true) then
+    SILE.settings.get(name) -- will issue an error if unknown
+  end
+  -- Inserts breakpoints after dots
+  local nameWithBreaks = inputfilter.transformContent(content, settingFilter)
+
+  SILE.call("autodoc:style", { type = "setting" }, nameWithBreaks)
+end, "Outputs a settings name in code, ensuring good line breaks and possibly checking their existence.")
+
 return {
-  documentation = [[
-  \begin{document}
+  documentation = [[\begin{document}
 This package extracts documentation from other packages. It’s used to
 construct the SILE documentation. Doing this allows us to keep the
 documentation near the implementation, which (in theory) makes it easy
 for documentation and implementation to be in sync.
-  \end{document}]]
+
+For that purpose, it provides the code{\\package-documentation[src=\em{package}]}
+command.
+
+Properly documented packages should export a \code{documentation} string
+containing their documentation, as a SILE document.
+
+For documenters and package designers, it also provides commands that can be used in their package
+documentations to present various pieces of information in a consistent way.
+
+Settings are usually namespaced and be fairly long (\em{namespace.area.some-stuff}).
+The \code{\\autodoc:setting} command helps line-breaking them automatically at
+appropriate points, so that package designers do not have care about it
+manually.
+
+\note{
+  This is just a start. More helper commands are planned.
+}
+
+\end{document}]]
 }

--- a/packages/chordmode.lua
+++ b/packages/chordmode.lua
@@ -130,7 +130,7 @@ into:
 
 The chords can be styled by redefining the \code{chordmode:chordfont}
 command, and the offset between the chord name and text set with the
-\code{chordmode:offset} parameter.
+\autodoc:setting{chordmode.offset} parameter.
 
 \end{document}
 ]]

--- a/packages/color.lua
+++ b/packages/color.lua
@@ -20,7 +20,7 @@ represents a hexadecimal digit (\code{#000} is black, \code{#fff} is white,
 
 \note{The HTML and CSS named colors can be found at \code{http://dev.w3.org/csswg/css-color/#named-colors}.}
 
-So, for example, \color[color=red]{this text is typeset with \code{\\color[color=red]\{\dots\}}}.
+So, for example, \color[color=red]{this text is typeset with \code{\\color[color=red]\{…\}}}.
 
 Here is a rule typeset with \code{\\color[color=#22dd33]}:
 \color[color=#ffdd33]{\hrule[width=120pt,height=0.5pt]}

--- a/packages/dropcaps.lua
+++ b/packages/dropcaps.lua
@@ -86,7 +86,7 @@ This may be useful for passing OpenType options or other font preferences.
 \begin{note}
 One caveat is that the size of the initials is calculated using the default linespacing mechanism.
 If you are using an alternative method from the linespacing package, you might see strange results.
-Set the \code{document.baselineskip} to approximate your effective leading value for best results.
+Set the \autodoc:setting{document.baselineskip} to approximate your effective leading value for best results.
 If that doesn't work set the size manually.
 Using \code{SILE.setCommandDefaults()} can be helpful for so you don't have to set the size every time.
 \end{note}

--- a/packages/image.lua
+++ b/packages/image.lua
@@ -32,8 +32,8 @@ As well as processing text, SILE can also include images.
 
 Loading the \code{image} package gives you the \code{\\img} command, fashioned
 after the HTML equivalent. \code{\\img} takes the following parameters:
-\code{src=\dots} must be the path to an image file;
-you may also give \code{height=\dots} and/or \code{width=\dots} parameters
+\code{src=…} must be the path to an image file;
+you may also give \code{height=…} and/or \code{width=…} parameters
 to specify the output size of the image on the paper. If the size parameters
 are not given, then the image will be output at its ‘natural’ size,
 honoring its resolution if available.

--- a/packages/linespacing.lua
+++ b/packages/linespacing.lua
@@ -143,7 +143,7 @@ users of TeX, but it is not the most friendly system for book designers. The
 \code{linespacing} package provides a better choice of leading systems.
 
 After loading the package (with \code{\\script[src=packages/linespacing]}),
-you are able to choose the linespacing mode by setting the \code{linespacing.method}
+you are able to choose the linespacing mode by setting the \autodoc:setting{linespacing.method}
 parameter. The following examples have funny sized words in them so that you can see
 how the different methods interact.
 
@@ -153,7 +153,7 @@ By default, this is set to \code{tex}. The other options available are:
 \set[parameter=linespacing.method,value=fixed]
 \set[parameter=linespacing.fixed.baselinedistance,value=1.5em]
 \noindent{}• \code{fixed}. This set the lines at a fixed baseline-to-baseline distance,
-determined by the \code{linespacing.\goodbreak{}fixed.baselinedistance} parameter. You
+determined by the \autodoc:setting{linespacing.fixed.baselinedistance} parameter. You
 can specify this parameter either relative to the type size (e.g. \code{1.2em})
 or as a absolute distance (\code{15pt}). This paragraph is set with a fixed 1.5em
 baseline-to-baseline distance.
@@ -168,7 +168,7 @@ You generally don’t want to use this as is.
 \set[parameter=linespacing.fit-glyph.extra-space,value=5pt]
 
 What you probably want to do is insert a constant (relative or absolute) s\font[size=20pt]{p}ace
-between the lines by setting the \code{linespacing.fit-glyph.extra-space} parameter.
+between the lines by setting the \autodoc:setting{linespacing.fit-glyph.extra-space} parameter.
 \font[size=20pt]{T}his paragraph is set with 5 points of space between the descenders and the ascenders.
 
 \medskip
@@ -183,13 +183,13 @@ boxes, this may not work so well.
 \set[parameter=linespacing.fit-font.extra-space,value=5pt]
 
 As with \code{fit-glyph}, you can insert extra space between the lines with the
-\code{linespacing.fit-font.\goodbreak{}extra-space} parameter.
+\autodoc:setting{linespacing.fit-font.extra-space} parameter.
 
 \medskip
 \set[parameter=linespacing.method,value=css]
 \set[parameter=linespacing.css.line-height,value=2em]
 \noindent{}• \code{css}. This is similar to the method used in browsers; the baseline
-distance is set with the \code{linespacing.\goodbreak{}css.line-height} parameter, and the excess
+distance is set with the \autodoc:setting{linespacing.css.line-height} parameter, and the excess
 \font[size=20pt]{space} between this parameter and the actual height of the line is distributed
 between the top and bottom of the line.
 \medskip

--- a/packages/math.lua
+++ b/packages/math.lua
@@ -22,7 +22,7 @@ system\footnote{A list of freely available math fonts can be found at
 \href[src=https://www.ctan.org/pkg/unicode-math]{https://www.ctan.org/pkg/unicode-math}}.
 By default, this package uses Libertinus Math, so it will fail if Libertinus
 Math can’t be found. Another font may be specified via the setting
-\code{math.font.family}.
+\autodoc:setting{math.font.family}.
 
 The first way to typeset math formulas is to enter them in the MathML format.
 MathML is a standard for encoding mathematical notation for the Web and for

--- a/packages/url.lua
+++ b/packages/url.lua
@@ -168,9 +168,9 @@ To typeset an URL and at the same type have it as active hyperlink,
 one can use the \code{\\href} command without the \code{src} option,
 but with the URL passed as argument.
 
-The breaks are controlled by two penalty settings, \code{url.linebreak.primaryPenalty}
+The breaks are controlled by two penalty settings, \autodoc:setting{url.linebreak.primaryPenalty}
 for preferred breakpoints and, for less acceptable but still tolerable breakpoints,
-\code{url.linebreak.secondaryPenalty}—its value should
+\autodoc:setting{url.linebreak.secondaryPenalty}—its value should
 logically be higher than the previous one.
 \end{document}]]
 }


### PR DESCRIPTION
This is a subset of the concerns addressed in #1194 
I have been sitting far too long on it - and my previous attempts ended up being very messy, so it's preferable (I think) to proceed by small steps. Hence the "stage 0" in the PR title.

1. Removal of the `\dots` command in the SILE Manual and package documentations.
   - _SILE doesn't do that_... There are plenty of other characters directly in Unicode in the Manual and package documentations (e.g. em-dashes, quotes, etc.), so there's no good reason introducing this only shortcut in the Manual and have package documentations depends on it...
   - One may use some LaTeX-[compatibility layer](https://github.com/ctrlcctrlv/sile-texmode) for such things, if one really wants them.
2. Addition of the `autodoc` package documentation (fixed) to the SILE manual (in the "experimental" section)
   - It has to be there eventually, for package designers to know about it!
   - We want packages to be properly documented, don't we?
3. Introduction of `\autodoc:setting{<setting name>}` in the autodoc package
   - Automatically inserts good breakpoints, avoiding the need for designers to manually add some `\goodbreak` here and there.
   - (Conditionally) ensures the setting exists - It actually helped finding a few typos in the documentation (= e.g. in `linebreak.parShape` and `chordmode.offset`), so I am considering more commands of that type in another stage...

(On the way, I also fixed the `value` argument in the Manual's call to `pdf:metadata`, to avoid the deprecation warning.)