### PR TITLE
Keep configure and install BSD and POSIX friendly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,7 +130,7 @@ check: selfcheck
 
 .PHONY: selfcheck
 selfcheck: | $(_BUILT_SUBDIRS)
-	output=$$(mktemp --suffix=.pdf)
+	output=$$(mktemp -t selfcheck-XXXXXX.pdf)
 	trap 'rm -f $$output' EXIT HUP TERM
 	echo "<sile>foo</sile>" | ./sile -o $$output -
 	$(PDFINFO) $$output | $(GREP) "SILE v@VERSION@"

--- a/Makefile.am
+++ b/Makefile.am
@@ -192,7 +192,7 @@ _DOCS_DEPS = $(and $$(filter documentation/%,$@),$(addprefix .fonts/,$(DOCSFONTF
 # TODO: remove _BUILT_SUBDIRS hack and replace it with something sensible when
 # these subdirs don't do crazy things like copying files outside of their own trees!
 _BUILT_SUBDIRS = .built-subdirs
-_SUBDIR_TELLS = core/justenoughharfbuzz.so libtexpdf/.libs/libtexpdf.so.0.0.0
+_SUBDIR_TELLS = core/justenoughfontconfig.so core/justenoughharfbuzz.so core/justenoughicu.so core/justenoughlibtexpdf.so libtexpdf/.libs/libtexpdf.so.0.0.0
 $(_BUILT_SUBDIRS): $(_SUBDIR_TELLS)
 	touch $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,8 @@ AC_SUBST([HARFBUZZ_CFLAGS])
 AC_SUBST([HARFBUZZ_LIBS])
 AC_SUBST([shared_ext])
 
-TRANSFORMED_PACKAGE_NAME="$(printf "$PACKAGE_NAME" | $SED -e "${program_transform_name//\$\$/\$}")"
+sed_program_transform_name="$(printf "$program_transform_name" | $SED -e 's,$$,$,g')"
+TRANSFORMED_PACKAGE_NAME="$(printf "$PACKAGE_NAME" | $SED -e "$sed_program_transform_name")"
 AC_SUBST([TRANSFORMED_PACKAGE_NAME])
 
 adl_RECURSIVE_EVAL(["${datadir}/${TRANSFORMED_PACKAGE_NAME}"], [SILE_PATH])


### PR DESCRIPTION
Fixes #1353

I had used a bashism that wasn't failing with an error, just not doing the expected job. It didn't matter for system installs to `/usr` (using `./config --prefix /usr`) because Lua has a default path to cover that use case, but it meant our custom path handling for non standard installations wasn't getting processed as expected in `sh` / `dash`. For systems that installed to `/usr/local` we weren't getting a matching `SILE_LIB_DIR` set right.