### PR TITLE
Drop std.string.monkey_patch()

### DIFF
--- a/core/debug-output.lua
+++ b/core/debug-output.lua
@@ -127,7 +127,7 @@ SILE.outputters.debug = {
     else
       buf = table.concat(value.glyphString, " ") .. " w=" .. _round(width)
     end
-    writeline("T", buf, "("..value.text..")")
+    writeline("T", buf, "(" .. tostring(value.text) .. ")")
   end,
 
   setFont = function (self, options)

--- a/core/font.lua
+++ b/core/font.lua
@@ -69,7 +69,7 @@ local _key = function (options)
   return table.concat({
       options.family,
       ("%g"):format(options.size),
-      ("%d"):format(options.weight),
+      ("%d"):format(options.weight or 0),
       options.style,
       options.variant,
       options.features,

--- a/core/frame.lua
+++ b/core/frame.lua
@@ -82,7 +82,7 @@ SILE.framePrototype = pl.class({
       constraint = SU.type(constraint) == "measurement"
         and constraint:tonumber()
         or SILE.frameParser:match(constraint)
-      SU.debug("frames", "Adding constraint " .. self.id .. "(" .. method .. ") = " .. constraint)
+      SU.debug("frames", "Adding constraint " .. self.id .. "(" .. method .. ") = " .. tostring(constraint))
       local eq = cassowary.Equation(self.variables[method], constraint)
       solver:addConstraint(eq)
       if stay then solver:addStay(eq) end

--- a/core/harfbuzz-shaper.lua
+++ b/core/harfbuzz-shaper.lua
@@ -61,7 +61,7 @@ SILE.shapers.harfbuzz = pl.class({
 
     getFace = function (opts)
       local face = SILE.fontManager:face(opts)
-      SU.debug("fonts", "Resolved font family '"..opts.family.."' -> "..(face and face.filename))
+      SU.debug("fonts", "Resolved font family '" .. tostring(opts.family) .. "' -> " .. tostring(face and face.filename))
       if not face or not face.filename then SU.error("Couldn't find face '"..opts.family.."'") end
       if SILE.makeDeps then SILE.makeDeps:add(face.filename) end
       if bitshim.rshift(face.index, 16) ~= 0 then

--- a/core/makedeps.lua
+++ b/core/makedeps.lua
@@ -29,7 +29,7 @@ local makeDeps = {
     end
     local depfile, err = io.open(self.filename, "w")
     if not depfile then return SU.error(err) end
-    depfile:write(SILE.outputFilename .. ": " .. self._deps .. "\n")
+    depfile:write(SILE.outputFilename .. ": " .. tostring(self._deps) .. "\n")
     depfile:close()
   end
 }

--- a/core/measurement.lua
+++ b/core/measurement.lua
@@ -87,6 +87,10 @@ local measurement = pl.class({
       return self.amount .. self.unit
     end,
 
+    __concat = function (a, b)
+      return tostring(a) .. tostring(b)
+    end,
+
     __add = function (self, other)
       if _similarunit(self, other) then
         return SILE.measurement(_amount(self) + _amount(other), _unit(self, other))

--- a/core/nodefactory.lua
+++ b/core/nodefactory.lua
@@ -68,7 +68,9 @@ nodefactory.box = pl.class({
       return self.type
     end,
 
-    __concat = function (a, b) return tostring(a) .. tostring(b) end,
+    __concat = function (a, b)
+      return tostring(a) .. tostring(b)
+    end,
 
     absolute = function (self)
       local clone = nodefactory[self.type](self:_tospec())
@@ -167,7 +169,7 @@ nodefactory.hbox = pl.class({
     type = "hbox",
 
     __tostring = function (self)
-      return "H<" .. self.width .. ">^" .. self.height .. "-" .. self.depth .. "v"
+      return "H<" .. tostring(self.width) .. ">^" .. tostring(self.height) .. "-" .. tostring(self.depth) .. "v"
     end,
 
     scaledWidth = function (self, line)
@@ -211,7 +213,7 @@ nodefactory.nnode = pl.class({
     end,
 
     __tostring = function (self)
-      return "N<" .. self.width .. ">^" .. self.height .. "-" .. self.depth .. "v(" .. self:toText() .. ")";
+      return "N<" .. tostring(self.width) .. ">^" .. tostring(self.height) .. "-" .. tostring(self.depth) .. "v(" .. self:toText() .. ")";
     end,
 
     absolute = function (self)
@@ -378,7 +380,7 @@ nodefactory.glue = pl.class({
     discardable = true,
 
     __tostring = function (self)
-      return (self.explicit and "E:" or "") .. "G<" .. self.width .. ">"
+      return (self.explicit and "E:" or "") .. "G<" .. tostring(self.width) .. ">"
     end,
 
     toText = function () return " " end,
@@ -415,7 +417,7 @@ nodefactory.kern = pl.class({
     discardable = false,
 
     __tostring = function (self)
-      return "K<" .. self.width .. ">"
+      return "K<" .. tostring(self.width) .. ">"
     end,
   })
 
@@ -432,7 +434,7 @@ nodefactory.vglue = pl.class({
     end,
 
     __tostring = function (self)
-      return (self.explicit and "E:" or "") .. "VG<" .. self.height .. ">";
+      return (self.explicit and "E:" or "") .. "VG<" .. tostring(self.height) .. ">";
     end,
 
     adjustGlue = function (self, adjustment)
@@ -470,7 +472,7 @@ nodefactory.vkern = pl.class({
     discardable = false,
 
     __tostring = function (self)
-      return "VK<" .. self.height .. ">"
+      return "VK<" .. tostring(self.height) .. ">"
     end
 
   })
@@ -489,7 +491,7 @@ nodefactory.penalty = pl.class({
     end,
 
     __tostring = function (self)
-      return "P(" .. self.penalty .. ")";
+      return "P(" .. tostring(self.penalty) .. ")";
     end,
 
     outputYourself = function () end,
@@ -512,7 +514,7 @@ nodefactory.vbox = pl.class({
     end,
 
     __tostring = function (self)
-      return "VB<" .. self.height .. "|" .. self:toText() .. "v".. self.depth ..")";
+      return "VB<" .. tostring(self.height) .. "|" .. self:toText() .. "v".. tostring(self.depth) ..")";
     end,
 
     toText = function (self)
@@ -569,7 +571,7 @@ nodefactory.migrating = pl.class({
     nodes = {},
 
     __tostring = function (self)
-      return "<M: "..self.material .. ">"
+      return "<M: " .. tostring(self.material) .. ">"
     end
 
   })

--- a/core/opentype-parser.lua
+++ b/core/opentype-parser.lua
@@ -395,7 +395,7 @@ local function parseMath(s)
   if s:len() <= 0 then return end
   local fd = vstruct.cursor(s)
   local header = vstruct.read(">majorVersion:u2 minorVersion:u2 mathConstantsOffset:u2 mathGlyphInfoOffset:u2 mathVariantsOffset:u2", fd)
-  SU.debug("opentype-parser", "header = "..header)
+  SU.debug("opentype-parser", "header = " .. tostring(header))
   if header.majorVersion > 1 then return end
   vstruct.compile("MathValueRecord", "value:i2 deviceTableOffset:u2")
   vstruct.compile("RangeRecord", "startGlyphID:u2 endGlyphID:u2 startCoverageIndex:u2")
@@ -409,7 +409,7 @@ local function parseMath(s)
                                      " extendedShapeCoverageOffset:u2"..
                                      " mathKernInfoOffset:u2", fd)
   SU.debug("opentype-parser", "mathGlyphInfoOffset = "..header.mathGlyphInfoOffset)
-  SU.debug("opentype-parser", "mathGlyphInfo = "..mathGlyphInfo)
+  SU.debug("opentype-parser", "mathGlyphInfo = " .. tostring(mathGlyphInfo))
   local mathItalicsCorrection = parseIfPresent(header.mathGlyphInfoOffset, mathGlyphInfo.mathItalicsCorrectionInfoOffset, function(offset)
     return parsePerGlyphTable(offset, "&MathValueRecord", fd)
   end)

--- a/core/packagemanager.lua
+++ b/core/packagemanager.lua
@@ -1,7 +1,7 @@
 local lfs = require("lfs")
 
 local catalogueURL = "https://raw.githubusercontent.com/sile-typesetter/sile-packages/master/packages.lua"
-local packageHome = SYSTEM_SILE_PATH .. "/packagemanager/"
+local packageHome = tostring(SYSTEM_SILE_PATH) .. "/packagemanager/"
 local catalogueHome = packageHome .. "catalogue.lua"
 local installedCatalogue = packageHome .. "installed.lua"
 

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -5,10 +5,6 @@ local inf_bad = 10000
 local supereject_penalty = 2 * -inf_bad
 -- local deplorable = 100000
 
-if std.string.monkey_patch then -- stdlib >= 40
-  std.string.monkey_patch()
-end
-
 SILE.settings.declare({
   parameter = "typesetter.widowpenalty",
   type = "integer",

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -581,14 +581,14 @@ SILE.defaultTypesetter = std.object {
   leadingFor = function (_, vbox, previous)
     -- Insert leading
     SU.debug("typesetter", "   Considering leading between two lines:")
-    SU.debug("typesetter", "   1) "..previous)
-    SU.debug("typesetter", "   2) "..vbox)
+    SU.debug("typesetter", "   1) " .. tostring(previous))
+    SU.debug("typesetter", "   2) " .. tostring(vbox))
     if not previous then return SILE.nodefactory.vglue() end
     local prevDepth = previous.depth
-    SU.debug("typesetter", "   Depth of previous line was " .. prevDepth)
+    SU.debug("typesetter", "   Depth of previous line was " .. tostring(prevDepth))
     local bls = SILE.settings.get("document.baselineskip")
     local depth = bls.height:absolute() - vbox.height:absolute() - prevDepth:absolute()
-    SU.debug("typesetter", "   Leading height = " .. bls.height .. " - " .. vbox.height .. " - " .. prevDepth .. " = "..depth)
+    SU.debug("typesetter", "   Leading height = " .. tostring(bls.height) .. " - " .. tostring(vbox.height) .. " - " .. tostring(prevDepth) .. " = " .. tostring(depth))
 
     -- the lineskip setting is a vglue, but we need a version absolutized at this point, see #526
     local lead = SILE.settings.get("document.lineskip").height:absolute()

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -1,4 +1,6 @@
 local bitshim = require("bitshim")
+local luautf8 = require("lua-utf8")
+
 local utilities = {}
 
 local epsilon = 1E-12
@@ -400,29 +402,10 @@ utilities.utf16codes = function (ustr, endian)
 end
 
 utilities.splitUtf8 = function (str) -- Return an array of UTF8 strings each representing a Unicode char
-  local seq = 0
   local rv = {}
-  local val = -1
-  local this = ""
-  for i = 1, #str do
-    local c = string.byte(str, i)
-    if seq == 0 then
-      if val > -1 then
-        rv[1+#rv] = this
-        this = ""
-      end
-      seq = c < 0x80 and 1 or c < 0xE0 and 2 or c < 0xF0 and 3 or
-            c < 0xF8 and 4 or --c < 0xFC and 5 or c < 0xFE and 6 or
-          error("invalid UTF-8 character sequence")
-      val = bitshim.band(c, 2^(8-seq) - 1)
-      this = this .. str[i]
-    else
-      val = bitshim.bor(bitshim.lshift(val, 6), bitshim.band(c, 0x3F))
-      this = this .. str[i]
-    end
-    seq = seq - 1
+  for _, cp in luautf8.next, str do
+    table.insert(rv, luautf8.char(cp))
   end
-  rv[1+#rv] = this
   return rv
 end
 

--- a/languages/ja.lua
+++ b/languages/ja.lua
@@ -151,10 +151,10 @@ SILE.nodeMakers.ja = pl.class({
               shrinkability(lastcp, thiscp)
             )
             if breakAllowed(lastcp, thiscp) then
-              db = db .." G ".. length
+              db = db .." G ".. tostring(length)
               coroutine.yield(SILE.nodefactory.glue(length))
             elseif length.length ~= 0 or length.stretch ~= 0 or length.shrink ~= 0 then
-              db = db .." K ".. length
+              db = db .." K ".. tostring(length)
               coroutine.yield(SILE.nodefactory.kern(length))
             else db = db .. " N"
             end

--- a/languages/unicode.lua
+++ b/languages/unicode.lua
@@ -105,7 +105,7 @@ SILE.nodeMakers.unicode = pl.class({
       if self.token then self:makeToken() end
       if self.lastnode and self.lastnode ~= "glue" then
         local w = SILE.settings.get("document.letterspaceglue").width
-        SU.debug("tokenizer", "Letter space glue: "..w)
+        SU.debug("tokenizer", "Letter space glue: " .. tostring(w))
         coroutine.yield(SILE.nodefactory.kern({ width = w }))
         self.lastnode = "glue"
       end

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -251,7 +251,7 @@ SILE.registerCommand("autodoc:environment", function (options, content)
     if not SILE.Commands[name] then SU.error("Unknown command "..name) end
   end
 
-  SILE.call("autodoc:code:style", { type = "environment" }, name)
+  SILE.call("autodoc:code:style", { type = "environment" }, { name })
 end, "Outputs a command name in code, checking its validity.")
 
 -- Documenting a package name

--- a/packages/bidi.lua
+++ b/packages/bidi.lua
@@ -169,7 +169,7 @@ local splitNodeAtPos = function (n, splitstart, p)
     end
     return n1, n2
   else
-    SU.error("Unsure how to split node "..n.." at position "..p, true)
+    SU.error("Unsure how to split node " .. tostring(n) .. " at position " .. p, true)
   end
 end
 

--- a/packages/break-firstfit.lua
+++ b/packages/break-firstfit.lua
@@ -7,16 +7,16 @@ local firstfit = function (typesetter, nl, breakWidth)
   local length = SILE.length()
   for i = 1,#nl do local n = nl[i]
     if n.is_box then
-      SU.debug("break", n .. " " .. n:lineContribution())
+      SU.debug("break", n .. " " .. tostring(n:lineContribution()))
       length = length + n:lineContribution()
-      SU.debug("break", " Length now " .. length.. " breakwidth ".. breakWidth)
+      SU.debug("break", " Length now " .. tostring(length) .. " breakwidth ".. tostring(breakWidth))
     end
     if not n.is_box or n.isHangable then
       SU.debug("break", n )
       if n.is_glue then
         length = length + n.width:absolute()
       end
-      SU.debug("break", " Length now " .. length .. " breakwidth " .. breakWidth)
+      SU.debug("break", " Length now " .. tostring(length) .. " breakwidth " .. tostring(breakWidth))
       -- Can we break?
       if length:tonumber() >= breakWidth:tonumber() then
         SU.debug("break", "Breaking!")

--- a/packages/chapterverse.lua
+++ b/packages/chapterverse.lua
@@ -20,15 +20,15 @@ SILE.registerCommand("save-verse-number", function (_, content)
     chapter = SILE.scratch.chapterverse.chapter,
     verse = SILE.scratch.chapterverse.verse
   }
-  SU.debug("chapterverse", "ref: " .. ref)
+  SU.debug("chapterverse", "ref: " .. tostring(ref))
   SILE.call("info", { category = "references", value = ref }, {})
 end)
 
 SILE.registerCommand("first-reference", function (_, _)
   local refs = SILE.scratch.info.thispage.references
-  SU.debug("chapterverse", "first-reference: " .. SILE.scratch.info)
+  SU.debug("chapterverse", "first-reference: " .. tostring(SILE.scratch.info))
   if refs then
-    SU.debug("chapterverse", "first-reference: " .. refs[1])
+    SU.debug("chapterverse", "first-reference: " .. tostring(refs[1]))
     SILE.call("format-reference", {}, refs[1])
   else
     SU.debug("chapterverse", "first-reference: none")
@@ -38,7 +38,7 @@ end)
 SILE.registerCommand("last-reference", function (options, _)
   local refs = SILE.scratch.info.thispage.references
   if refs then
-    SU.debug("chapterverse", "last-reference: " .. refs[#(refs)])
+    SU.debug("chapterverse", "last-reference: " .. tostring(refs[#(refs)]))
     SILE.call("format-reference", options, refs[#(refs)])
   else
     SU.debug("chapterverse", "last-reference: none")
@@ -47,14 +47,14 @@ end)
 
 SILE.registerCommand("format-reference", function (options, content)
   if type(options.showbook) == "nil" then options.showbook = true end
-  SU.debug("chapterverse", "formatting: " .. content)
+  SU.debug("chapterverse", "formatting: " .. tostring(content))
   local ref
   if content.book and options.showbook then
-    ref = content.book .. " " .. content.chapter .. ":" .. content.verse
+    ref = tostring(content.book) .. " " .. tostring(content.chapter) .. ":" .. tostring(content.verse)
   else
-    ref = content.chapter .. ":" .. content.verse
+    ref = tostring(content.chapter) .. ":" .. tostring(content.verse)
   end
-  SU.debug("chapterverse", "formatting: " .. ref)
+  SU.debug("chapterverse", "formatting: " .. tostring(ref))
   SILE.typesetter:typeset(ref)
 end)
 

--- a/packages/features.lua
+++ b/packages/features.lua
@@ -204,7 +204,7 @@ SILE.registerCommand("font", function (options, content)
   SU.debug("features", "Font features parsed as:", otfeatures)
   options.features = (options.features and options.features .. ";" or "") .. tostring(otfeatures)
   return fontfn(options, content)
-end, SILE.Help.font .. " (overridden)")
+end, tostring(SILE.Help.font) .. " (overridden)")
 
 return { documentation = [[\begin{document}
 As mentioned in Chapter 3, SILE automatically applies ligatures defined by the fonts

--- a/packages/font-fallback.lua
+++ b/packages/font-fallback.lua
@@ -71,7 +71,7 @@ SILE.shapers.harfbuzzWithFallback = pl.class({
       end
       local shapeQueue = fallbackQueue(text, optionSet)
       while shapeQueue:continuing() do
-        SU.debug("fonts", "Queue: ".. shapeQueue.q)
+        SU.debug("fonts", "Queue: ".. tostring(shapeQueue.q))
         options = shapeQueue:currentFont()
         if not (options.family or options.filename) then return end
         SU.debug("fonts", shapeQueue:currentJob())
@@ -88,7 +88,7 @@ SILE.shapers.harfbuzzWithFallback = pl.class({
               if startOfNotdefRun > -1 then
                 shapeQueue:addJob(start + newItems[startOfNotdefRun].index,
                   start + newItems[i].index - 1)
-                SU.debug("fonts", "adding run "..shapeQueue:lastJob())
+                SU.debug("fonts", "adding run " .. tostring(shapeQueue:lastJob()))
                 startOfNotdefRun = -1
               end
               newItems[i].fontOptions = options

--- a/packages/grid.lua
+++ b/packages/grid.lua
@@ -10,10 +10,10 @@ end
 
 local function leadingFor (typesetter, vbox, previous)
   SU.debug("typesetter", "   Considering leading between two lines (grid mode):")
-  SU.debug("typesetter", "   1) "..previous)
-  SU.debug("typesetter", "   2) "..vbox)
+  SU.debug("typesetter", "   1) " .. tostring(previous))
+  SU.debug("typesetter", "   2) " .. vbox)
   if not previous then return SILE.nodefactory.vglue() end
-  SU.debug("typesetter", "   Depth of previous line was " .. previous.depth)
+  SU.debug("typesetter", "   Depth of previous line was " .. tostring(previous.depth))
   local totals = typesetter.frame.state.totals
   local oldCursor = SILE.measurement(totals.gridCursor)
   totals.gridCursor = oldCursor + vbox.height:absolute() + previous.depth
@@ -110,7 +110,7 @@ local gridPagebuilder = pl.class({
         local left = target - totalHeight
         local _left = left:tonumber()
         SU.debug("pagebuilder", "I have " .. left .. "left")
-        SU.debug("pagebuilder", "totalHeight " .. totalHeight .. " with target " .. target)
+        SU.debug("pagebuilder", "totalHeight " .. tostring(totalHeight) .. " with target " .. tostring(target))
         local badness = 0
         if _left < 0 then badness = 1000000 end
         if node.is_penalty then

--- a/packages/insertions.lua
+++ b/packages/insertions.lua
@@ -187,7 +187,7 @@ SILE.insertions.setShrinkage = function (classname, amount)
     local frame = SILE.getFrame(fName)
     if frame then
       initShrinkage(frame)
-      SU.debug("insertions", "Shrinking " .. fName .. " by " .. amount * ratio)
+      SU.debug("insertions", "Shrinking " .. fName .. " by " .. tostring(amount * ratio))
       frame.state.totals.shrinkage = frame.state.totals.shrinkage + amount * ratio
     end
   end
@@ -215,7 +215,7 @@ end
 SILE.insertions.increaseInsertionFrame = function (insertionvbox, classname)
   local amount = insertionvbox.height + insertionvbox.depth
   local opts = SILE.scratch.insertions.classes[classname]
-  SU.debug("insertions", "Increasing insertion frame by "..amount)
+  SU.debug("insertions", "Increasing insertion frame by " .. tostring(amount))
   local stealPosition = opts["steal-position"] or "bottom"
   local insertionFrame = SILE.getFrame(opts["insertInto"].frame)
   local oldHeight = insertionFrame:height()

--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -801,7 +801,7 @@ elements.text = pl.class({
       end
     end
     for attribute,value in pairs(attributes) do
-      SU.debug("math", "attribute = "..attribute..", value = "..value)
+      SU.debug("math", "attribute = " .. attribute .. ", value = " .. tostring(value))
       self[attribute] = value
     end
   end,
@@ -900,7 +900,7 @@ elements.text = pl.class({
       .vertGlyphConstructions[glyphs[1].gid]
     if constructions then
       local variants = constructions.mathGlyphVariantRecord
-      SU.debug("math", "stretch: variants = " .. variants)
+      SU.debug("math", "stretch: variants = " .. tostring(variants))
       local closest
       local closestI
       local m = requiredAdvance - (self.depth+self.height):tonumber() * upem/sz
@@ -914,7 +914,7 @@ elements.text = pl.class({
           m = diff
         end
       end
-      SU.debug("math", "stretch: closestI = " .. closestI)
+      SU.debug("math", "stretch: closestI = " .. tostring(closestI))
       if closest then
         -- Now we have to re-shape the glyph chain. We will assume there
         -- is only one glyph.

--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -340,13 +340,13 @@ local function compileToMathML(arg_env, tree)
     end
   end
   tree.id = nil
-  SU.debug("texmath", "Resulting MathML:\n"..tree)
+  SU.debug("texmath", "Resulting MathML:\n" .. tostring(tree))
   return tree
 end
 
 local function convertTexlike(content)
   local ret = epnf.parsestring(mathParser, content[1])
-  SU.debug("texmath", "parsed TeX math:\n"..ret)
+  SU.debug("texmath", "parsed TeX math:\n" .. tostring(ret))
   return ret
 end
 

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -38,7 +38,7 @@ function ConvertMathML(content)
     local attributes = {}
     if syms.symbolDefaults[text] then
       for attribute,value in pairs(syms.symbolDefaults[text]) do
-        SU.debug("math", "attribute = "..attribute..", value = "..value)
+        SU.debug("math", "attribute = " .. attribute .. ", value = " .. tostring(value))
         attributes[attribute] = value
       end
     end

--- a/packages/parallel.lua
+++ b/packages/parallel.lua
@@ -89,7 +89,7 @@ local addBalancingGlue = function (height)
   allTypesetters(function (frame, typesetter)
     local glue = height - calculations[frame].heightOfNewMaterial
     if glue.length:tonumber() > 0 then
-      SU.debug("parallel", "Adding "..glue.." to "..frame)
+      SU.debug("parallel", "Adding " .. tostring(glue) .. " to " .. tostring(frame))
       typesetter:pushVglue({ height = glue })
     end
     calculations[frame].mark = #typesetter.state.outputQueue
@@ -124,7 +124,7 @@ SILE.registerCommand("sync", function (_, _)
       calculations[frame].heightOfNewMaterial = calculations[frame].heightOfNewMaterial + thisHeight
     end
     if maxheight < calculations[frame].heightOfNewMaterial then maxheight = calculations[frame].heightOfNewMaterial end
-    SU.debug("parallel", frame..": pre-sync content="..calculations[frame].mark..", now "..#typesetter.state.outputQueue..", height of material: "..calculations[frame].heightOfNewMaterial)
+    SU.debug("parallel", frame .. ": pre-sync content=" .. calculations[frame].mark .. ", now " .. #typesetter.state.outputQueue .. ", height of material: " .. tostring(calculations[frame].heightOfNewMaterial))
   end)
   addBalancingGlue(maxheight)
   SILE.typesetter = nulTypesetter

--- a/packages/pdfstructure.lua
+++ b/packages/pdfstructure.lua
@@ -48,7 +48,7 @@ end)
 
 local _typeset = SILE.typesetter.typeset
 SILE.typesetter.typeset = function (self, text)
-  actualtext[#actualtext] = actualtext[#actualtext] .. text
+  actualtext[#actualtext] = tostring(actualtext[#actualtext]) .. text
   _typeset(self, text)
 end
 

--- a/packages/ruby.lua
+++ b/packages/ruby.lua
@@ -88,7 +88,7 @@ return {
       else
         local diff = rubybox:lineContribution() - cbox:lineContribution()
         local to_insert = SILE.length(diff / 2)
-        SU.debug("ruby", "Ruby is longer, inserting " .. to_insert .. " either side of base")
+        SU.debug("ruby", "Ruby is longer, inserting " .. tostring(to_insert) .. " either side of base")
         cbox.width = rubybox:lineContribution()
         rubybox.height = 0
         rubybox.width = 0

--- a/sile-dev-1.rockspec
+++ b/sile-dev-1.rockspec
@@ -10,7 +10,7 @@ source = {
 dependencies = {
   "lua >= 5.1",
   "bit32", -- versions vary on different VMs
-  "cassowary == 2.3.1-2",
+  "cassowary == 2.3.2-1",
   "cldr == 0.2.0-0",
   "compat53 == 0.8-1",
   "cosmo == 16.06.04-1",


### PR DESCRIPTION
The Lua (scare quotes) "stdlib" has some *serious* funny business under the hood. I understand why some bits of it are *convenient* at times, but debugging anything it has touched is a nightmare.

This PR is actually bits extracted from #1065. It was getting really confusing trying to figure out what I broken by changing the class model and what was related to the monkey patch business conflicting with explicit meta methods I was trying to set using Penlight. Separating just the de-monkify bits let me work through all the tests.

By the way in case anything ever `git bisect`s back to here, one way to test if you problem is related to this change or not (especially if you have downsteam code that might have built on the assumption SILE's Lua strings were monkey patched) is to load it manually yourself:

```console
$ sile -e 'require("std.string").monkey_patch()' your_file.sil
```

If that works, then

a) add it as a require for *your* project, but leave SILE out of it
b) consider refactoring to use standard Lua or explicitly using `std.string` instead of monkey patching `string`.
