### PR TITLE
Leverage package documentation and manual (stage 1)

### DIFF
--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -211,6 +211,30 @@ SILE.registerCommand("autodoc:command", function (options, content)
   SILE.call("autodoc:ast", options, content)
 end, "Outputs a formatted command, possibly checking its validity.")
 
+-- Documenting a parameter
+
+SILE.registerCommand("autodoc:parameter", function (_, content)
+  if type(content) ~= "table" then SU.error("Expected a table content") end
+  if #content ~= 1 then SU.error("Expected a single element") end
+  local param = type(content[1] == "string") and content[1]
+
+  local parts = {}
+  for v in string.gmatch(param, "[^=]+") do
+    parts[#parts+1] = v
+  end
+  SILE.call("autodoc:style", { type = "ast" }, function ()
+    if #parts < 1 or #parts > 2 then SU.error("Unexpected parameter '"..param.."'") end
+    SILE.call("autodoc:style", { type = "parameter" }, { parts[1] })
+    if #parts == 2 then
+      SILE.typesetter:typeset("=")
+
+      SILE.call("penalty", { penalty = 100 }, nil) -- Quite decent to break here if need be.
+      SILE.call("autodoc:value", {}, { parts[2] })
+    end
+  end)
+end, "Outputs a nicely presented parameter, possibly with a value.")
+
+
 return {
   documentation = [[\begin{document}
 This package extracts documentation information from other packages. It’s used to
@@ -247,8 +271,12 @@ to math-related commands. So it comes with many benefits, but also at a cost.
 Both \autodoc:command{\autodoc:setting} and \autodoc:command{\autodoc:command} check
 the validity and existence of their inputs. Would you want to disable this feature (e.g. to
 refer to a setting or command defined in another package or module that might not be loaded
-at this point), you can set the optional parameter \code{check} to false. Note, however, that
-for commands, it is applied recursively to the parsed AST (so it is a all-or-none trade-off).
+at this point), you can set the optional parameter \autodoc:parameter{check} to false.
+Note, however, that for commands, it is applied recursively to the parsed AST
+(so it is a all-or-none trade-off).
+
+The \autodoc:command{\autodoc:parameter} commands takes either a parameter name, possibly
+with a value (which as above, may be bracketed) and typesets it in the same fashion.
 
 \end{document}]]
 }

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -18,11 +18,46 @@ end)
 
 -- Styling hook
 
