### PR TITLE
fix(deps): Correct include to work with current LuaRocks packages

### DIFF
--- a/lua-libraries/lunamark/entities.lua
+++ b/lua-libraries/lunamark/entities.lua
@@ -5,8 +5,8 @@
 
 local M = {}
 
-local utf8=require("utf8")
-utf8_char = utf8.char
+local luautf8=require("lua-utf8")
+utf8_char = luautf8.char
 
 local character_entities = {
   ["quot"] = 0x0022,

--- a/lua-libraries/lunamark/reader/markdown.lua
+++ b/lua-libraries/lunamark/reader/markdown.lua
@@ -11,7 +11,7 @@ local P, R, S, V, C, Cg, Cb, Cmt, Cc, Ct, B, Cs =
   lpeg.Cmt, lpeg.Cc, lpeg.Ct, lpeg.B, lpeg.Cs
 local lpegmatch = lpeg.match
 local expand_tabs_in_line = util.expand_tabs_in_line
-local utf8 = require("utf8")
+local luautf8 = require("lua-utf8")
 
 local M = {}
 
@@ -20,7 +20,7 @@ local rope_to_string = util.rope_to_string
 -- Normalize a markdown reference tag.  (Make lowercase, and collapse
 -- adjacent whitespace characters.)
 local function normalize_tag(tag)
-  return utf8.lower(gsub(rope_to_string(tag), "[ \n\r\t]+", " "))
+  return luautf8.lower(gsub(rope_to_string(tag), "[ \n\r\t]+", " "))
 end
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
See #669, notably allows `--with-luajit` builds to do more things without tripping over the bogus `require()` that used to be cross-wired to a fork of the correct package with a different module name. Lua 5.3+ doesn't have the same issue because of the internal module of the same name.