### PR TITLE
Setup SILE interface to be localized

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -38,6 +38,7 @@ rules:
     - inputs
     - installation
     - languages
+    - l10n
     - manpage
     - manual
     - math

--- a/core/languages.lua
+++ b/core/languages.lua
@@ -3,7 +3,7 @@ local loadkit = require("loadkit")
 loadkit.register("ftl", function (file)
   local contents = assert(file:read("*a"))
   file:close()
-  return assert(SILE.fluent:add_messages(contents))
+  return contents
 end)
 
 SILE.languageSupport = {
@@ -13,18 +13,20 @@ SILE.languageSupport = {
     language = SILE.cldr.locales[language] and language or "und"
     if SILE.languageSupport.languages[language] then return end
     if SILE.hyphenator.languages[language] then return end
-    local lang, fail = pcall(function () SILE.require("languages/" .. language) end)
-    if fail then
-      if fail:match("not found") then fail = "no support for this language" end
-      SU.warn("Error loading language " .. language .. ": " .. fail)
+    local ret1, lang = pcall(SILE.require, "languages/" .. language)
+    if not ret1 then
+      if lang:match("not found") then lang = "no support for this language" end
+      SU.warn("Error loading language " .. language .. ": " .. lang)
       SILE.languageSupport.languages[language] = {} -- Don't try again
     end
     local ftlresource = string.format("i18n.%s", language)
     SU.debug("fluent", "Loading FTL resource", ftlresource, "into locale", language)
     SILE.fluent:set_locale(language)
-    local _, ftlfail = pcall(function () return require(ftlresource) end)
-    if not ftlfail then
-      SU.warn("Error loading localizations " .. language .. ": " .. ftlfail)
+    local ret2, ftl = pcall(require, ftlresource)
+    if ret2 then
+      SILE.fluent:add_messages(ftl)
+    else
+      SU.warn("No document localizations found for " .. language .. ": " .. ftl)
     end
     if type(lang) == "table" and lang.init then
       lang.init()

--- a/core/languages.lua
+++ b/core/languages.lua
@@ -34,6 +34,22 @@ SILE.languageSupport = {
   end
 }
 
+-- Function to load UI localizations for SILE itself. Also sets the default
+-- document language, but this is primarily about the UI not the document.
+SILE.set_locale = function (locale)
+  locale = SILE.cldr.locales[locale] and locale or "en"
+  SILE.languageSupport.loadLanguage(locale)
+  SILE.settings.set("document.language", locale, true)
+  SILE.l10n:set_locale(locale)
+  local ftlresource = string.format("l10n.%s", locale)
+  local ret, ftl = pcall(require, ftlresource)
+  if ret then
+    SILE.l10n:add_messages(ftl)
+  else
+    SU.warn("Error loading UI localizations " .. locale .. ": " .. ftl)
+  end
+end
+
 SILE.registerCommand("language", function (options, content)
   local main = SU.required(options, "main", "language setting")
   SILE.languageSupport.loadLanguage(main)

--- a/core/measurement.lua
+++ b/core/measurement.lua
@@ -84,6 +84,7 @@ local measurement = pl.class({
     end,
 
     __tostring = function (self)
+      SU.debug("l10n", "measurement to string")
       return self.amount .. self.unit
     end,
 

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -38,7 +38,8 @@ SILE.preamble = {}
 
 -- Internal functions / classes / factories
 SILE.cldr = require("cldr")
-SILE.fluent = require("fluent")()
+SILE.fluent = require("fluent")() -- for document localizations
+SILE.l10n = require("fluent")() -- for UI localizations
 SILE.utilities = require("core/utilities")
 SU = SILE.utilities -- alias
 SILE.traceStack = require("core/tracestack")()

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -127,6 +127,7 @@ SILE.parseArguments = function ()
   cli:splat("INPUT", "input file, SIL or XML format")
   cli:option("-b, --backend=VALUE", "choose an alternative output backend")
   cli:option("-d, --debug=VALUE", "show debug information for tagged aspects of SILE’s operation", {})
+  cli:option("-l, --locale=VALUE", "locale for SILE interface and default document language", {})
   cli:option("-e, --evaluate=VALUE", "evaluate some Lua code before processing file", {})
   cli:option("-f, --fontmanager=VALUE", "choose an alternative font manager")
   cli:option("-m, --makedeps=FILE", "generate a list of dependencies in Makefile format")
@@ -152,6 +153,11 @@ SILE.parseArguments = function ()
     -- Strip extension
     SILE.masterFilename = string.match(SILE.inputFile, "(.+)%..-$") or SILE.inputFile
     SILE.masterDir = SILE.masterFilename:match("(.-)[^%/]+$")
+  end
+  if opts.locale then
+    for _, locale in ipairs(opts.locale) do
+      SILE.set_locale(locale)
+    end
   end
   if opts.backend then
     SILE.backend = opts.backend

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -43,6 +43,25 @@ utilities.warn = function(message, bug)
   io.stderr:write("\n")
 end
 
+utilities.info = function(message, ...)
+  SU.msg(message, ...)
+end
+
+utilities.msg = function(message, ...)
+  local inputs = pl.utils.pack(...)
+  for i, v in ipairs(inputs) do
+    inputs[i] = nil
+    inputs[string.char(96+i)] = tostring(v)
+  end
+  local msg = SILE.l10n[message](inputs)
+  SU.debug("l10n", msg)
+  -- SU.dump{ message, callback }
+  -- local arg = { ... } -- Avoid things that Lua stuffs in arg like args to self()
+  -- pl.pretty.dump(#arg == 1 and arg[1] or arg, "/dev/stderr")
+    -- local inputs = table.pack(...)
+    -- for i, input in ipairs(inputs) do
+end
+
 utilities.debugging = function (category)
   return SILE.debugFlags.all or SILE.debugFlags[category]
 end

--- a/l10n/en.ftl
+++ b/l10n/en.ftl
@@ -1,0 +1,3 @@
+full-version = SILE { $a }
+
+loading = Loading { $a }

--- a/sile.1.in
+++ b/sile.1.in
@@ -22,6 +22,10 @@ Print help message and exit.
 .BR \-v ", " \-\-version
 Print version information and exit.
 .TP
+.BR \-l ", " \-\-locale= \fIvalue\fR
+Interface locale for localized messages.
+Also sets the default document language.
+.TP
 .BR \-b ", " \-\-backend= \fIvalue\fR
 Choose an alternative output backend.
 The default backend for producing PDF files is \fIlibtexpdf\fR.

--- a/sile.in
+++ b/sile.in
@@ -36,6 +36,12 @@ extendPath(".")
 SILE = require("core/sile")
 SILE.version = "v@VERSION@"
 io.stdout:setvbuf 'no'
+
+-- Load at least a default locale, may be overridden shortly when we parse arguments
+-- but we will always want to be able to fall back to these localizations for any
+-- messages that are not localized anyway so this is not a waste.
+SILE.set_locale("en")
+
 SILE.parseArguments()
 if not os.getenv 'LUA_REPL_RLWRAP' then
   io.stderr:write(SILE.full_version .. '\n')


### PR DESCRIPTION
With the tooling in place to localize, I got to thinking ... passing args to a string localizer instead of generating strings in place will actually fix the issue with unused debug messages actually slowing down our runtime. This is some initial work to swap out the internals and

a) quantify if this will enough of a gain to bother with and
b) see if it makes working with the code harder

**NOT FOR CONSUMPTION**, just a proof of concept.