-SILE.registerCommand("autodoc:style", function (_, content)
+SILE.scratch.autodoc = {
+  theme = {
+    command = "#1d4851", -- oil blue
+    parameter = "#3f5218", -- some sort of dark green
+    setting = "#42280e", -- some kind of dark brown
+    bracketed = "#656565", -- some grey
+  }
+}
+-- DEBUGs:
+-- SILE.scratch.autodoc = {
+--   theme = {
+--     command = "red", -- oil blue
+--     parameter = "red", -- some sort of dark green
+--     setting = "red", -- some kind of dark orange/brown
+--     bracketed = "#333333" -- some dark grey
+--   }
+-- }
+
+
+local colorWrapper = function (ctype, content)
+  local color = SILE.scratch.autodoc.theme[ctype]
+  if color and SILE.Commands["color"] then
+    SILE.call("color", { color = color }, content)
+  else
+    SILE.process(content)
+  end
+end
+
+SILE.registerCommand("autodoc:style", function (options, content)
   -- options.type can be used to distinguish the type of item and style
-  -- it accordingly, redefining this command.
-  -- Here by default, though, just typeset it in \code.
-  SILE.call("code", {}, content)
+  -- it accordingly.
+  if options.type == "ast" then
+    SILE.call("code", {}, content)
+  elseif options.type == "setting" then
+    SILE.call("code", {}, function()
+      colorWrapper(options.type, content)
+    end)
+  else
+    colorWrapper(options.type, content)
+  end
 end)
 
 -- Documenting a setting with good line-breaks
@@ -61,6 +96,121 @@ SILE.registerCommand("autodoc:setting", function (options, content)
   SILE.call("autodoc:style", { type = "setting" }, nameWithBreaks)
 end, "Outputs a settings name in code, ensuring good line breaks and possibly checking their existence.")
 
+-- Documenting a command, benefiting from AST parsing
+
+local function optionSorter(o1, o2)
+  -- options are in an associative table and Lua doesn't guarantee a fixed order.
+  -- To ensure we get a consistent and stable output, we make with some wild guesses here
+  -- (Quick'n dirty, could be improved!), and rely on alphabetical order otherwise.
+  if o1 == "src" then return true end
+  if o2 == "src" then return false end
+  if o1 == "name" then return true end
+  if o2 == "name" then return false end
+  return o1 < o2
+end
+
+local function typesetOptions(options)
+end
+
+local function typesetAST(options, content)
+  if not content then return end
+  local seenCommandWithoutArg = false
+  for i = 1, #content do
+    local ast = content[i]
+
+    if type(ast) == "string" then
+      if seenCommandWithoutArg and ast:sub(1,1) ~= " " and ast:sub(1,1) ~= "{" then
+        -- Touchy:
+        -- There might have been a space or a {} here in the original code. The AST does
+        -- not remember it, we only know we have to separate somehow the string from
+        -- the previous command...
+        SILE.typesetter:typeset(" ")
+        seenCommandWithoutArg = false
+      end
+      if ast:sub(1, 1) == "<" and ast:sub(-1) == ">" then
+        SILE.call("autodoc:bracketed", {}, { ast:sub(2, -2) })
+      else
+        SILE.typesetter:typeset(ast)
+      end
+
+    elseif ast.command then
+      local cmd = SILE.Commands[ast.command]
+      if not cmd and SU.boolean(options.check, true) then
+        SU.error("Unexpected command '"..ast.command.."'")
+      end
+      SILE.typesetter:typeset("\\")
+      SILE.call("autodoc:style", { type = "command" }, { ast.command })
+
+      local sortedOpts = {}
+      for k, _ in pairs(ast.options) do table.insert(sortedOpts, k) end
+      table.sort(sortedOpts, optionSorter)
+      if #sortedOpts > 0 then
+        local iOpt = 0
+        SILE.typesetter:typeset("[")
+        for iOpt, option in ipairs(sortedOpts) do
+          SILE.call("autodoc:style", { type = "parameter" }, { option })
+          SILE.typesetter:typeset("=")
+          SILE.call("penalty", { penalty = 100 }, nil) -- Quite decent to break here if need be.
+          SILE.call("autodoc:value", {}, { ast.options[option] })
+          if iOpt == #sortedOpts then
+            SILE.typesetter:typeset("]")
+          else
+            SILE.typesetter:typeset(", ")
+          end
+        end
+      end
+      if (#ast >= 1) then
+        SILE.call("penalty", { penalty = 200 }, nil) -- Less than optimal break.
+        SILE.typesetter:typeset("{")
+        typesetAST(options, ast)
+        SILE.typesetter:typeset("}")
+      else
+        seenCommandWithoutArg = true
+      end
+
+    else
+      SU.error("Unrecognized AST element")
+    end
+  end
+end
+
+SILE.registerCommand("autodoc:ast", function (options, content)
+  if type(content) ~= "table" then SU.error("Expected a table content") end
+  SILE.call("autodoc:style", { type = "ast" }, function ()
+    typesetAST(options, content)
+  end)
+end, "Outputs a nicely typeset AST (low-level command).")
+
+SILE.registerCommand("autodoc:bracketed", function (_, content)
+  SILE.typesetter:typeset("⟨")
+  SILE.call("autodoc:style", { type = "bracketed" }, function()
+    SILE.call("em", {}, content)
+  end)
+  SILE.call("kern", { width = "0.1em" }) -- fake italic correction.
+  SILE.typesetter:typeset("⟩")
+end, "Outputs a nicely formatted user-given value within <brackets>.")
+
+SILE.registerCommand("autodoc:value", function (_, content)
+  local value = type(content) == "table" and content[1] or content
+  if type(value) ~= "string" then SU.error("Expected a string") end
+
+  if value:sub(1, 1) == "<" and value:sub(-1) == ">" then
+    SILE.call("autodoc:bracketed", {}, { value:sub(2, -2) })
+  else
+    -- Here we should check for comma/semicolon, or surrounding spaces, and in that
+    -- case add quotes around the value. This is a bit of an edge-case though, esp.
+    -- for documentation needs.
+    SILE.call("autodoc:style", { type = "value" }, content)
+  end
+end, "Outputs a nicely formatted argument within <brackets>.")
+
+SILE.registerCommand("autodoc:command", function (options, content)
+  if type(content) ~= "table" then SU.error("Expected a table content") end
+  if type(content[1]) ~= "table" then SU.error("Expected a command, got "..type(content[1]).." '"..content[1].."'") end
+
+  SILE.call("autodoc:ast", options, content)
+end, "Outputs a formatted command, possibly checking its validity.")
+
 return {
   documentation = [[\begin{document}
 This package extracts documentation information from other packages. It’s used to
@@ -68,7 +218,7 @@ construct the SILE manual. Keeping package documentation in the package itself
 keeps the documentation near the implementation, which (in theory) makes it easy
 for documentation and implementation to be in sync.
 
-For that purpose, it provides the \code{\\package-documentation[src=\em{package}]}
+For that purpose, it provides the \autodoc:command{\package-documentation[src=<package>]}
 command.
 
 Properly documented packages should export a \code{documentation} string
@@ -77,10 +227,28 @@ containing their documentation, as a SILE document.
 For documenters and package authors, it also provides commands that can be used in their package
 documentation to present various pieces of information in a consistent way.
 
-Setting names can be fairly long (e.g. \em{namespace.area.some-stuff}).
-The \code{\\autodoc:setting} command helps line-breaking them automatically at
+Setting names can be fairly long (e.g. \em{namespace.area.some-stuff\kern[width=0.1em]}).
+The \autodoc:command{\autodoc:setting} command helps line-breaking them automatically at
 appropriate points, so that package authors do not have care about them
 manually.
+
+With the \autodoc:command{\autodoc:command} command, one can pass a simple command, or even
+a full commands (with parameters and arguments), without the need for escaping special
+characters. This relies on SILE’s AST (abstract syntax tree) parsing, so you benefit from
+typing simplicity, syntax check, and even more –such as styling\footnote{If the \code{color}
+package is loaded, you get syntax highlighting.}.
+Moreover, for text content in parameter values or command arguments, if they are enclosed
+between angle brackets, they will be presented with an distinguishable style.
+Just type the command as it would appear in code, and it will be nicely typeset. It comes with
+a few caveats, though: parameters are not guaranteed to appear in the order you entered them and
+some purely syntactic sequences are just skipped and not reconstructed. Also, it is not adapted
+to math-related commands. So it comes with many benefits, but also at a cost.
+
+Both \autodoc:command{\autodoc:setting} and \autodoc:command{\autodoc:command} check
+the validity and existence of their inputs. Would you want to disable this feature (e.g. to
+refer to a setting or command defined in another package or module that might not be loaded
+at this point), you can set the optional parameter \code{check} to false. Note, however, that
+for commands, it is applied recursively to the parsed AST (so it is a all-or-none trade-off).
 
 \end{document}]]
 }

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -55,6 +55,10 @@ SILE.registerCommand("autodoc:style", function (options, content)
     SILE.call("code", {}, function()
       colorWrapper(options.type, content)
     end)
+  elseif options.type == "environment" then
+    SILE.call("code", {}, function()
+      colorWrapper("command", content)
+    end)
   else
     colorWrapper(options.type, content)
   end
@@ -84,7 +88,7 @@ SILE.registerCommand("autodoc:setting", function (options, content)
   if type(content) ~= "table" then SU.error("Expected a table content") end
   if #content ~= 1 then SU.error("Expected a single element") end
   local name = type(content[1] == "string") and content[1]
-  if not name then SU.error("Unexpected setting '"..name.."'") end
+  if not name then SU.error("Unexpected setting") end
   -- Conditional existence check (can be disable is passing check=false), e.g.
   -- for settings that would be define in another context.
   if SU.boolean(options.check, true) then
@@ -234,6 +238,20 @@ SILE.registerCommand("autodoc:parameter", function (_, content)
   end)
 end, "Outputs a nicely presented parameter, possibly with a value.")
 
+-- Documenting an environment
+
+SILE.registerCommand("autodoc:environment", function (options, content)
+  if type(content) ~= "table" then SU.error("Expected a table content") end
+  if #content ~= 1 then SU.error("Expected a single element") end
+  local name = type(content[1] == "string") and content[1]
+  if not name then SU.error("Unexpected environment") end
+  -- Conditional existence check
+  if SU.boolean(options.check, true) then
+    if not SILE.Commands[name] then SU.error("Unknown command "..name) end
+  end
+
+  SILE.call("autodoc:style", { type = "environment" }, name)
+end, "Outputs a command name in code, checking its validity.")
 
 return {
   documentation = [[\begin{document}
@@ -268,10 +286,14 @@ a few caveats, though: parameters are not guaranteed to appear in the order you 
 some purely syntactic sequences are just skipped and not reconstructed. Also, it is not adapted
 to math-related commands. So it comes with many benefits, but also at a cost.
 
-Both \autodoc:command{\autodoc:setting} and \autodoc:command{\autodoc:command} check
-the validity and existence of their inputs. Would you want to disable this feature (e.g. to
-refer to a setting or command defined in another package or module that might not be loaded
-at this point), you can set the optional parameter \autodoc:parameter{check} to false.
+The \autodoc:command{\autodoc:environment} command just takes an environment name, so
+basically a command, but just displays it without leading backslash.
+
+The \autodoc:command{\autodoc:setting}, \autodoc:command{\autodoc:command} and
+\autodoc:command{\autodoc:environment} commands all check the validity and existence of
+their inputs. Would you want to disable this feature (e.g. to refer to a setting or command
+defined in another package or module that might not be loaded at this point), you can set the
+optional parameter \autodoc:parameter{check} to false.
 Note, however, that for commands, it is applied recursively to the parsed AST
 (so it is a all-or-none trade-off).
 

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -24,19 +24,9 @@ SILE.scratch.autodoc = {
     parameter = "#3f5218", -- some sort of dark green
     setting = "#42280e", -- some kind of dark brown
     bracketed = "#656565", -- some grey
+    package = "#172557", -- saturated space blue
   }
 }
--- DEBUGs:
--- SILE.scratch.autodoc = {
---   theme = {
---     command = "red", -- oil blue
---     parameter = "red", -- some sort of dark green
---     setting = "red", -- some kind of dark orange/brown
---     bracketed = "#333333" -- some dark grey
---   }
--- }
-
-
 local colorWrapper = function (ctype, content)
   local color = SILE.scratch.autodoc.theme[ctype]
   if color and SILE.Commands["color"] then
@@ -51,7 +41,7 @@ SILE.registerCommand("autodoc:style", function (options, content)
   -- it accordingly.
   if options.type == "ast" then
     SILE.call("code", {}, content)
-  elseif options.type == "setting" then
+  elseif options.type == "setting" or options.type == "package" then
     SILE.call("code", {}, function()
       colorWrapper(options.type, content)
     end)
@@ -253,6 +243,18 @@ SILE.registerCommand("autodoc:environment", function (options, content)
   SILE.call("autodoc:style", { type = "environment" }, name)
 end, "Outputs a command name in code, checking its validity.")
 
+-- Documenting a package name
+
+SILE.registerCommand("autodoc:package", function (_, content)
+  if type(content) ~= "table" then SU.error("Expected a table content") end
+  if #content ~= 1 then SU.error("Expected a single element") end
+  local name = type(content[1] == "string") and content[1]
+  if not name then SU.error("Unexpected package name") end
+  -- We cannot really check package name to exist!
+
+  SILE.call("autodoc:style", { type = "package" }, { name })
+end, "Outputs a package name in code, checking its validity.")
+
 return {
   documentation = [[\begin{document}
 This package extracts documentation information from other packages. It’s used to
@@ -277,7 +279,7 @@ manually.
 With the \autodoc:command{\autodoc:command} command, one can pass a simple command, or even
 a full commands (with parameters and arguments), without the need for escaping special
 characters. This relies on SILE’s AST (abstract syntax tree) parsing, so you benefit from
-typing simplicity, syntax check, and even more –such as styling\footnote{If the \code{color}
+typing simplicity, syntax check, and even more –such as styling\footnote{If the \autodoc:package{color}
 package is loaded, you get syntax highlighting.}.
 Moreover, for text content in parameter values or command arguments, if they are enclosed
 between angle brackets, they will be presented with an distinguishable style.

--- a/packages/background.lua
+++ b/packages/background.lua
@@ -23,7 +23,7 @@ SILE.registerCommand("background", function (options, _)
 end, "Draws a solid background color <color> on pages after initialization.")
 
 return { documentation = [[\begin{document}
-The \code{background} package allows you to set the color of the canvas
+The \autodoc:package{background} package allows you to set the color of the canvas
 background (by drawing a solid color block the full size of the page on page
 initialization). The package provides a \autodoc:command{\background} command which
 requires at least one parameter,
@@ -31,7 +31,7 @@ requires at least one parameter,
 current and all following pages to that color. If setting only the current page
 background different from the default is desired, an extra parameter
 \autodoc:parameter{allpages=false} can be passed. The color specification in the same as
-specified in the \code{color} package.
+specified in the \autodoc:package{color} package.
 
 \background[color=#e9d8ba,allpages=false]
 

--- a/packages/background.lua
+++ b/packages/background.lua
@@ -25,9 +25,9 @@ end, "Draws a solid background color <color> on pages after initialization.")
 return { documentation = [[\begin{document}
 The \code{background} package allows you to set the color of the canvas
 background (by drawing a solid color block the full size of the page on page
-initialization). The package provides a \code{\\background} command which
+initialization). The package provides a \autodoc:command{\background} command which
 requires at least one parameter,
-\code{color=\em{<color \nobreak{}specification}}, and sets the backgound of the
+\code{color=\em{<color \nobreak{}specification>}}, and sets the backgound of the
 current and all following pages to that color. If setting only the current page
 background different from the default is desired, an extra parameter
 \code{allpages=false} can be passed. The color specification in the same as
@@ -35,6 +35,6 @@ specified in the \code{color} package.
 
 \background[color=#e9d8ba,allpages=false]
 
-So, for example, \code{\\background[color=#e9d8ba,allpages=false]} will set a
+So, for example, \autodoc:command{\background[color=#e9d8ba,allpages=false]} will set a
 sepia tone background on the current page.
 \end{document}]] }

--- a/packages/background.lua
+++ b/packages/background.lua
@@ -27,10 +27,10 @@ The \code{background} package allows you to set the color of the canvas
 background (by drawing a solid color block the full size of the page on page
 initialization). The package provides a \autodoc:command{\background} command which
 requires at least one parameter,
-\code{color=\em{<color \nobreak{}specification>}}, and sets the backgound of the
+\autodoc:parameter{color=<color specification>}, and sets the backgound of the
 current and all following pages to that color. If setting only the current page
 background different from the default is desired, an extra parameter
-\code{allpages=false} can be passed. The color specification in the same as
+\autodoc:parameter{allpages=false} can be passed. The color specification in the same as
 specified in the \code{color} package.
 
 \background[color=#e9d8ba,allpages=false]

--- a/packages/balanced-frames.lua
+++ b/packages/balanced-frames.lua
@@ -75,7 +75,7 @@ return {
 This package attempts to ensure that the main content frames on a
 page are balanced; that is, that they have the same height. In your
 frame definitions for the columns, you will need to ensure that they
-have the parameter \code{balanced} set to a true value. See the example
+have the parameter \autodoc:parameter{balanced} set to a true value. See the example
 in \code{tests/balanced.sil}.
 
 The current algorithm does not work particularly well, and a better solution

--- a/packages/bibliography.lua
+++ b/packages/bibliography.lua
@@ -403,7 +403,7 @@ Bibliography = {
 
 Bibliography.documentation = [[
 \begin{document}
-This package provides backend functions used by the \code{bibtex} package;
+This package provides backend functions used by the \autodoc:package{bibtex} package;
 see that instead.
 \end{document}
 ]]

--- a/packages/bibtex.lua
+++ b/packages/bibtex.lua
@@ -87,7 +87,7 @@ This experimental package allows SILE to read and process BibTeX
 (It doesn’t currently produce full bibliography listings.)
 
 To load a BibTeX file, issue the command
-\autodoc:command{\loadbibliography[file=whatever.bib]}
+\autodoc:command{\loadbibliography[file=<whatever.bib>]}
 
 To produce an inline citation, call \autodoc:command{\cite{<key>}}, which
 will typeset something like “Jones 1982”. If you want to cite a

--- a/packages/bibtex.lua
+++ b/packages/bibtex.lua
@@ -87,13 +87,13 @@ This experimental package allows SILE to read and process BibTeX
 (It doesn’t currently produce full bibliography listings.)
 
 To load a BibTeX file, issue the command
-\code{\\loadbibliography[file=whatever.bib]}
+\autodoc:command{\loadbibliography[file=whatever.bib]}
 
-To produce an inline citation, call \code{\\cite\{key\}}, which
+To produce an inline citation, call \autodoc:command{\cite{<key>}}, which
 will typeset something like “Jones 1982”. If you want to cite a
-particular page number, use \code{\\cite[page=22]\{key\}}.
+particular page number, use \autodoc:command{\cite[page=22]{<key>}}.
 
-To produce a full reference, use \code{\\reference\{key\}}.
+To produce a full reference, use \autodoc:command{\reference{<key>}}.
 
 Currently, the only supported bibliography style is Chicago referencing,
 but other styles should be easy to implement if there is interest.

--- a/packages/bidi.lua
+++ b/packages/bidi.lua
@@ -280,13 +280,13 @@ documentation = [[\begin{document}
 
 Scripts like the Latin alphabet you are currently reading are normally written left to
 right; however, some scripts, such as Arabic and Hebrew, are written right to left.
-The \code{bidi} package, which is loaded by default, provides SILE with the ability to
+The \autodoc:package{bidi} package, which is loaded by default, provides SILE with the ability to
 correctly typeset right-to-left text and also documents which mix right-to-left and
 left-to-right typesetting. Because it is loaded by default, you can use both
 LTR and RTL text within a paragraph and SILE will ensure that the output
 characters appear in the correct order.
 
-The \code{bidi} package provides two commands, \autodoc:command{\thisframeLTR} and
+The \autodoc:package{bidi} package provides two commands, \autodoc:command{\thisframeLTR} and
 \autodoc:command{\thisframeRTL}, which set the default text direction for the current frame.
 That is, if you tell SILE that a frame is RTL, the text will start in the right margin
 and proceed leftward. It also provides the commands \autodoc:command{\bidi-off} and

--- a/packages/bidi.lua
+++ b/packages/bidi.lua
@@ -286,11 +286,11 @@ left-to-right typesetting. Because it is loaded by default, you can use both
 LTR and RTL text within a paragraph and SILE will ensure that the output
 characters appear in the correct order.
 
-The \code{bidi} package provides two commands, \command{\\thisframeLTR} and
-\command{\\thisframeRTL}, which set the default text direction for the current frame.
+The \code{bidi} package provides two commands, \autodoc:command{\thisframeLTR} and
+\autodoc:command{\thisframeRTL}, which set the default text direction for the current frame.
 That is, if you tell SILE that a frame is RTL, the text will start in the right margin
-and proceed leftward. It also provides the commands \command{\\bidi-off} and
-\command{\\bidi-on}, which allow you to trade off bidirectional support for a dubious
-increase in speed.
+and proceed leftward. It also provides the commands \autodoc:command{\bidi-off} and
+\autodoc:command{\bidi-on}, which allow you to trade off bidirectional support for a
+dubious increase in speed.
 
 \end{document}]] }

--- a/packages/boustrophedon.lua
+++ b/packages/boustrophedon.lua
@@ -52,7 +52,7 @@ real use by classicists, the boustrophedon package allows you to typeset
 ancient Greek texts in the ‘ox-turning’ layout—the first line is
 written left to right as normal, but the next is set right to
 left, then left to right, and so on. To use it, you will need to set the font’s language to ancient
-Greek (\code{grc}) and wrap text in a \code{boustrophedon} environment:
+Greek (\code{grc}) and wrap text in a \autodoc:environment{boustrophedon} environment:
 
 \set[parameter=document.parindent,value=0]{\par
 \begin{boustrophedon}

--- a/packages/boustrophedon.lua
+++ b/packages/boustrophedon.lua
@@ -48,7 +48,7 @@ return {
 documentation = [[\begin{document}
 
 Partly designed to show off SILE’s extensibility, and partly designed for
-real use by classicists, the boustrophedon package allows you to typeset
+real use by classicists, the \autodoc:package{boustrophedon} package allows you to typeset
 ancient Greek texts in the ‘ox-turning’ layout—the first line is
 written left to right as normal, but the next is set right to
 left, then left to right, and so on. To use it, you will need to set the font’s language to ancient

--- a/packages/chapterverse.lua
+++ b/packages/chapterverse.lua
@@ -67,21 +67,21 @@ provides commands which will generally be called by the higher-level
 \code{\\verse} and \code{\\chapter} (or moral equivalent) commands of the
 classes which handle this kind of content:
 
-\noindent{}• \code{\\save-book-title} takes its argument and squirrels
+\noindent{}• \autodoc:command{\save-book-title} takes its argument and squirrels
 it away as the current book name.
 
-\noindent{}• \code{\\save-chapter-number} and \code{\\save-verse-number}
+\noindent{}• \autodoc:command{\save-chapter-number} and \autodoc:command{\save-verse-number}
 does the same but for the chapter and verse reference respectively.
 
-\noindent{}• \code{\\format-reference} is expected to be called from
+\noindent{}• \autodoc:command{\format-reference} is expected to be called from
 Lua code with a content table of \code{\{book = ..., chapter = ..., verse = ...\}}
 and typesets the reference in the form \code{cc:vv}.
 If the parameter \code{[showbook=true]} is given then the book name
 is also output. (You can override this command to output your references
 in a different format.)
 
-\noindent{}• \code{\\first-reference} and \code{\\last-reference}
-typeset (using \code{\\format-reference}) the first reference on the
+\noindent{}• \autodoc:command{\first-reference} and \autodoc:command{\last-reference}
+typeset (using \autodoc:command{\format-reference}) the first reference on the
 page and the last reference on the page respectively. This is helpful for
 running headers.
 

--- a/packages/chapterverse.lua
+++ b/packages/chapterverse.lua
@@ -76,7 +76,7 @@ does the same but for the chapter and verse reference respectively.
 \noindent{}• \autodoc:command{\format-reference} is expected to be called from
 Lua code with a content table of \code{\{book = ..., chapter = ..., verse = ...\}}
 and typesets the reference in the form \code{cc:vv}.
-If the parameter \code{[showbook=true]} is given then the book name
+If the parameter \autodoc:parameter{showbook=true} is given then the book name
 is also output. (You can override this command to output your references
 in a different format.)
 

--- a/packages/chapterverse.lua
+++ b/packages/chapterverse.lua
@@ -61,7 +61,7 @@ end)
 return {
   documentation = [[
 \begin{document}
-The \code{chapterverse} package is designed as a helper package for
+The \autodoc:package{chapterverse} package is designed as a helper package for
 book classes which deal with versified content such as scriptures. It
 provides commands which will generally be called by the higher-level
 \code{\\verse} and \code{\\chapter} (or moral equivalent) commands of the

--- a/packages/chordmode.lua
+++ b/packages/chordmode.lua
@@ -130,7 +130,7 @@ into:
 
 The chords can be styled by redefining the \autodoc:command{\chordmode:chordfont}
 command, and the offset between the chord name and text set with the
-\autodoc:setting{chordmode.offset} parameter.
+\autodoc:setting{chordmode.offset} setting.
 
 \end{document}
 ]]

--- a/packages/chordmode.lua
+++ b/packages/chordmode.lua
@@ -114,7 +114,7 @@ return {
   documentation = [[
 \begin{document}
 
-This package provides the \code{chordmode} environment, which transforms
+This package provides the \autodoc:environment{chordmode} environment, which transforms
 lines like:
 
 \begin{verbatim}

--- a/packages/chordmode.lua
+++ b/packages/chordmode.lua
@@ -128,7 +128,7 @@ into:
 \end{chordmode}
 \par
 
-The chords can be styled by redefining the \code{chordmode:chordfont}
+The chords can be styled by redefining the \autodoc:command{\chordmode:chordfont}
 command, and the offset between the chord name and text set with the
 \autodoc:setting{chordmode.offset} parameter.
 

--- a/packages/color-fonts.lua
+++ b/packages/color-fonts.lua
@@ -92,7 +92,7 @@ return {
   end,
   documentation = [[
 \begin{document}
-  The \code{color-fonts} package adds support for fonts with a \code{COLR}
+  The \autodoc:package{color-fonts} package adds support for fonts with a \code{COLR}
   OpenType table. This package is automatically loaded when such a font is
   detected.
 \end{document}

--- a/packages/color.lua
+++ b/packages/color.lua
@@ -12,7 +12,7 @@ end, "Changes the active ink color to the color <color>.")
 return { documentation = [[\begin{document}
 The \code{color} package allows you to temporarily change the color of the
 (virtual) ink that SILE uses to output text and rules. The package provides
-a \code{\\color} command which takes one parameter, \code{color=\em{<color \nobreak{}specification>}}, and typesets
+a \autodoc:command{\color} command which takes one parameter, \code{color=\em{<color \nobreak{}specification>}}, and typesets
 its argument in that color. The color specification is the same as HTML:
 it can be a RGB color value in \code{#xxx} or \code{#xxxxxx} format, where \code{x}
 represents a hexadecimal digit (\code{#000} is black, \code{#fff} is white,
@@ -20,8 +20,8 @@ represents a hexadecimal digit (\code{#000} is black, \code{#fff} is white,
 
 \note{The HTML and CSS named colors can be found at \code{http://dev.w3.org/csswg/css-color/#named-colors}.}
 
-So, for example, \color[color=red]{this text is typeset with \code{\\color[color=red]\{…\}}}.
+So, for example, \color[color=red]{this text is typeset with \autodoc:command{\color[color=red]{…}}}.
 
-Here is a rule typeset with \code{\\color[color=#22dd33]}:
+Here is a rule typeset with \autodoc:command{\color[color=#22dd33]}:
 \color[color=#ffdd33]{\hrule[width=120pt,height=0.5pt]}
 \end{document}]] }

--- a/packages/color.lua
+++ b/packages/color.lua
@@ -12,7 +12,8 @@ end, "Changes the active ink color to the color <color>.")
 return { documentation = [[\begin{document}
 The \code{color} package allows you to temporarily change the color of the
 (virtual) ink that SILE uses to output text and rules. The package provides
-a \autodoc:command{\color} command which takes one parameter, \code{color=\em{<color \nobreak{}specification>}}, and typesets
+a \autodoc:command{\color} command which takes one parameter,
+\autodoc:parameter{color=<color specification>}, and typesets
 its argument in that color. The color specification is the same as HTML:
 it can be a RGB color value in \code{#xxx} or \code{#xxxxxx} format, where \code{x}
 represents a hexadecimal digit (\code{#000} is black, \code{#fff} is white,

--- a/packages/color.lua
+++ b/packages/color.lua
@@ -10,7 +10,7 @@ SILE.registerCommand("color", function (options, content)
 end, "Changes the active ink color to the color <color>.")
 
 return { documentation = [[\begin{document}
-The \code{color} package allows you to temporarily change the color of the
+The \autodoc:package{color} package allows you to temporarily change the color of the
 (virtual) ink that SILE uses to output text and rules. The package provides
 a \autodoc:command{\color} command which takes one parameter,
 \autodoc:parameter{color=<color specification>}, and typesets

--- a/packages/converters.lua
+++ b/packages/converters.lua
@@ -96,12 +96,12 @@ return {
   },
   documentation= [[
 \begin{document}
-The \code{converters} package allows you to register additional handlers
+The \autodoc:package{converters} package allows you to register additional handlers
 to process included files and images. That sounds a bit abstract, so it’s
 best explained by example. Suppose you have a GIF image that you would
 like to include in your document. You read the documentation for the
-\code{image} package and you discover that sadly GIF images are not supported.
-What \code{converters} does is allow you to teach SILE how to get the GIF
+\autodoc:package{image} package and you discover that sadly GIF images are not supported.
+What \autodoc:package{converters} does is allow you to teach SILE how to get the GIF
 format into something that \em{is} supported. We can use the ImageMagick
 toolkit to turn a GIF into a JPG, and JPGs are supported.
 

--- a/packages/converters.lua
+++ b/packages/converters.lua
@@ -105,7 +105,7 @@ What \code{converters} does is allow you to teach SILE how to get the GIF
 format into something that \em{is} supported. We can use the ImageMagick
 toolkit to turn a GIF into a JPG, and JPGs are supported.
 
-We do this by registering a converter with the \code{converters:register}
+We do this by registering a converter with the \autodoc:command{\converters:register}
 command:
 
 \begin{verbatim}

--- a/packages/counters.lua
+++ b/packages/counters.lua
@@ -98,17 +98,17 @@ allows you to set up, increment and typeset named counters. It
 provides the following commands:
 
 • \autodoc:command{\set-counter[id=<counter-name>, value=<value>]} — sets
-the counter called \code{<counter-name>} to the \code{<value>} given.
+the counter with the specified name to the given value.
 
 • \autodoc:command{\increment-counter[id=<counter-name>]} — does the
-same as \autodoc:command{\set-counter} except that when no \code{value} parameter
+same as \autodoc:command{\set-counter} except that when no \autodoc:parameter{value} parameter
 is given, the counter is incremented by one.
 
 • \autodoc:command{\show-counter[id=<counter-name>]} — this typesets the
 value of the counter according to the counter’s declared display type.
 
 \note{All of the commands in the counters package take an optional
-\code{display=\em{<display-type>}} parameter
+\autodoc:parameter{display=<display-type>} parameter
 to set the \em{display type} of the counter.
 
 The available built-in display types are:
@@ -126,7 +126,7 @@ The available built-in display types are:
 The ICU library also provides ways of formatting numbers in global (non-Latin)
 scripts. You can use any of the display types in this list:
 \url{http://www.unicode.org/repos/cldr/tags/latest/common/bcp47/number.xml}.
-For example, \code{display=beng} will format your numbers in Bengali digits.
+For example, \autodoc:parameter{display=beng} will format your numbers in Bengali digits.
 }
 
 

--- a/packages/counters.lua
+++ b/packages/counters.lua
@@ -91,7 +91,7 @@ return {
   },
   documentation = [[\begin{document}
 
-Various parts of SILE such as the \code{footnotes} package and the
+Various parts of SILE such as the \autodoc:package{footnotes} package and the
 sectioning commands keep a counter of things going on: the current
 footnote number, the chapter number, and so on. The counters package
 allows you to set up, increment and typeset named counters. It

--- a/packages/counters.lua
+++ b/packages/counters.lua
@@ -97,14 +97,14 @@ footnote number, the chapter number, and so on. The counters package
 allows you to set up, increment and typeset named counters. It
 provides the following commands:
 
-• \code{\\set-counter[id=\em{<counter-name>},value=\em{<value>}]} — sets
+• \autodoc:command{\set-counter[id=<counter-name>, value=<value>]} — sets
 the counter called \code{<counter-name>} to the \code{<value>} given.
 
-• \code{\\increment-counter[id=\em{<counter-name>}]} — does the
-same as \code{\\set-counter} except that when no \code{value} parameter
+• \autodoc:command{\increment-counter[id=<counter-name>]} — does the
+same as \autodoc:command{\set-counter} except that when no \code{value} parameter
 is given, the counter is incremented by one.
 
-• \code{\\show-counter[id=\em{<counter-name>}]} — this typesets the
+• \autodoc:command{\show-counter[id=<counter-name>]} — this typesets the
 value of the counter according to the counter’s declared display type.
 
 \note{All of the commands in the counters package take an optional

--- a/packages/cropmarks.lua
+++ b/packages/cropmarks.lua
@@ -96,7 +96,7 @@ documentation = [[\begin{document}
   the side of the page are correctly cut.)
 
   This package provides the \autodoc:command{\crop:setup} command which should be
-  run early in your document file. It takes one argument, \code{papersize},
+  run early in your document file. It takes one argument, \autodoc:parameter{papersize},
   which is the true target paper size. It place cropmarks around the
   true page content.
 

--- a/packages/cropmarks.lua
+++ b/packages/cropmarks.lua
@@ -95,14 +95,14 @@ documentation = [[\begin{document}
   size. (This is to ensure that pages where the content “bleeds” off
   the side of the page are correctly cut.)
 
-  This package provides the \code{crop:setup} command which should be
+  This package provides the \autodoc:command{\crop:setup} command which should be
   run early in your document file. It takes one argument, \code{papersize},
   which is the true target paper size. It place cropmarks around the
   true page content.
 
   It also adds a header at the top of the page with the filename, date
   and output sheet number. You can customize this header by redefining
-  \code{crop:header}.
+  \autodoc:command{\crop:header}.
 
 \end{document}]]
 }

--- a/packages/date.lua
+++ b/packages/date.lua
@@ -22,7 +22,7 @@ return {
 documentation = [[\begin{document}
 The \code{date} package provides the \autodoc:command{\date} command, which simply
 outputs the date using the system’s date function. You can customize
-the format by passing the \code{format} parameter, following the
+the format by passing the \autodoc:parameter{format} parameter, following the
 formatting codes in the Lua manual. (\url{https://www.lua.org/pil/22.1.html})
 \end{document}
 ]]

--- a/packages/date.lua
+++ b/packages/date.lua
@@ -20,7 +20,7 @@ return {
     date = date
   },
 documentation = [[\begin{document}
-The \code{date} package provides the \autodoc:command{\date} command, which simply
+The \autodoc:package{date} package provides the \autodoc:command{\date} command, which simply
 outputs the date using the system’s date function. You can customize
 the format by passing the \autodoc:parameter{format} parameter, following the
 formatting codes in the Lua manual. (\url{https://www.lua.org/pil/22.1.html})

--- a/packages/date.lua
+++ b/packages/date.lua
@@ -20,7 +20,7 @@ return {
     date = date
   },
 documentation = [[\begin{document}
-The \code{date} package provides the \code{date} command, which simply
+The \code{date} package provides the \autodoc:command{\date} command, which simply
 outputs the date using the system’s date function. You can customize
 the format by passing the \code{format} parameter, following the
 formatting codes in the Lua manual. (\url{https://www.lua.org/pil/22.1.html})

--- a/packages/debug.lua
+++ b/packages/debug.lua
@@ -11,9 +11,9 @@ end)
 return {
 documentation = [[
 \begin{document}
-This package provides two commands: \code{debug}, which turns
+This package provides two commands: \autodoc:command{\debug}, which turns
 on and off SILE’s internal debugging flags (similar to using \code{--debug=...}
-on the command line); and \code{disable-pushback} which is used
+on the command line); and \autodoc:command{\disable-pushback} which is used
 by SILE’s developers to turn off the typesetter’s pushback routine, because we
 don’t really trust it very much.
 \end{document}

--- a/packages/dropcaps.lua
+++ b/packages/dropcaps.lua
@@ -69,7 +69,7 @@ end, "Show an 'initial capital' (also known as a 'drop cap') at the start of the
 return {
   documentation = [[
 \begin{document}
-The \code{dropcaps} package allows you to format paragraphs with an 'initial capital' (also commonly
+The \autodoc:package{dropcaps} package allows you to format paragraphs with an 'initial capital' (also commonly
 referred as a 'drop cap'), typically one large capital letter used as a decorative element at the beginning of a paragraph.
 
 It provides the \autodoc:command{\dropcap} command.

--- a/packages/dropcaps.lua
+++ b/packages/dropcaps.lua
@@ -72,7 +72,7 @@ return {
 The \code{dropcaps} package allows you to format paragraphs with an 'initial capital' (also commonly
 referred as a 'drop cap'), typically one large capital letter used as a decorative element at the beginning of a paragraph.
 
-It provides the \code{\\dropcap} command.
+It provides the \autodoc:command{\dropcap} command.
 The content passed will be the initial character(s).
 The primary option is \code{lines}, an integer specifying the number of lines to span (defaults to 3).
 The scale of can be adjusted relative to the first line using the \code{scale} option (defaults to 1.0).
@@ -80,7 +80,7 @@ The \code{join} is a boolean for whether to join the dropcap to the first line (
 If \code{join} is true, the value of the \code{standoff} option (defaults to 1spc) is applied to all but the first line.
 Optionally \code{color} can be passed to change the typeface color, sometimes useful to offset the apparent weight of a large glyph.
 To tweak the position of the dropcap, measurements may be passed to the \code{raise} and \code{shift} options.
-Other options passed to \\dropcap will be passed through to \\font when drawing the initial letter(s).
+Other options passed to \autodoc:command{\dropcap} will be passed through to \autodoc:command{\font} when drawing the initial letter(s).
 This may be useful for passing OpenType options or other font preferences.
 
 \begin{note}

--- a/packages/dropcaps.lua
+++ b/packages/dropcaps.lua
@@ -74,12 +74,12 @@ referred as a 'drop cap'), typically one large capital letter used as a decorati
 
 It provides the \autodoc:command{\dropcap} command.
 The content passed will be the initial character(s).
-The primary option is \code{lines}, an integer specifying the number of lines to span (defaults to 3).
-The scale of can be adjusted relative to the first line using the \code{scale} option (defaults to 1.0).
-The \code{join} is a boolean for whether to join the dropcap to the first line (defaults to false).
-If \code{join} is true, the value of the \code{standoff} option (defaults to 1spc) is applied to all but the first line.
-Optionally \code{color} can be passed to change the typeface color, sometimes useful to offset the apparent weight of a large glyph.
-To tweak the position of the dropcap, measurements may be passed to the \code{raise} and \code{shift} options.
+The primary option is \autodoc:parameter{lines}, an integer specifying the number of lines to span (defaults to 3).
+The scale of can be adjusted relative to the first line using the \autodoc:parameter{scale} option (defaults to 1.0).
+The \autodoc:parameter{join} is a boolean for whether to join the dropcap to the first line (defaults to false).
+If \autodoc:parameter{join} is true, the value of the \autodoc:parameter{standoff} option (defaults to 1spc) is applied to all but the first line.
+Optionally \autodoc:parameter{color} can be passed to change the typeface color, sometimes useful to offset the apparent weight of a large glyph.
+To tweak the position of the dropcap, measurements may be passed to the \autodoc:parameter{raise} and \autodoc:parameter{shift} options.
 Other options passed to \autodoc:command{\dropcap} will be passed through to \autodoc:command{\font} when drawing the initial letter(s).
 This may be useful for passing OpenType options or other font preferences.
 

--- a/packages/features.lua
+++ b/packages/features.lua
@@ -218,7 +218,7 @@ some fonts come with documentation explaining their supported features. Discussi
 of OpenType features is beyond the scope of this manual.
 
 These features can be turned on and off by passing ‘raw’ feature names to the
-\code{\\font} command like so:
+\autodoc:command{\font} command like so:
 
 \begin{verbatim}
 \line
@@ -227,7 +227,7 @@ These features can be turned on and off by passing ‘raw’ feature names to th
 \end{verbatim}
 
 However, this is unwieldy and requires memorizing the feature codes. \code{features}
-provides two commands, \code{\\add-font-feature} and \code{\\remove-font-feature},
+provides two commands, \autodoc:command{\add-font-feature} and \autodoc:command{\remove-font-feature},
 which make it easier to access OpenType features. The interface is patterned on the
 TeX package \code{fontspec}; for full documentation of the OpenType features supported,
 see the documentation for that package.\footnote{\code{http://texdoc.net/texmf-dist/doc/latex/fontspec/fontspec.pdf}}

--- a/packages/features.lua
+++ b/packages/features.lua
@@ -212,7 +212,7 @@ that you use. These ligatures are defined by tables of \em{features} within
 the font file. As well as ligatures (multiple glyphs displayed as a single glyph),
 the features tables also declare other glyph substitutions.
 
-The \code{features} package provides an interface to selecting the features that you
+The \autodoc:package{features} package provides an interface to selecting the features that you
 want SILE to apply to a font. The features available will be specific to the font file;
 some fonts come with documentation explaining their supported features. Discussion
 of OpenType features is beyond the scope of this manual.
@@ -226,13 +226,13 @@ These features can be turned on and off by passing ‘raw’ feature names to th
 \line
 \end{verbatim}
 
-However, this is unwieldy and requires memorizing the feature codes. \code{features}
+However, this is unwieldy and requires memorizing the feature codes. \autodoc:package{features}
 provides two commands, \autodoc:command{\add-font-feature} and \autodoc:command{\remove-font-feature},
 which make it easier to access OpenType features. The interface is patterned on the
 TeX package \code{fontspec}; for full documentation of the OpenType features supported,
 see the documentation for that package.\footnote{\code{http://texdoc.net/texmf-dist/doc/latex/fontspec/fontspec.pdf}}
 
-Here is how you would turn on discretionary and historic ligatures with the \code{features}
+Here is how you would turn on discretionary and historic ligatures with the \autodoc:package{features}
 package:
 
 \begin{verbatim}

--- a/packages/folio.lua
+++ b/packages/folio.lua
@@ -64,7 +64,7 @@ return {
   },
   documentation= [[
 \begin{document}
-The \code{folio} package (which is automatically loaded by the
+The \autodoc:package{folio} package (which is automatically loaded by the
 plain class, and therefore by nearly every SILE class) controls
 the output of folios—the old-time typesetter word for page numbers.
 

--- a/packages/folio.lua
+++ b/packages/folio.lua
@@ -70,13 +70,13 @@ the output of folios—the old-time typesetter word for page numbers.
 
 It provides four commands to users:
 
-\noindent{}• \code{\\nofolios}: turns page numbers off.
+\noindent{}• \autodoc:command{\nofolios}: turns page numbers off.
 
-\noindent{}• \code{\\nofoliothispage}: turns page numbers off for one page, then on again afterward.
+\noindent{}• \autodoc:command{\nofoliothispage}: turns page numbers off for one page, then on again afterward.
 
-\noindent{}• \code{\\folios}: turns page numbers back on.
+\noindent{}• \autodoc:command{\folios}: turns page numbers back on.
 
-\noindent{}• \code{\\foliostyle}: a command you can override to style the page numbers. By default, they are centered on the page.
+\noindent{}• \autodoc:command{\foliostyle}: a command you can override to style the page numbers. By default, they are centered on the page.
 
 If, for instance, you want to set page numbers in a different font
 you can redefine the command like so:

--- a/packages/font-fallback.lua
+++ b/packages/font-fallback.lua
@@ -184,7 +184,7 @@ instead.
 But there are times when this is just too strict. If you’re typesetting
 a document in English and Japanese, you should be able to choose your
 English font and choose your Japanese font, and if the glyph isn’t available
-in one, SILE should try the other. The \code{font-fallback} package gives you
+in one, SILE should try the other. The \autodoc:package{font-fallback} package gives you
 a way to specify a list of font specifications, and it will try each one in
 turn if glyphs cannot be found.
 

--- a/packages/font-fallback.lua
+++ b/packages/font-fallback.lua
@@ -188,9 +188,10 @@ in one, SILE should try the other. The \code{font-fallback} package gives you
 a way to specify a list of font specifications, and it will try each one in
 turn if glyphs cannot be found.
 
-It provides two commands, \command{\\font:add-fallback} and
-\command{\\font:clear-fallbacks}. The parameters to \command{\\font:add-fallback}
-are the same as the parameters to \command{\\font}. So this code:
+It provides two commands, \autodoc:command{\font:add-fallback} and
+\autodoc:command{\font:clear-fallbacks}.
+The parameters to \autodoc:command{\font:add-fallback} are the same as the
+parameters to \autodoc:command{\font}. So this code:
 
 \begin{verbatim}
 \line
@@ -216,10 +217,10 @@ and SILE will produce:
 \font:remove-fallback
 \font:remove-fallback
 
-\command{\\font:clear-fallbacks} removes all font fallbacks from the list
+\autodoc:command{\font:clear-fallbacks} removes all font fallbacks from the list
 of fonts to try.
 
-\command{\\font:remove-fallback} removes the last added fallback from the
+\autodoc:command{\font:remove-fallback} removes the last added fallback from the
 list of fonts to try.
 
 \end{document} ]]}

--- a/packages/footnotes.lua
+++ b/packages/footnotes.lua
@@ -105,9 +105,9 @@ return {
 \begin{document}
 We’ve seen that the \code{book} class allows you to add
 footnotes to text with the \autodoc:command{\footnote} command. This command is
-actually provided by the \code{footnotes} package. The \code{book}
+actually provided by the \autodoc:package{footnotes} package. The \code{book}
 class loads up the package and tells it where to put the footnotes
-that are typeset, and the \code{footnotes} package takes care of
+that are typeset, and the \autodoc:package{footnotes} package takes care of
 formatting the footnotes. It does this by using a number of other
 packages that we will describe below.
 \end{document}

--- a/packages/footnotes.lua
+++ b/packages/footnotes.lua
@@ -104,7 +104,7 @@ return {
   documentation = [[
 \begin{document}
 We’ve seen that the \code{book} class allows you to add
-footnotes to text with the \code{\\footnote} command. This command is
+footnotes to text with the \autodoc:command{\footnote} command. This command is
 actually provided by the \code{footnotes} package. The \code{book}
 class loads up the package and tells it where to put the footnotes
 that are typeset, and the \code{footnotes} package takes care of

--- a/packages/frametricks.lua
+++ b/packages/frametricks.lua
@@ -225,7 +225,7 @@ return {
   }, documentation = [[
 \begin{document}
 As we mentioned in the first chapter, SILE uses frames as an indication
-of where to put text onto the page. The \code{frametricks} package assists
+of where to put text onto the page. The \autodoc:package{frametricks} package assists
 package authors by providing a number of commands to manipulate frames.
 
 The most immediately useful is \autodoc:command{\showframe}. This asks the output
@@ -237,7 +237,7 @@ current class are displayed.
 It’s possible to define frames such as sidebars which are not connected
 to the main text flow of a page. We’ll see how to do that in a later chapter, but
 this raises the obvious question: if they’re not part of the text flow, how do we
-get stuff into them? \code{frametricks} provides the \autodoc:command{\typeset-into}
+get stuff into them? \autodoc:package{frametricks} provides the \autodoc:command{\typeset-into}
 command, which allows you to write text into a specified frame:
 
 \begin{verbatim}
@@ -246,7 +246,7 @@ command, which allows you to write text into a specified frame:
 \line
 \end{verbatim}
 
-\code{frametricks} also provides a number of commands which, to be perfectly
+\autodoc:package{frametricks} also provides a number of commands which, to be perfectly
 honest, we \em{thought} were going to be useful, but haven’t quite ended up
 being as useful as all that.
 
@@ -292,7 +292,7 @@ live on the page, but messing about with them dynamically seems to create
 more problems than it solves. There’s probably a reason why InDesign and
 similar applications handle floats, drop caps, tables and so on inside the
 context of a content frame rather than by messing with the frames themselves.
-If you feel tempted to play with \code{frametricks}, there’s almost always
+If you feel tempted to play with \autodoc:package{frametricks}, there’s almost always
 a better way to achieve what you want without it.
 \end{document}
 ]]

--- a/packages/frametricks.lua
+++ b/packages/frametricks.lua
@@ -228,7 +228,7 @@ As we mentioned in the first chapter, SILE uses frames as an indication
 of where to put text onto the page. The \code{frametricks} package assists
 package authors by providing a number of commands to manipulate frames.
 
-The most immediately useful is \code{\\showframe}. This asks the output
+The most immediately useful is \autodoc:command{\showframe}. This asks the output
 engine to draw a box and label around a particular frame. It takes an optional
 parameter \code{id=\em{<frame id>}}; if this is not supplied, the current
 frame is used. If the ID is \code{all}, then all frames declared by the
@@ -237,7 +237,7 @@ current class are displayed.
 It’s possible to define frames such as sidebars which are not connected
 to the main text flow of a page. We’ll see how to do that in a later chapter, but
 this raises the obvious question: if they’re not part of the text flow, how do we
-get stuff into them? \code{frametricks} provides the \command{\\typeset-into}
+get stuff into them? \code{frametricks} provides the \autodoc:command{\typeset-into}
 command, which allows you to write text into a specified frame:
 
 \begin{verbatim}
@@ -251,28 +251,28 @@ honest, we \em{thought} were going to be useful, but haven’t quite ended up
 being as useful as all that.
 
 \breakframevertical\par
-The command \code{\\breakframevertical} breaks the current frame in two
+The command \autodoc:command{\breakframevertical} breaks the current frame in two
 at the specified location into an upper and lower frame. If the frame initially had the ID
 \code{main}, then \code{main} becomes the upper frame (before the command)
 and the lower frame (after the command) is called \code{main_}. We just
-issued a \code{\\breakframevertical} command at the start of this paragraph,
-and now we will issue the command \code{\\showframe}. \showframe As you can
+issued a \autodoc:command{\breakframevertical} command at the start of this paragraph,
+and now we will issue the command \autodoc:command{\showframe}. \showframe As you can
 see, the current frame is called
 \code{\script{SILE.typesetter:typeset(SILE.typesetter.frame.id)}}
 and now begins at the start of the paragraph.
 
-Similarly, the \code{\\breakframehorizontal} command breaks the frame in two
+Similarly, the \autodoc:command{\breakframehorizontal} command breaks the frame in two
 into a left and a right frame.
 The command takes an optional argument \code{offset=<dimension>}, specifying
 where on the line the frame should be split. If it is not supplied, the
 frame is split at the current position in the line.
 
-The command \code{\\shiftframeedge} allows you to reposition the current
+The command \autodoc:command{\shiftframeedge} allows you to reposition the current
 frame left or right. It takes \code{left=} and/or \code{right=} parameters,
 which can be positive or negative dimensions. It should only be used at the
 top of a frame, as it reinitializes the typesetter object.
 
-Combining all of these commands, the \code{\\float} command breaks the current
+Combining all of these commands, the \autodoc:command{\float} command breaks the current
 frame, creates a small frame to hold a floating object, flows text into
 the surrounding frame, and then, once text has descended past the floating object,
 moves the frame back into place again. It takes two optional parameters, \code{bottomboundary=\em{<dimension>}} and/or \code{rightboundary=\em{<dimension>}}, which

--- a/packages/frametricks.lua
+++ b/packages/frametricks.lua
@@ -230,7 +230,7 @@ package authors by providing a number of commands to manipulate frames.
 
 The most immediately useful is \autodoc:command{\showframe}. This asks the output
 engine to draw a box and label around a particular frame. It takes an optional
-parameter \code{id=\em{<frame id>}}; if this is not supplied, the current
+parameter \autodoc:parameter{id=<frame id>}; if this is not supplied, the current
 frame is used. If the ID is \code{all}, then all frames declared by the
 current class are displayed.
 
@@ -263,20 +263,21 @@ and now begins at the start of the paragraph.
 
 Similarly, the \autodoc:command{\breakframehorizontal} command breaks the frame in two
 into a left and a right frame.
-The command takes an optional argument \code{offset=<dimension>}, specifying
+The command takes an optional argument \autodoc:parameter{offset=<dimension>}, specifying
 where on the line the frame should be split. If it is not supplied, the
 frame is split at the current position in the line.
 
 The command \autodoc:command{\shiftframeedge} allows you to reposition the current
-frame left or right. It takes \code{left=} and/or \code{right=} parameters,
+frame left or right. It takes \autodoc:parameter{left} and/or \autodoc:parameter{right} parameters,
 which can be positive or negative dimensions. It should only be used at the
 top of a frame, as it reinitializes the typesetter object.
 
 Combining all of these commands, the \autodoc:command{\float} command breaks the current
 frame, creates a small frame to hold a floating object, flows text into
 the surrounding frame, and then, once text has descended past the floating object,
-moves the frame back into place again. It takes two optional parameters, \code{bottomboundary=\em{<dimension>}} and/or \code{rightboundary=\em{<dimension>}}, which
-open up additional space around the frame. At the start of this paragraph, I issued
+moves the frame back into place again. It takes two optional parameters,
+\autodoc:parameter{bottomboundary=<dimension>} and/or \autodoc:parameter{rightboundary=<dimension>},
+which open up additional space around the frame. At the start of this paragraph, I issued
 the command
 
 \medskip

--- a/packages/grid.lua
+++ b/packages/grid.lua
@@ -206,10 +206,10 @@ the paper; on the right, no such guarantee is made.
 The \code{grid} package alters the way that the SILE’s typesetter operates so that
 the two rules above do not apply; lines are always aligned on a fixed grid, and
 spaces between paragraphs etc. are adjusted to conform to the grid. Loading the package
-adds two new commands to SILE: \code{\\grid[spacing=\em{<dimension>}]} and \code{\\no-grid}.
+adds two new commands to SILE: \autodoc:command{\grid[spacing=<dimension>]} and \autodoc:command{\no-grid}.
 The first turns on grid typesetting for the remainder of the document; the second turns it off again.
 
-At the start of this section, we issued the command \code{\\grid[spacing=15pt]} to
+At the start of this section, we issued the command \autodoc:command{\grid[spacing=15pt]} to
 set up a regular 15-point grid. Here is some text typeset with the grid set up:
 
 \smallskip
@@ -221,7 +221,7 @@ cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 \smallskip
 
-And here is the same text after we issue \code{\\no-grid}:
+And here is the same text after we issue \autodoc:command{\no-grid}:
 
 \no-grid\smallskip
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod

--- a/packages/grid.lua
+++ b/packages/grid.lua
@@ -203,7 +203,7 @@ the paper; on the right, no such guarantee is made.
 \img[src=documentation/grid-1.png,height=130]
 \img[src=documentation/grid-2.png,height=130]
 
-The \code{grid} package alters the way that the SILE’s typesetter operates so that
+The \autodoc:package{grid} package alters the way that the SILE’s typesetter operates so that
 the two rules above do not apply; lines are always aligned on a fixed grid, and
 spaces between paragraphs etc. are adjusted to conform to the grid. Loading the package
 adds two new commands to SILE: \autodoc:command{\grid[spacing=<dimension>]} and \autodoc:command{\no-grid}.

--- a/packages/gutenberg.lua
+++ b/packages/gutenberg.lua
@@ -29,7 +29,7 @@ extending SILE’s justification engine, the \code{gutenberg} package allows
 SILE to choose between a number of different options for a particular
 piece of text, depending on what would improve the line fitting.
 
-For instance, issuing the command \code{\\alternative\{\{and\}\{&\}\}} would insert
+For instance, issuing the command \autodoc:command{\alternative{\{and\}\{&\}}} would insert
 either the text \examplefont{and} or an ampersand, depending on what best
 fits the current line.
 \end{document}

--- a/packages/hanmenkyoshi.lua
+++ b/packages/hanmenkyoshi.lua
@@ -85,10 +85,10 @@ Japanese documents are traditionally typeset on a grid layout called a
 \code{hanmen}, with each character essentially monospaced inside the
 grid. (It’s like writing on graph paper.) The \code{hanmenkyoshi} package
 provides tools to Japanese class designers for creating hanmen frames with
-correctly spaced grids. It also provides the \code{\\show-hanmen}
+correctly spaced grids. It also provides the \autodoc:command{\show-hanmen}
 command for debugging the grid.
 
-The name \code{hanmenkyoshi} is a terrible pun.
+The name \em{hanmenkyoshi} is a terrible pun.
 \end{document}
   ]]
 }

--- a/packages/hanmenkyoshi.lua
+++ b/packages/hanmenkyoshi.lua
@@ -83,7 +83,7 @@ return {
 \begin{document}
 Japanese documents are traditionally typeset on a grid layout called a
 \code{hanmen}, with each character essentially monospaced inside the
-grid. (It’s like writing on graph paper.) The \code{hanmenkyoshi} package
+grid. (It’s like writing on graph paper.) The \autodoc:package{hanmenkyoshi} package
 provides tools to Japanese class designers for creating hanmen frames with
 correctly spaced grids. It also provides the \autodoc:command{\show-hanmen}
 command for debugging the grid.

--- a/packages/ifattop.lua
+++ b/packages/ifattop.lua
@@ -15,7 +15,7 @@ end)
 return {
   documentation = [[
 \begin{document}
-This package provides two commands: \code{\\ifattop} and \code{\\ifnotattop}.
+This package provides two commands: \autodoc:command{\ifattop} and \autodoc:command{\ifnotattop}.
 The argument of the command is processed only if the typesetter is at the top
 of a frame or is not at the top of a frame respectively.
 \end{document}

--- a/packages/image.lua
+++ b/packages/image.lua
@@ -32,8 +32,8 @@ As well as processing text, SILE can also include images.
 
 Loading the \code{image} package gives you the \autodoc:command{\img} command, fashioned
 after the HTML equivalent. It takes the following parameters:
-\code{src=…} must be the path to an image file;
-you may also give \code{height=…} and/or \code{width=…} parameters
+\autodoc:parameter{src=<file>} must be the path to an image file;
+you may also give \autodoc:parameter{height} and/or \autodoc:parameter{width} parameters
 to specify the output size of the image on the paper. If the size parameters
 are not given, then the image will be output at its ‘natural’ size,
 honoring its resolution if available.

--- a/packages/image.lua
+++ b/packages/image.lua
@@ -30,8 +30,8 @@ return {
 
 As well as processing text, SILE can also include images.
 
-Loading the \code{image} package gives you the \code{\\img} command, fashioned
-after the HTML equivalent. \code{\\img} takes the following parameters:
+Loading the \code{image} package gives you the \autodoc:command{\img} command, fashioned
+after the HTML equivalent. It takes the following parameters:
 \code{src=…} must be the path to an image file;
 you may also give \code{height=…} and/or \code{width=…} parameters
 to specify the output size of the image on the paper. If the size parameters
@@ -43,16 +43,16 @@ With the libtexpdf backend (the default), the images can be in JPEG, PNG,
 EPS or PDF formats.
 \end{note}
 
-Here is a 200x243 pixel image output with \code{\\img[src=documentation/gutenberg.png]}.
+Here is a 200x243 pixel image output with \autodoc:command{\img[src=documentation/gutenberg.png]}.
 The image has a claimed resolution of 100 pixels per inch, so ends up being 2 inches (144pt)
 wide on the page:\par
 \img[src=documentation/gutenberg.png]
 
 \raggedright{
 Here it is with (respectively)
-\code{\\img[src=documentation/gutenberg.png,width=120pt]},
-\code{\\img[src=documentation/gutenberg.png,height=200pt]}, and
-\code{\\img[src=documentation/gutenberg.png,width=120pt,height=200pt]}:}
+\autodoc:command{\img[src=documentation/gutenberg.png,width=120pt]},
+\autodoc:command{\img[src=documentation/gutenberg.png,height=200pt]}, and
+\autodoc:command{\img[src=documentation/gutenberg.png,width=120pt,height=200pt]}:}
 
 \img[src=documentation/gutenberg.png,width=120pt]
 \img[src=documentation/gutenberg.png,height=200pt]

--- a/packages/image.lua
+++ b/packages/image.lua
@@ -30,7 +30,7 @@ return {
 
 As well as processing text, SILE can also include images.
 
-Loading the \code{image} package gives you the \autodoc:command{\img} command, fashioned
+Loading the \autodoc:package{image} package gives you the \autodoc:command{\img} command, fashioned
 after the HTML equivalent. It takes the following parameters:
 \autodoc:parameter{src=<file>} must be the path to an image file;
 you may also give \autodoc:parameter{height} and/or \autodoc:parameter{width} parameters

--- a/packages/indexer.lua
+++ b/packages/indexer.lua
@@ -74,17 +74,17 @@ return {
   documentation = [[
 \begin{document}
 An index is essentially the same thing as a table of contents, but sorted.
-This package provides the \code{indexentry} command, which can be called
-as either \code{\\indexentry[label=...]} or \code{\\indexentry\{...\}} (so
+This package provides the \autodoc:command{\indexentry} command, which can be called
+as either \autodoc:command{\indexentry[label=<text>]} or \autodoc:command{\indexentry{<text>}} (so
 that it can be called from a macro). Index entries are collated at the end
-of each page, and the command \code{\\printindex} will deposit them in a list.
-The entry can be styled using the \code{\\index:item} command.
+of each page, and the command \autodoc:command{\printindex} will deposit them in a list.
+The entry can be styled using the \autodoc:command{\index:item} command.
 
 Multiple indexes are available and an index can be selected by passing the
-\code{index=...} parameter to \code{\\indexentry} and \code{\\printindex}.
+\code{index=...} parameter to \autodoc:command{\indexentry} and \autodoc:command{\printindex}.
 
 Classes using the indexer will need to call its exported function \code{buildIndex}
 as part of the end page routine.
 \end{document}
-  ]]
+]]
 }

--- a/packages/indexer.lua
+++ b/packages/indexer.lua
@@ -81,7 +81,7 @@ of each page, and the command \autodoc:command{\printindex} will deposit them in
 The entry can be styled using the \autodoc:command{\index:item} command.
 
 Multiple indexes are available and an index can be selected by passing the
-\code{index=...} parameter to \autodoc:command{\indexentry} and \autodoc:command{\printindex}.
+\autodoc:parameter{index=<name>} parameter to \autodoc:command{\indexentry} and \autodoc:command{\printindex}.
 
 Classes using the indexer will need to call its exported function \code{buildIndex}
 as part of the end page routine.

--- a/packages/infonode.lua
+++ b/packages/infonode.lua
@@ -62,8 +62,8 @@ nodes} into the text stream; when a page is outputted, these nodes are collected
 a list, and a class’s output routine can examine this list to determine which nodes
 fell on a particular page. \code{infonode} provides the \autodoc:command{\info} command
 to put an information node into the text stream; it has two required parameters,
-\code{category=} and \code{value=}. Categories are used to group similar sets of
-node together.
+\autodoc:parameter{category=<name>} and \autodoc:parameter{value=<any object>}.
+Categories are used to group similar sets of node together.
 
 As an example, when typesetting a Bible, you may wish to display which range
 of verses are on each page as a running header. During the command which starts

--- a/packages/infonode.lua
+++ b/packages/infonode.lua
@@ -60,7 +60,7 @@ for a particular element.
 To get around this problem, the \code{infonode} allows you to insert \em{information
 nodes} into the text stream; when a page is outputted, these nodes are collected into
 a list, and a class’s output routine can examine this list to determine which nodes
-fell on a particular page. \code{infonode} provides the \code{\\info} command
+fell on a particular page. \code{infonode} provides the \autodoc:command{\info} command
 to put an information node into the text stream; it has two required parameters,
 \code{category=} and \code{value=}. Categories are used to group similar sets of
 node together.
@@ -71,7 +71,7 @@ a new verse, you would insert an information node with the verse reference:
 
 \begin{verbatim}
 \line
-SILE.call("info", { category = "references", value = ref }, {})
+SILE.call("info", \{ category = "references", value = ref \}, \{\})
 \line
 \end{verbatim}
 

--- a/packages/infonode.lua
+++ b/packages/infonode.lua
@@ -57,10 +57,10 @@ the text will eventually end up on. This makes it difficult to produce
 indexes, tables of contents and so on where one needs to know the page number
 for a particular element.
 
-To get around this problem, the \code{infonode} allows you to insert \em{information
+To get around this problem, the \autodoc:package{infonode} package allows you to insert \em{information
 nodes} into the text stream; when a page is outputted, these nodes are collected into
 a list, and a class’s output routine can examine this list to determine which nodes
-fell on a particular page. \code{infonode} provides the \autodoc:command{\info} command
+fell on a particular page. \autodoc:package{infonode} provides the \autodoc:command{\info} command
 to put an information node into the text stream; it has two required parameters,
 \autodoc:parameter{category=<name>} and \autodoc:parameter{value=<any object>}.
 Categories are used to group similar sets of node together.

--- a/packages/inputfilter.lua
+++ b/packages/inputfilter.lua
@@ -36,11 +36,11 @@ return {
     transformContent = transformContent
   },
   documentation = [[\begin{document}
-The \code{inputfilter} package provides ways for class authors to transform the
+The \autodoc:package{inputfilter} package provides ways for class authors to transform the
 input of a SILE document after it is parsed but before it is processed. It does
 this by allowing you to rewrite the abstract syntax tree representing the document.
 
-Loading \code{inputfilter} into your class with \code{class:loadPackage("inputfilter")}
+Loading \autodoc:package{inputfilter} into your class with \code{class:loadPackage("inputfilter")}
 provides you with two new Lua functions: \code{transformContent} and \code{createCommand}.
 \code{transformContent} takes a content tree and applies a transformation function to the
 text within it. See \url{https://sile-typesetter.org/examples/inputfilter.sil} for a simple example, and

--- a/packages/insertions.lua
+++ b/packages/insertions.lua
@@ -447,9 +447,9 @@ return {
   },
   documentation = [[
 \begin{document}
-The \code{footnotes} package works by taking auxiliary material (the
+The \autodoc:package{footnotes} package works by taking auxiliary material (the
 footnote content), shrinking the current frame and inserting it into the
-footnote frame. This is powered by the \code{insertions} package; it doesn’t
+footnote frame. This is powered by the \autodoc:package{insertions} package; it doesn’t
 provide any user-visible SILE commands, but provides Lua functionality to
 other packages. TeX wizards may be interested to realise that insertions are
 implemented by an external add-on package, rather than being part of the SILE core.

--- a/packages/leaders.lua
+++ b/packages/leaders.lua
@@ -106,7 +106,7 @@ end)
 return {
   documentation = [[
 \begin{document}
-The leaders package allows you to create repeating patterns which fill a
+The \autodoc:package{leaders} package allows you to create repeating patterns which fill a
 given space. It provides the \autodoc:command{\dotfill} command, which does this:
 
 \begin{verbatim}

--- a/packages/leaders.lua
+++ b/packages/leaders.lua
@@ -107,7 +107,7 @@ return {
   documentation = [[
 \begin{document}
 The leaders package allows you to create repeating patterns which fill a
-given space. It provides the \code{\\dotfill} command, which does this:
+given space. It provides the \autodoc:command{\dotfill} command, which does this:
 
 \begin{verbatim}
 \line
@@ -119,7 +119,7 @@ A\\dotfill\{\}B
 A\dotfill{}B\par
 \end{examplefont}
 
-It also provides the \code{\\leaders[width=...]\{content\}} command which
+It also provides the \autodoc:command{\leaders[width=<dimension>]{<content>}} command which
 allow you to define your own leaders. For example:
 
 \begin{verbatim}
@@ -133,7 +133,7 @@ A\leaders[width=40pt]{/\\}B\par
 \end{examplefont}
 
 If the width is omitted, the leaders extend as much as possible (as a
-\code{\\dotfill} or \code{\\hfill}).
+\autodoc:command{\dotfill} or \autodoc:command{\hfill}).
 
 Leader patterns are always vertically aligned, respectively to the end
 edge of the frame they appear in, for a given font.

--- a/packages/linespacing.lua
+++ b/packages/linespacing.lua
@@ -140,7 +140,7 @@ return { documentation = [[\begin{document}
 
 SILE’s default method of inserting leading between lines should be familiar to
 users of TeX, but it is not the most friendly system for book designers. The
-\code{linespacing} package provides a better choice of leading systems.
+\autodoc:package{linespacing} package provides a better choice of leading systems.
 
 After loading the package, you are able to choose the linespacing mode by setting
 the \autodoc:setting{linespacing.method} parameter. The following examples have

--- a/packages/linespacing.lua
+++ b/packages/linespacing.lua
@@ -142,10 +142,9 @@ SILE’s default method of inserting leading between lines should be familiar to
 users of TeX, but it is not the most friendly system for book designers. The
 \code{linespacing} package provides a better choice of leading systems.
 
-After loading the package (with \code{\\script[src=packages/linespacing]}),
-you are able to choose the linespacing mode by setting the \autodoc:setting{linespacing.method}
-parameter. The following examples have funny sized words in them so that you can see
-how the different methods interact.
+After loading the package, you are able to choose the linespacing mode by setting
+the \autodoc:setting{linespacing.method} parameter. The following examples have
+funny sized words in them so that you can see how the different methods interact.
 
 By default, this is set to \code{tex}. The other options available are:
 

--- a/packages/lorem.lua
+++ b/packages/lorem.lua
@@ -95,7 +95,7 @@ return {
 \begin{document}
 Sometimes you just need some dummy text. The command \autodoc:command{\lorem}
 produces fifty words of “lorem ipsum”; you can choose a different
-number of words with the \code{[words=...]} parameter. Here’s
+number of words with the \autodoc:parameter{words=<number>} parameter. Here’s
 \autodoc:command{\lorem[words=20]}:
 
 \examplefont{\lorem[words=20]}

--- a/packages/lorem.lua
+++ b/packages/lorem.lua
@@ -93,10 +93,10 @@ end)
 return {
   documentation = [[
 \begin{document}
-Sometimes you just need some dummy text. The command \code{\\lorem}
+Sometimes you just need some dummy text. The command \autodoc:command{\lorem}
 produces fifty words of “lorem ipsum”; you can choose a different
 number of words with the \code{[words=...]} parameter. Here’s
-\code{\\lorem[words=20]}:
+\autodoc:command{\lorem[words=20]}:
 
 \examplefont{\lorem[words=20]}
 \end{document}

--- a/packages/masters.lua
+++ b/packages/masters.lua
@@ -97,10 +97,10 @@ return {
 
 The masters functionality is also itself an add-on package. It allows a class to
 define sets of frames and switch between them either temporarily or permanently.
-It defines the commands \command{\\define-master-template} (which is pattern
-on the \command{\\pagetemplate} function we will meet in chapter 8), \command{\\switch-master}
-and \command{\\switch-master-one-page}. See \code{tests/masters.sil} for more
-about this package.
+It defines the commands \autodoc:command{\define-master-template} (which is pattern
+on the \autodoc:command{\pagetemplate} function we will meet in chapter 8),
+\autodoc:command{\switch-master} and \autodoc:command{\switch-master-one-page}.
+See \code{tests/masters.sil} for more about this package.
 
 \end{document}
 ]]

--- a/packages/math.lua
+++ b/packages/math.lua
@@ -66,7 +66,7 @@ To render an equation encoded in MathML, one simply has to put it in a
 \end{verbatim}
 
 \noindent By default, formulas are integrated into the flow of text. To typeset
-them on their own line, one may use the \code{[mode=display]} option:
+them on their own line, one may use the \autodoc:parameter{mode=display} option:
 
 \mathml[mode=display]{
     \mrow{

--- a/packages/parallel.lua
+++ b/packages/parallel.lua
@@ -134,7 +134,7 @@ return {
   init = setupParallel,
   documentation = [[
 \begin{document}
-The parallel package provides the mechanism for typesetting diglot or other
+The \autodoc:package{parallel} package provides the mechanism for typesetting diglot or other
 parallel documents. When used by a class such as \code{classes/diglot.lua},
 it registers a command for each parallel frame, to allow you to select
 which frame you’re typesetting into. It also defines the \autodoc:command{\sync}

--- a/packages/parallel.lua
+++ b/packages/parallel.lua
@@ -137,7 +137,7 @@ return {
 The parallel package provides the mechanism for typesetting diglot or other
 parallel documents. When used by a class such as \code{classes/diglot.lua},
 it registers a command for each parallel frame, to allow you to select
-which frame you’re typesetting into. It also defines the \code{\\sync}
+which frame you’re typesetting into. It also defines the \autodoc:command{\sync}
 command, which adds vertical spacing to each frame such that the \em{next}
 set of text is vertically aligned. See \url{https://sile-typesetter.org/examples/parallel.sil}
 and the source of \code{classes/diglot.lua} for examples which makes the operation clear.

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -148,14 +148,14 @@ end)
 
 return { documentation = [[\begin{document}
 The \code{pdf} package enables (basic) support for PDF links and table-of-contents
-entries. It provides the four commands \command{\\pdf:destination}, \command{\\pdf:link},
-\command{\\pdf:bookmark}, and \command{\\pdf:metadata}.
+entries. It provides the four commands \autodoc:command{\pdf:destination}, \autodoc:command{\pdf:link},
+\autodoc:command{\pdf:bookmark}, and \autodoc:command{\pdf:metadata}.
 
-The \command{\\pdf:destination} parameter creates a link target; it expects a
+The \autodoc:command{\pdf:destination} parameter creates a link target; it expects a
 parameter called \code{name} to uniquely identify the target. To create a link to
-that location in the document, use \code{\\pdf:link[dest=\goodbreak{}name]\{link content\}}.
+that location in the document, use \autodoc:command{\pdf:link[dest=<name>]{link content}}.
 
-The \command{\\pdf:link} command accepts several options defining its border style:
+The \autodoc:command{\pdf:link} command accepts several options defining its border style:
 a \code{borderwidth} length setting the border width (defaults to 0, meaning no border),
 a \code{borderstyle} string (can be set to “underline” or “dashed”, otherwise a
 solid box),
@@ -168,7 +168,7 @@ It also has an \code{external} option for URL links, which is not intended to be
 directly—refer to the \code{url} package for more flexibility typesetting external
 links.
 
-To set arbitrary key-value metadata, use something like \code{\\pdf:metadata[key=Author,
+To set arbitrary key-value metadata, use something like \autodoc:command{\pdf:metadata[key=Author,
 value=J. Smith]}. The PDF metadata field names are case-sensitive. Common keys include
 \code{Title}, \code{Author}, \code{Subject}, \code{Keywords}, \code{CreationDate}, and
 \code{ModDate}.

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -152,19 +152,19 @@ entries. It provides the four commands \autodoc:command{\pdf:destination}, \auto
 \autodoc:command{\pdf:bookmark}, and \autodoc:command{\pdf:metadata}.
 
 The \autodoc:command{\pdf:destination} parameter creates a link target; it expects a
-parameter called \code{name} to uniquely identify the target. To create a link to
-that location in the document, use \autodoc:command{\pdf:link[dest=<name>]{link content}}.
+parameter called \autodoc:parameter{name} to uniquely identify the target. To create a link to
+that location in the document, use \autodoc:command{\pdf:link[dest=<name>]{<content>}}.
 
 The \autodoc:command{\pdf:link} command accepts several options defining its border style:
-a \code{borderwidth} length setting the border width (defaults to 0, meaning no border),
-a \code{borderstyle} string (can be set to “underline” or “dashed”, otherwise a
+a \autodoc:parameter{borderwidth} length setting the border width (defaults to 0, meaning no border),
+a \autodoc:parameter{borderstyle} string (can be set to “underline” or “dashed”, otherwise a
 solid box),
-a \code{bordercolor} color specification for this border (defaults to blue),
-and finally a \code{borderoffset} length for adjusting the border with some vertical space
+a \autodoc:parameter{bordercolor} color specification for this border (defaults to blue),
+and finally a \autodoc:parameter{borderoffset} length for adjusting the border with some vertical space
 above the content and below the baseline (defaults to 1pt). Note that PDF renderers may vary on how
 they honor these border styling features on link annotations.
 
-It also has an \code{external} option for URL links, which is not intended to be used
+It also has an \autodoc:parameter{external} option for URL links, which is not intended to be used
 directly—refer to the \code{url} package for more flexibility typesetting external
 links.
 

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -147,7 +147,7 @@ SILE.registerCommand("pdf:metadata", function (options, _)
 end)
 
 return { documentation = [[\begin{document}
-The \code{pdf} package enables (basic) support for PDF links and table-of-contents
+The \autodoc:package{pdf} package enables (basic) support for PDF links and table-of-contents
 entries. It provides the four commands \autodoc:command{\pdf:destination}, \autodoc:command{\pdf:link},
 \autodoc:command{\pdf:bookmark}, and \autodoc:command{\pdf:metadata}.
 
@@ -165,7 +165,7 @@ above the content and below the baseline (defaults to 1pt). Note that PDF render
 they honor these border styling features on link annotations.
 
 It also has an \autodoc:parameter{external} option for URL links, which is not intended to be used
-directly—refer to the \code{url} package for more flexibility typesetting external
+directly—refer to the \autodoc:package{url} package for more flexibility typesetting external
 links.
 
 To set arbitrary key-value metadata, use something like \autodoc:command{\pdf:metadata[key=Author,

--- a/packages/pdfstructure.lua
+++ b/packages/pdfstructure.lua
@@ -119,17 +119,17 @@ end
 return {
   documentation = [[
 \begin{document}
-\pdf:structure[type=P]{
+\pdf:structure[type=P]{%
 For PDF documents to be considered accessible, they must contain a
 description of the PDF’s document structure. This package allows
 structure trees to be created and saved to the PDF file. Currently
 this provides a low-level interface to creating nodes in the tree;
-classes which require PDF accessibility should use the \code{\\pdf:structure}
+classes which require PDF accessibility should use the \autodoc:command{\pdf:structure}
 command in their sectioning implementation to declare the document
 structure.
 }
 
-\pdf:structure[type=P]{
+\pdf:structure[type=P]{%
 See \code{tests/pdf.sil} for an example of using the \code{pdfstructure}
 package to create a PDF/UA compatible document.
 }

--- a/packages/pdfstructure.lua
+++ b/packages/pdfstructure.lua
@@ -130,7 +130,7 @@ structure.
 }
 
 \pdf:structure[type=P]{%
-See \code{tests/pdf.sil} for an example of using the \code{pdfstructure}
+See \code{tests/pdf.sil} for an example of using the \autodoc:package{pdfstructure}
 package to create a PDF/UA compatible document.
 }
 \end{document}

--- a/packages/pullquote.lua
+++ b/packages/pullquote.lua
@@ -85,9 +85,9 @@ Optional values are available for:
 • \code{scale} to change the relative size of the quote marks\par
 
 If you want to specify what font the pullquote environment should use, you
-can redefine the \code{pullquote:font} command. By default it will be the same
+can redefine the \autodoc:command{\pullquote:font} command. By default it will be the same
 as the surrounding document. The font style used for the attribution line
-can likewise be set using \code{pullquote:author-font} and the font used for
-the quote marks can be set using \code{pullquote:mark-font}.
+can likewise be set redefining \autodoc:command{\pullquote:author-font} and the font used for
+the quote marks can be set redefining \autodoc:command{\pullquote:mark-font}.
 
 \end{document}]] }

--- a/packages/pullquote.lua
+++ b/packages/pullquote.lua
@@ -79,10 +79,10 @@ do not know.
 
 Optional values are available for:
 
-• \code{author} to add an attribution line\par
-• \code{setback} to set the bilateral margins around the block\par
-• \code{color} to change the color of the quote marks\par
-• \code{scale} to change the relative size of the quote marks\par
+• \autodoc:parameter{author} to add an attribution line\par
+• \autodoc:parameter{setback} to set the bilateral margins around the block\par
+• \autodoc:parameter{color} to change the color of the quote marks\par
+• \autodoc:parameter{scale} to change the relative size of the quote marks\par
 
 If you want to specify what font the pullquote environment should use, you
 can redefine the \autodoc:command{\pullquote:font} command. By default it will be the same

--- a/packages/pullquote.lua
+++ b/packages/pullquote.lua
@@ -66,12 +66,12 @@ end, "Typesets its contents in a formatted blockquote with decorative quotation\
 
 return { documentation = [[\begin{document}
 
-The \code{pullquote} command formats longer quotations in an indented
+The \autodoc:environment{pullquote} environment formats longer quotations in an indented
 blockquote block with decorative quotation marks in the margins.
 
 Here is some text set in a pullquote environment:
 
-\begin[author=Anatole France]{pullquote}
+\begin[author=Anatole France]{pullquote}%
 An education is not how much you have committed to memory, or even how much you
 know. It is being able to differentiate between what you do know and what you
 do not know.

--- a/packages/raiselower.lua
+++ b/packages/raiselower.lua
@@ -26,8 +26,8 @@ return {
 \begin{document}
 
 If you don’t want your images, rules or text to be placed along
-the baseline, you can use the \code{raiselower} package to move them up
-and down. (The \code{footnote} package uses this to superscript the
+the baseline, you can use the \autodoc:package{raiselower} package to move them up
+and down. (The \autodoc:package{footnote} package uses this to superscript the
 footnote reference numbers.)
 
 It provides two simple commands, \autodoc:command{\raise} and \autodoc:command{\lower} which

--- a/packages/raiselower.lua
+++ b/packages/raiselower.lua
@@ -31,7 +31,7 @@ and down. (The \code{footnote} package uses this to superscript the
 footnote reference numbers.)
 
 It provides two simple commands, \autodoc:command{\raise} and \autodoc:command{\lower} which
-both take a \code{height=\em{<dimension>}} parameter. They will respectively
+both take a \autodoc:parameter{height=<dimension>} parameter. They will respectively
 raise or lower their argument by the given height. The raised or lowered
 content will not alter the height or depth of the line.
 

--- a/packages/raiselower.lua
+++ b/packages/raiselower.lua
@@ -30,7 +30,7 @@ the baseline, you can use the \code{raiselower} package to move them up
 and down. (The \code{footnote} package uses this to superscript the
 footnote reference numbers.)
 
-It provides two simple commands, \code{\\raise} and \code{\\lower} which
+It provides two simple commands, \autodoc:command{\raise} and \autodoc:command{\lower} which
 both take a \code{height=\em{<dimension>}} parameter. They will respectively
 raise or lower their argument by the given height. The raised or lowered
 content will not alter the height or depth of the line.

--- a/packages/rebox.lua
+++ b/packages/rebox.lua
@@ -15,7 +15,7 @@ end, "Place the output within a hbox of specified width, height, depth and visib
 return {
   documentation = [[
 \begin{document}
-This package provides the \code{\\rebox} command, which allows you to
+This package provides the \autodoc:command{\rebox} command, which allows you to
 lie to SILE about the size of content. You can change the \code{width},
 \code{height}, or \code{depth} of your content with the respective
 parameters, or make it invisible by using the \code{phantom} parameter.

--- a/packages/rebox.lua
+++ b/packages/rebox.lua
@@ -16,9 +16,9 @@ return {
   documentation = [[
 \begin{document}
 This package provides the \autodoc:command{\rebox} command, which allows you to
-lie to SILE about the size of content. You can change the \code{width},
-\code{height}, or \code{depth} of your content with the respective
-parameters, or make it invisible by using the \code{phantom} parameter.
+lie to SILE about the size of content. You can change the \autodoc:parameter{width},
+\autodoc:parameter{height}, or \autodoc:parameter{depth} of your content with the respective
+parameters, or make it invisible by setting the \autodoc:parameter{phantom} parameter to true.
 
 For example:
 

--- a/packages/rotate.lua
+++ b/packages/rotate.lua
@@ -97,8 +97,8 @@ end)
 return { documentation = [[\begin{document}
 The \code{rotate} package allows you to rotate things. You can rotate entire
 frames, by adding the \code{rotate=<angle>} declaration to your frame declaration,
-and you can rotate any content by issuing the command \code{\\rotate[angle=<angle>]\{...\}},
-where \code{<angle>} is measured in degrees.
+and you can rotate any content by issuing the command \autodoc:command{\rotate[angle=<angle>]{<content>}},
+where the angle is measured in degrees.
 
 Content which is rotated is placed in a box and rotated. The height and width of
 the rotated box is measured, and then put into the normal horizontal list for

--- a/packages/rotate.lua
+++ b/packages/rotate.lua
@@ -96,7 +96,7 @@ end)
 
 return { documentation = [[\begin{document}
 The \code{rotate} package allows you to rotate things. You can rotate entire
-frames, by adding the \code{rotate=<angle>} declaration to your frame declaration,
+frames, by adding the \autodoc:parameter{rotate=<angle>} declaration to your frame declaration,
 and you can rotate any content by issuing the command \autodoc:command{\rotate[angle=<angle>]{<content>}},
 where the angle is measured in degrees.
 

--- a/packages/rotate.lua
+++ b/packages/rotate.lua
@@ -95,7 +95,7 @@ SILE.registerCommand("rotate", function(options, content)
 end)
 
 return { documentation = [[\begin{document}
-The \code{rotate} package allows you to rotate things. You can rotate entire
+The \autodoc:package{rotate} package allows you to rotate things. You can rotate entire
 frames, by adding the \autodoc:parameter{rotate=<angle>} declaration to your frame declaration,
 and you can rotate any content by issuing the command \autodoc:command{\rotate[angle=<angle>]{<content>}},
 where the angle is measured in degrees.

--- a/packages/ruby.lua
+++ b/packages/ruby.lua
@@ -109,7 +109,8 @@ difficult kanji or foreign words. These hints are traditionally placed either
 above (in horizontal typesetting) or beside (in vertical typesetting) the word
 that they explain. The typesetting term for these glosses is \em{ruby}.
 
-The \code{ruby} package provides the \code{\\ruby[reading=...]\{...\}} command
+The \code{ruby} package provides the
+\autodoc:command[check=false]{\ruby[reading=<ruby text>]{<base text>}} command
 which sets a piece of ruby above or beside the base text. For example:
 
 % Unit zw throws errors if there is not way to shape あ

--- a/packages/ruby.lua
+++ b/packages/ruby.lua
@@ -109,7 +109,7 @@ difficult kanji or foreign words. These hints are traditionally placed either
 above (in horizontal typesetting) or beside (in vertical typesetting) the word
 that they explain. The typesetting term for these glosses is \em{ruby}.
 
-The \code{ruby} package provides the
+The \autodoc:package{ruby} package provides the
 \autodoc:command[check=false]{\ruby[reading=<ruby text>]{<base text>}} command
 which sets a piece of ruby above or beside the base text. For example:
 

--- a/packages/rules.lua
+++ b/packages/rules.lua
@@ -112,7 +112,7 @@ SILE.registerCommand("boxaround", function (_, content)
 end, "Draws a box around some content")
 
 return { documentation = [[\begin{document}
-The \code{rules} package draws lines. It provides three commands.
+The \autodoc:package{rules} package draws lines. It provides three commands.
 
 The first command is \autodoc:command{\hrule},
 which draws a line of a given length and thickness, although it calls these
@@ -124,7 +124,7 @@ was generated with \autodoc:command{\hrule[width=20pt, height=0.5pt]}.)
 
 Like images, rules are placed along the baseline of a line of text.
 
-The second command provided by \code{rules} is \autodoc:command{\underline}, which
+The second command provided by this package is \autodoc:command{\underline}, which
 underlines its contents.
 
 \note{

--- a/packages/rules.lua
+++ b/packages/rules.lua
@@ -116,7 +116,7 @@ The \code{rules} package draws lines. It provides three commands.
 
 The first command is \autodoc:command{\hrule},
 which draws a line of a given length and thickness, although it calls these
-\code{width} and \code{height}. (A box is just a square line.)
+\autodoc:parameter{width} and \autodoc:parameter{height}. (A box is just a square line.)
 
 Lines are treated just like other text to be output, and so can appear in the
 middle of a paragraph, like this: \hrule[width=20pt, height=0.5pt] (that one

--- a/packages/rules.lua
+++ b/packages/rules.lua
@@ -114,24 +114,24 @@ end, "Draws a box around some content")
 return { documentation = [[\begin{document}
 The \code{rules} package draws lines. It provides three commands.
 
-The first command is \code{\\hrule},
+The first command is \autodoc:command{\hrule},
 which draws a line of a given length and thickness, although it calls these
 \code{width} and \code{height}. (A box is just a square line.)
 
 Lines are treated just like other text to be output, and so can appear in the
 middle of a paragraph, like this: \hrule[width=20pt, height=0.5pt] (that one
-was generated with \code{\\hrule[width=20pt, height=0.5pt]}.)
+was generated with \autodoc:command{\hrule[width=20pt, height=0.5pt]}.)
 
 Like images, rules are placed along the baseline of a line of text.
 
-The second command provided by \code{rules} is \code{\\underline}, which
+The second command provided by \code{rules} is \autodoc:command{\underline}, which
 underlines its contents.
 
 \note{
 Underlining is horrible typographic practice, and
 you should \underline{never} do it.}
 
-(That was produced with \code{\\underline\{never\}}.)
+(That was produced with \autodoc:command{\underline{never}}.)
 
-Finally, \code{fullrule} draws a thin line across the width of the current frame.
+Finally, \autodoc:command{\fullrule} draws a thin line across the width of the current frame.
 \end{document}]] }

--- a/packages/simpletable.lua
+++ b/packages/simpletable.lua
@@ -86,7 +86,7 @@ myclass:loadpackage("simpletable", \{
 \end{verbatim}
 
 this will define commands \code{\\a}, \code{\\b} and \code{\\c} which
-are equivalent to the \code{<table>, \code{<tr>} and \code{td} tags.
+are equivalent to the \code{<table>, \code{<tr>} and \code{<td>} tags.
 
 this is not a complete table implementation, and should be replaced by
 one which implements the css2.1 two-pass table formatting algorithm.

--- a/packages/specimen.lua
+++ b/packages/specimen.lua
@@ -57,9 +57,9 @@ SILE has found itself becoming well used by type designers, who often
 want to create specimen documents to show off their new fonts. This package
 provides a few commands to help create test documents. (The \code{fontproof}
 class, available from the package manager, contains many more tools for creating
-specimens.) The \code{\\repertoire} command prints out every glyph in the
-font, in a simple table. The \code{\\pangrams} command prints out a few
-pangrams for the Latin script. Finally, \code{\\set-to-width[width=...]\{...\}}
+specimens.) The \autodoc:command{\repertoire} command prints out every glyph in the
+font, in a simple table. The \autodoc:command{\pangrams} command prints out a few
+pangrams for the Latin script. Finally, \autodoc:command{\set-to-width[width=<dimension>]{<content>}}
 will process each line of content, changing the font size so that the output
 is a constant width.
 

--- a/packages/svg.lua
+++ b/packages/svg.lua
@@ -62,17 +62,17 @@ return {
   documentation = [[\begin{document}
 This package provides two commands.
 
-The first is \code{\\svg[src=...,[width=...,]{}[height=...,]{}[density=...]{}]}.
+The first is \autodoc:command{\svg[src=<file>]}.
 This loads and parses an SVG file and attempts to render it in the current
-document. Optional width or height options will scale the SVG canvas to the
-given size calculated at a given density option (which defaults to 72 ppi). For
+document. Optional \code{width} or \code{height} options will scale the SVG canvas to the
+given size calculated at a given \code{density} option (which defaults to 72 ppi). For
 example, the command
-\code{\\svg[src=packages/svg/smiley.svg,\goodbreak{}height=12pt]}
+\autodoc:command{\svg[src=packages/svg/smiley.svg,height=12pt]}
 produces the following:
 
 \svg[src=packages/svg/smiley.svg,height=12pt]
 
-The second is a more experimental \code{\\svg-glyph}. When the current font is
+The second is a more experimental \autodoc:command{\svg-glyph}. When the current font is
 set to an SVG font, SILE does not currently render the SVG glyphs
 automatically. This command is intended to be used as a means of eventually
 implementing SVG fonts; it retrieves the SVG glyph provided and renders it.

--- a/packages/svg.lua
+++ b/packages/svg.lua
@@ -79,7 +79,7 @@ implementing SVG fonts; it retrieves the SVG glyph provided and renders it.
 
 In both cases the rendering is done with our own SVG drawing library; it is currently
 very minimal, only handling lines, curves, strokes and fills. For a fuller
-implementation, consider using a \code{converters} registration to render
+implementation, consider using a \autodoc:package{converters} registration to render
 your SVG file to PDF and include it on the fly.
 \end{document}]]
 

--- a/packages/svg.lua
+++ b/packages/svg.lua
@@ -64,10 +64,10 @@ This package provides two commands.
 
 The first is \autodoc:command{\svg[src=<file>]}.
 This loads and parses an SVG file and attempts to render it in the current
-document. Optional \code{width} or \code{height} options will scale the SVG canvas to the
-given size calculated at a given \code{density} option (which defaults to 72 ppi). For
-example, the command
-\autodoc:command{\svg[src=packages/svg/smiley.svg,height=12pt]}
+document. Optional \autodoc:parameter{width} or \autodoc:parameter{height}
+options will scale the SVG canvas to the given size calculated at a given
+\autodoc:parameter{density} option (which defaults to 72 ppi). For
+example, the command \autodoc:command{\svg[src=packages/svg/smiley.svg,height=12pt]}
 produces the following:
 
 \svg[src=packages/svg/smiley.svg,height=12pt]

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -137,38 +137,39 @@ SILE.doTexlike([[%
 The \code{tableofcontents} package provides tools for class authors to
 create tables of contents. When you are writing sectioning commands such
 as \code{\\chapter} or \code{\\section}, your classes should call the
-\code{\\tocentry[level=...]\{Entry\}} command to register a table of
-contents entry. At the end of each page, the exported Lua function
-\code{moveTocNodes} should be called to collate the table of contents
+\autodoc:command{\tocentry[level=<number>, number=<string>]{<title>}}
+command to register a table of contents entry.
+At the end of each page, the exported Lua function \code{moveTocNodes}
+should be called to collate the table of contents
 entries and store which page they’re on. At the end of the document,
 the \code{writeToc} Lua function writes the table of contents data
 to a file. This is because the table of contents (written out with
-the \code{\\tableofcontents} command) is usually found at the
+the \autodoc:command{\tableofcontents} command) is usually found at the
 start of a document, before the entries have been processed. Because of
 this, documents with a table of contents need to be processed at least
 twice—once to collect the entries and work out which pages they’re on,
 then to write the table of contents.
 
-The \code{\\tableofcontents} command accepts a \code{depth} option to
+The \autodoc:command{\tableofcontents} command accepts a \code{depth} option to
 control the depth of the content added to the table.
 
 If the \code{pdf} package is loaded before using sectioning commands,
 then a PDF document outline will be generated.
 Moreover, entries in the table of contents will be active links to the
 relevant sections. To disable the latter behavior, pass \code{linking=false} to
-the \code{\\tableofcontents} command.
+the \autodoc:command{\tableofcontents} command.
 
 Class designers can also style the table of contents by overriding the
 following commands:
 
-\noindent{}• \code{\\tableofcontents:title} - the text at the top of the TOC.
+\noindent{}• \autodoc:command{\tableofcontents:title} - the text at the top of the TOC.
 
-\noindent{}• \code{\\tableofcontents:headerfont} - the font used for the header.
+\noindent{}• \autodoc:command{\tableofcontents:headerfont} - the font used for the header.
 
-\noindent{}• \code{\\tableofcontents:level1item}, \code{\\tableofcontents:level2item}, etc. - styling
+\noindent{}• \autodoc:command{\tableofcontents:level1item}, \autodoc:command{\tableofcontents:level2item}, etc. - styling
 for entries.
 
-\noindent{}• \code{\\tableofcontents:level1number}, \code{\\tableofcontents:level2number}, etc. - deciding
+\noindent{}• \autodoc:command{\tableofcontents:level1number}, \autodoc:command{\tableofcontents:level2number}, etc. - deciding
 what to do with entry section number, if defined: by default, nothing (so they do not show
 up in the table of contents).
 

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -137,7 +137,7 @@ SILE.doTexlike([[%
 The \code{tableofcontents} package provides tools for class authors to
 create tables of contents. When you are writing sectioning commands such
 as \code{\\chapter} or \code{\\section}, your classes should call the
-\autodoc:command{\tocentry[level=<number>, number=<string>]{<title>}}
+\autodoc:command{\tocentry[level=<number>, number=<strings>]{<title>}}
 command to register a table of contents entry.
 At the end of each page, the exported Lua function \code{moveTocNodes}
 should be called to collate the table of contents
@@ -150,13 +150,13 @@ this, documents with a table of contents need to be processed at least
 twice—once to collect the entries and work out which pages they’re on,
 then to write the table of contents.
 
-The \autodoc:command{\tableofcontents} command accepts a \code{depth} option to
+The \autodoc:command{\tableofcontents} command accepts a \autodoc:parameter{depth} option to
 control the depth of the content added to the table.
 
 If the \code{pdf} package is loaded before using sectioning commands,
 then a PDF document outline will be generated.
 Moreover, entries in the table of contents will be active links to the
-relevant sections. To disable the latter behavior, pass \code{linking=false} to
+relevant sections. To disable the latter behavior, pass \autodoc:parameter{linking=false} to
 the \autodoc:command{\tableofcontents} command.
 
 Class designers can also style the table of contents by overriding the

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -134,7 +134,7 @@ SILE.doTexlike([[%
   end,
   documentation = [[
 \begin{document}
-The \code{tableofcontents} package provides tools for class authors to
+The \autodoc:package{tableofcontents} package provides tools for class authors to
 create tables of contents. When you are writing sectioning commands such
 as \code{\\chapter} or \code{\\section}, your classes should call the
 \autodoc:command{\tocentry[level=<number>, number=<strings>]{<title>}}
@@ -153,7 +153,7 @@ then to write the table of contents.
 The \autodoc:command{\tableofcontents} command accepts a \autodoc:parameter{depth} option to
 control the depth of the content added to the table.
 
-If the \code{pdf} package is loaded before using sectioning commands,
+If the \autodoc:package{pdf} package is loaded before using sectioning commands,
 then a PDF document outline will be generated.
 Moreover, entries in the table of contents will be active links to the
 relevant sections. To disable the latter behavior, pass \autodoc:parameter{linking=false} to

--- a/packages/tate.lua
+++ b/packages/tate.lua
@@ -136,7 +136,7 @@ return {
   end,
   documentation = [[
 \begin{document}
-The \code{tate} package provides support for Japanese vertical typesetting.
+The \autodoc:package{tate} package provides support for Japanese vertical typesetting.
 It allows for the definition of vertical-oriented frames, as well
 as for two specific typesetting techniques required in vertical
 documents: \autodoc:command{\latin-in-tate} typesets its content as Latin

--- a/packages/tate.lua
+++ b/packages/tate.lua
@@ -139,8 +139,8 @@ return {
 The \code{tate} package provides support for Japanese vertical typesetting.
 It allows for the definition of vertical-oriented frames, as well
 as for two specific typesetting techniques required in vertical
-documents: \code{latin-in-tate} typesets its content as Latin
-text rotated 90 degrees, and \code{tate-chu-yoko} places (Latin)
+documents: \autodoc:command{\latin-in-tate} typesets its content as Latin
+text rotated 90 degrees, and \autodoc:command{\tate-chu-yoko} places (Latin)
 text horizontally within a single grid-square of the vertical \em{hanmen}.
 \end{document}
 ]]

--- a/packages/textcase.lua
+++ b/packages/textcase.lua
@@ -42,7 +42,7 @@ return {
   },
   documentation = [[
 \begin{document}
-The \font{textcase} package provides commands for language-aware case conversion
+The \autodoc:package{textcase} package provides commands for language-aware case conversion
 of input text. For example, when language is set to English, then
 \autodoc:command{\uppercase{hij}} will return \examplefont{\uppercase{hij}}. However,
 when language is set to Turkish, it will return

--- a/packages/textcase.lua
+++ b/packages/textcase.lua
@@ -44,12 +44,12 @@ return {
 \begin{document}
 The \font{textcase} package provides commands for language-aware case conversion
 of input text. For example, when language is set to English, then
-\code{\\uppercase\{hij\}} will return \examplefont{\uppercase{hij}}. However,
+\autodoc:command{\uppercase{hij}} will return \examplefont{\uppercase{hij}}. However,
 when language is set to Turkish, it will return
 \examplefont{\font[language=tr]{\uppercase{hij}}}.
 
-As well as \code{\\uppercase}, the package provides the commands \code{\\lowercase}
-and \code{\\titlecase}.
+As well as \autodoc:command{\uppercase}, the package provides the commands \autodoc:command{\lowercase}
+and \autodoc:command{\titlecase}.
 \end{document}
 ]]
 }

--- a/packages/twoside.lua
+++ b/packages/twoside.lua
@@ -53,7 +53,7 @@ return {
   }, documentation = [[
 \begin{document}
 The \code{book} class described in chapter 4 sets up left and right mirrored
-page masters; the \code{twoside} package is responsible for swapping between
+page masters; the \autodoc:package{twoside} package is responsible for swapping between
 the two left and right frames, running headers and so on. It has no user-serviceable
 parts.
 \end{document}

--- a/packages/unichar.lua
+++ b/packages/unichar.lua
@@ -17,7 +17,7 @@ SILE is Unicode compatible, and expects its input files to be in the UTF-8 encod
 of the fonts that SILE is using to typeset.) Some Unicode characters are hard to
 locate on a standard keyboard, and so are difficult to enter into SILE documents.
 The \code{unichar} package helps with this problem by providing a command to enter
-Unicode codepoints. After loading \code{unichar}, the \code{\\unichar} command becomes
+Unicode codepoints. After loading \code{unichar}, the \autodoc:command{\unichar} command becomes
 available:
 
 \begin{verbatim}
@@ -26,7 +26,7 @@ available:
 \line
 \end{verbatim}
 
-If the argument to \code{\\unichar} begins \code{U+}, \code{u+}, \code{0x} or \code{0X},
+If the argument to \autodoc:command{\unichar} begins \code{U+}, \code{u+}, \code{0x} or \code{0X},
 then it is assumed to be a hexadecimal value. Otherwise it is assumed to be a
 decimal codepoint.
 \end{document}]] }

--- a/packages/unichar.lua
+++ b/packages/unichar.lua
@@ -16,8 +16,8 @@ SILE is Unicode compatible, and expects its input files to be in the UTF-8 encod
 (The actual range of Unicode characters supported will depend on the supported ranges
 of the fonts that SILE is using to typeset.) Some Unicode characters are hard to
 locate on a standard keyboard, and so are difficult to enter into SILE documents.
-The \code{unichar} package helps with this problem by providing a command to enter
-Unicode codepoints. After loading \code{unichar}, the \autodoc:command{\unichar} command becomes
+The \autodoc:package{unichar} package helps with this problem by providing a command to enter
+Unicode codepoints. After loading \autodoc:package{unichar}, the \autodoc:command{\unichar} command becomes
 available:
 
 \begin{verbatim}

--- a/packages/url.lua
+++ b/packages/url.lua
@@ -137,27 +137,27 @@ end)
 return {
   documentation = [[\begin{document}
 This package enhances the typesetting of URLs in two ways.
-First, it provides the \code{\\href[src=...]\{\}} command which
+First, it provides the \autodoc:command{\href[src=...]\{\}} command which
 inserts PDF hyperlinks,
   \href[src=http://www.sile-typesetter.org/]{like this}.
 
-The \code{\\href} command accepts the same \code{borderwidth},
+The \autodoc:command{\href} command accepts the same \code{borderwidth},
 \code{bordercolor}, \code{borderstyle} and \code{borderoffset} styling
-options as the \code{\\pdf:link} command from the \code{pdf} package,
+options as the \autodoc:command[check=false]{\pdf:link} command from the \code{pdf} package,
 for instance
 \href[src=http://www.sile-typesetter.org/, borderwidth=0.4pt,
   bordercolor=blue, borderstyle=underline]{like this}.
 
 Nowadays, it is a common practice to have URLs in print articles
 (whether it is a good practice or not is yet \em{another} topic).
-Therefore, the package also provides the \code{\\url} command, which will
+Therefore, the package also provides the \autodoc:command{\url} command, which will
 automatically insert breakpoints into unwieldy
 URLs like \url{https://github.com/sile-typesetter/sile-typesetter.github.io/tree/master/examples}
 so that they can be broken up over multiple lines.
 
 It allows line breaks after the colon, and before or after appropriate
 segments of an URL (path elements, query parts, fragments, etc.).
-By default, the \code{\\url} command ignores the current language,
+By default, the \autodoc:command{\url} command ignores the current language,
 as one would not want hyphenation to occur in URL segments. If you have no
 other choice, however, you can pass it a \code{language} option
 to enforce a language to be applied. Note that if French (\code{fr})
@@ -165,12 +165,12 @@ is selected, the special typographic rules applying to punctuations
 in this language are disabled.
 
 To typeset an URL and at the same type have it as active hyperlink,
-one can use the \code{\\href} command without the \code{src} option,
+one can use the \autodoc:command{\href} command without the \code{src} option,
 but with the URL passed as argument.
 
 The breaks are controlled by two penalty settings, \autodoc:setting{url.linebreak.primaryPenalty}
 for preferred breakpoints and, for less acceptable but still tolerable breakpoints,
-\autodoc:setting{url.linebreak.secondaryPenalty}—its value should
+\autodoc:setting{url.linebreak.secondaryPenalty} —its value should
 logically be higher than the previous one.
 \end{document}]]
 }

--- a/packages/url.lua
+++ b/packages/url.lua
@@ -141,8 +141,8 @@ First, it provides the \autodoc:command{\href[src=...]\{\}} command which
 inserts PDF hyperlinks,
   \href[src=http://www.sile-typesetter.org/]{like this}.
 
-The \autodoc:command{\href} command accepts the same \code{borderwidth},
-\code{bordercolor}, \code{borderstyle} and \code{borderoffset} styling
+The \autodoc:command{\href} command accepts the same \autodoc:parameter{borderwidth},
+\autodoc:parameter{bordercolor}, \autodoc:parameter{borderstyle} and \autodoc:parameter{borderoffset} styling
 options as the \autodoc:command[check=false]{\pdf:link} command from the \code{pdf} package,
 for instance
 \href[src=http://www.sile-typesetter.org/, borderwidth=0.4pt,
@@ -159,13 +159,13 @@ It allows line breaks after the colon, and before or after appropriate
 segments of an URL (path elements, query parts, fragments, etc.).
 By default, the \autodoc:command{\url} command ignores the current language,
 as one would not want hyphenation to occur in URL segments. If you have no
-other choice, however, you can pass it a \code{language} option
+other choice, however, you can pass it a \autodoc:parameter{language} option
 to enforce a language to be applied. Note that if French (\code{fr})
 is selected, the special typographic rules applying to punctuations
 in this language are disabled.
 
 To typeset an URL and at the same type have it as active hyperlink,
-one can use the \autodoc:command{\href} command without the \code{src} option,
+one can use the \autodoc:command{\href} command without the \autodoc:parameter{src} option,
 but with the URL passed as argument.
 
 The breaks are controlled by two penalty settings, \autodoc:setting{url.linebreak.primaryPenalty}

--- a/packages/url.lua
+++ b/packages/url.lua
@@ -143,7 +143,7 @@ inserts PDF hyperlinks,
 
 The \autodoc:command{\href} command accepts the same \autodoc:parameter{borderwidth},
 \autodoc:parameter{bordercolor}, \autodoc:parameter{borderstyle} and \autodoc:parameter{borderoffset} styling
-options as the \autodoc:command[check=false]{\pdf:link} command from the \code{pdf} package,
+options as the \autodoc:command[check=false]{\pdf:link} command from the \autodoc:package{pdf} package,
 for instance
 \href[src=http://www.sile-typesetter.org/, borderwidth=0.4pt,
   bordercolor=blue, borderstyle=underline]{like this}.

--- a/packages/verbatim.lua
+++ b/packages/verbatim.lua
@@ -52,7 +52,7 @@ end
 \end{verbatim}
 
 If you want to specify what font the verbatim environment should use, you
-can redefine the \code{verbatim:font} command. For example you could change
+can redefine the \autodoc:command{\verbatim:font} command. For example you could change
 it from XML like this:
 
 \begin{verbatim}

--- a/packages/verbatim.lua
+++ b/packages/verbatim.lua
@@ -38,11 +38,11 @@ so that text is set ragged right, with no hyphenation, no indentation and
 regular spacing. It tells SILE to honor multiple spaces, and sets a monospaced
 font.
 
-\note{Despite the name, \code{verbatim} does not alter the way that SILE
+\note{Despite the name, \autodoc:environment{verbatim} does not alter the way that SILE
 sees special characters. You still need to escape backslashes and braces:
 to produce a backslash, you need to write \code{\\\\}.}
 
-Here is some text set in the verbatim environment:
+Here is some text set in the \autodoc:environment{verbatim} environment:
 
 \begin{verbatim}
 function SILE.repl()

--- a/packages/verbatim.lua
+++ b/packages/verbatim.lua
@@ -32,7 +32,7 @@ end)
 
 return {documentation = [[\begin{document}
 
-The \code{verbatim} package is useful when quoting pieces of computer code and
+The \autodoc:package{verbatim} package is useful when quoting pieces of computer code and
 other text for which formatting is significant. It changes SILE’s settings
 so that text is set ragged right, with no hyphenation, no indentation and
 regular spacing. It tells SILE to honor multiple spaces, and sets a monospaced

--- a/packages/xmltricks.lua
+++ b/packages/xmltricks.lua
@@ -17,13 +17,13 @@ Most of the work of typesetting XML with SILE is creating processing
 expectations for particular XML tags. \code{xmltricks} makes the process
 somewhat easier by providing commands to handle two common cases.
 
-\code{\\xmltricks:ignore\{tag1 tag2 tag3\}} instructs SILE not to bother
+\autodoc:command{\xmltricks:ignore{tag1 tag2 tag3}} instructs SILE not to bother
 investigating the given tags. For instance, when processing a HTML document,
 you probably don’t need to typeset the \code{head} tag or anything inside it.
 
 Similarly, some tags are just wrappers; you want to process their content,
 but there’s nothing specific about the tag itself that needs any styling.
-List those tags in a \code{\\xmltricks:passthru\{...\}} command, and SILE
+List those tags in a \autodoc:command{\xmltricks:passthru{...}} command, and SILE
 will descend into the content without requiring a specific command for the
 tag itself.
 \end{document}]]

--- a/packages/xmltricks.lua
+++ b/packages/xmltricks.lua
@@ -14,7 +14,7 @@ return {
   documentation = [[\begin{document}
 In chapter 9, we’re going to use SILE to typeset existing XML documents.
 Most of the work of typesetting XML with SILE is creating processing
-expectations for particular XML tags. \code{xmltricks} makes the process
+expectations for particular XML tags. \autodoc:package{xmltricks} makes the process
 somewhat easier by providing commands to handle two common cases.
 
 \autodoc:command{\xmltricks:ignore{tag1 tag2 tag3}} instructs SILE not to bother


### PR DESCRIPTION
This PR is a proposal for the first two items in the task list from #1194 - or "low hanging fruits"
- `\autodoc:command` typesets a command (or more) without needing to escape characters, relying on the AST parsing. Due to this (i.e. because of the things skipped at parsing and thus not "reconstructible", such as spacing, option ordering, grouping), it may have a few shortcomings, but on the other hand, besides the sudden ease of typesetting, it comes with the benefits of syntax check and even syntax highlighting.
- `\autodoc:package` just takes a package name and typesets in a different style instead of "code".

Additionally,
- `\autodoc:environment` just takes a command name (string), but checks its validity - needed to be on par with `\autodoc:command` regarding styling.
- `\autodoc:parameter` typesets a parameter name or a parameter=value, again to be in line with the other commands.

And a few extra goodies, such as recognizing angle brackets around parameter or content value, and presenting them in a nicer way. See the package's documentation for more details.

The syntax highlighting setting is disabled by default. Would it be enabled, I tried to propose very discrete colors (i.e. quite dark, so as to remain readable if printed on B&W paper, and also not too intrusive for readers, yet possibly giving the impression that there's a little something to this documentation.)

Hope you like the principle.