### PR TITLE
More followup refactoring after class changes

### DIFF
--- a/classes/base.lua
+++ b/classes/base.lua
@@ -235,18 +235,10 @@ function base:initPackage (pack, args)
   if type(pack) == "table" then
     if pack.exports then pl.tablex.update(self, pack.exports) end
     if type(pack.init) == "function" then
-      if self._initialized then
-        pack.init(self, args)
-      else
-        self:registerPostinit(pack.init, args)
-      end
+      self:registerPostinit(pack.init, args)
     end
     if type(pack.registerCommands) == "function" then
-      if self._initialized then
-        pack.registerCommands(self)
-      else
-        self:registerPostinit(pack.registerCommands)
-      end
+      self:registerPostinit(pack.registerCommands)
     end
   end
 end

--- a/classes/base.lua
+++ b/classes/base.lua
@@ -87,6 +87,18 @@ function base:_init (options)
   self:declareSettings()
   self:registerCommands()
   self:declareFrames(self.defaultFrameset)
+  self:registerPostinit(function (self_)
+      if type(self.firstContentFrame) == "string" then
+        self_.pageTemplate.firstContentFrame = self_.pageTemplate.frames[self_.firstContentFrame]
+      end
+      local frame = self_:initialFrame()
+      SILE.typesetter = SILE.defaultTypesetter(frame)
+      SILE.typesetter:registerPageEndHook(function ()
+        if SU.debugging("frames") then
+          for _, v in pairs(SILE.frames) do SILE.outputter:debugFrame(v) end
+        end
+      end)
+    end)
   -- Avoid calling this (yet) if we're the parent of some child class
   if self._name == "base" then self:post_init() end
   return self
@@ -111,16 +123,6 @@ function base:post_init ()
       self.deferredLegacyInit[i] = nil
     end
   end
-  if type(self.firstContentFrame) == "string" then
-    self.pageTemplate.firstContentFrame = self.pageTemplate.frames[self.firstContentFrame]
-  end
-  local frame = self:initialFrame()
-  SILE.typesetter = SILE.defaultTypesetter(frame)
-  SILE.typesetter:registerPageEndHook(function ()
-    if SU.debugging("frames") then
-      for _, v in pairs(SILE.frames) do SILE.outputter:debugFrame(v) end
-    end
-  end)
   self._initialized = true
   for i, func in ipairs(self.deferredInit) do
     func(self)

--- a/classes/bible.lua
+++ b/classes/bible.lua
@@ -185,18 +185,22 @@ function bible:_init(options)
     end
     return _gutterwidth
   end)
-  plain._init(self, options)
   self:loadPackage("masters")
+  plain._init(self, options)
   self:loadPackage("infonode")
   self:loadPackage("chapterverse")
-  if self.options.twocolumns then
-    self:twoColumnMaster()
-    SILE.settings:set("linebreak.tolerance", 9000)
-  else
-    self:singleColumnMaster()
-  end
-  self:loadPackage("twoside", { oddPageMaster = "right", evenPageMaster = "left" })
-  self.pageTemplate = SILE.scratch.masters["right"]
+  self:registerPostinit(function (self_)
+    if self_.options.twocolumns then
+      self_:twoColumnMaster()
+      SILE.settings:set("linebreak.tolerance", 9000)
+    else
+      self_:singleColumnMaster()
+    end
+  end)
+  self:loadPackage("twoside", {
+    oddPageMaster = "right",
+    evenPageMaster = "left"
+  })
   -- Avoid calling this (yet) if we're the parant of some child class
   if self._name == "bible" then self:post_init() end
   return self

--- a/classes/book.lua
+++ b/classes/book.lua
@@ -40,16 +40,16 @@ function book:_init (options)
       firstContentFrame = self.firstContentFrame,
       frames = self.defaultFrameset
     })
-  self:loadPackage("twoside", { oddPageMaster = "right", evenPageMaster = "left" })
-  self:registerPostinit(function(self_)
-      self_:mirrorMaster("right", "left")
-      if not SILE.scratch.headers then SILE.scratch.headers = {} end
-  end)
+  self:loadPackage("twoside", {
+      oddPageMaster = "right",
+      evenPageMaster = "left"
+    })
   self:loadPackage("tableofcontents")
   self:loadPackage("footnotes", {
       insertInto = "footnotes",
       stealFrom = { "content" }
     })
+  if not SILE.scratch.headers then SILE.scratch.headers = {} end
   -- Avoid calling this (yet) if we're the parant of some child class
   if self._name == "book" then self:post_init() end
   return self

--- a/classes/book.lua
+++ b/classes/book.lua
@@ -32,18 +32,17 @@ book.defaultFrameset = {
 
 function book:_init (options)
   if self._legacy and not self._deprecated then return self:_deprecator(book) end
-  plain._init(self, options)
   self:loadPackage("counters")
-  self:loadPackage("masters")
-  self:defineMaster({
+  self:loadPackage("masters", {{
       id = "right",
       firstContentFrame = self.firstContentFrame,
       frames = self.defaultFrameset
-    })
+    }})
   self:loadPackage("twoside", {
       oddPageMaster = "right",
       evenPageMaster = "left"
     })
+  plain._init(self, options)
   self:loadPackage("tableofcontents")
   self:loadPackage("footnotes", {
       insertInto = "footnotes",

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -148,7 +148,7 @@ SILE.require = function (dependency, pathprefix, deprecation_ack)
   end
   if not status then lib = require(dependency) end
   local class = SILE.documentState.documentClass
-  if not class then
+  if not class and not deprecation_ack then
     SU.warn(string.format([[
     Use of SILE.require() is only supported in documents, packages, or class
       init functions. It cannot be used before the class is instantiated.

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -477,11 +477,11 @@ function SILE.defaultTypesetter:initNextFrame ()
   if #self.state.outputQueue == 0 then
     self.state.previousVbox = nil
   end
-  if (self.frame.next and not (self.state.lastPenalty <= supereject_penalty )) then
+  if self.frame.next and self.state.lastPenalty > supereject_penalty then
     self:initFrame(SILE.getFrame(self.frame.next))
   elseif not self.frame:isMainContentFrame() then
     if #self.state.outputQueue > 0 then
-      SU.warn("Overfull content for frame "..self.frame.id)
+      SU.warn("Overfull content for frame " .. self.frame.id)
       self:chuck()
     end
   else
@@ -495,9 +495,11 @@ function SILE.defaultTypesetter:initNextFrame ()
   else
     -- If I have some things on the vertical list already, they need
     -- proper top-of-frame leading applied.
-    if #(self.state.outputQueue) > 0 then
-      local lead = self:leadingFor(self.state.outputQueue[1],nil)
-      if lead then table.insert(self.state.outputQueue,1,lead) end
+    if #self.state.outputQueue > 0 then
+      local lead = self:leadingFor(self.state.outputQueue[1], nil)
+      if lead then
+        table.insert(self.state.outputQueue, 1, lead)
+      end
     end
   end
   self:runHooks("newframe")
@@ -505,7 +507,7 @@ function SILE.defaultTypesetter:initNextFrame ()
 end
 
 function SILE.defaultTypesetter:pushBack ()
-  SU.debug("typesetter", "Pushing back "..#(self.state.outputQueue).." nodes")
+  SU.debug("typesetter", "Pushing back " .. #self.state.outputQueue .. " nodes")
   local oldqueue = self.state.outputQueue
   self.state.outputQueue = {}
   self.state.previousVbox = nil

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -377,29 +377,29 @@ function SILE.defaultTypesetter:getTargetLength ()
   return self.frame:getTargetLength()
 end
 
-function SILE.defaultTypesetter:registerHook (category, frame)
+function SILE.defaultTypesetter:registerHook (category, func)
   if not self.hooks[category] then self.hooks[category] = {} end
-  self.hooks[category][1+#(self.hooks[category])] = frame
+  table.insert(self.hooks[category], func)
 end
 
 function SILE.defaultTypesetter:runHooks (category, data)
   if not self.hooks[category] then return data end
-  for i = 1, #self.hooks[category] do
-    data = self.hooks[category][i](self, data)
+  for _, func in ipairs(self.hooks[category]) do
+    data = func(self, data)
   end
   return data
 end
 
-function SILE.defaultTypesetter:registerFrameBreakHook (frame)
-  self:registerHook("framebreak", frame)
+function SILE.defaultTypesetter:registerFrameBreakHook (func)
+  self:registerHook("framebreak", func)
 end
 
-function SILE.defaultTypesetter:registerNewFrameHook (frame)
-  self:registerHook("newframe", frame)
+function SILE.defaultTypesetter:registerNewFrameHook (func)
+  self:registerHook("newframe", func)
 end
 
-function SILE.defaultTypesetter:registerPageEndHook (frame)
-  self:registerHook("pageend", frame)
+function SILE.defaultTypesetter:registerPageEndHook (func)
+  self:registerHook("pageend", func)
 end
 
 function SILE.defaultTypesetter:buildPage ()
@@ -419,7 +419,7 @@ function SILE.defaultTypesetter:buildPage ()
   end
   self.state.lastPenalty = res
   self.frame.state.pageRestart = nil
-  pageNodeList = self:runHooks("framebreak",pageNodeList)
+  pageNodeList = self:runHooks("framebreak", pageNodeList)
   self:setVerticalGlue(pageNodeList, self:getTargetLength())
   self:outputLinesToPage(pageNodeList)
   return true

--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -274,16 +274,16 @@ the composition of such packages into a class is not completely automatic\footno
 in other words, loading the package will not necessarily by itself change the output routines.
 You need to explicitly plug the various features provided by those packages into the output routine yourself.
 
-So, for instance,
-the \code{footnote} or \code{insertions} packages provide a \code{outputInsertions} method which needs to be called at the end of each page.
-If you want to build a document class that inherits from \code{plain} but also has footnote functionality,
-you will want your \code{endPage} method to look like this:
+So, for instance, the \code{twoside} package provides a \code{switchPage} method which needs to be called when creating a new page.
+The \code{book} class adds this call to it's \code{book:newPage()} function.
+If you want to bulid a document class that inherits from \code{plain} instead of \code{book} but want to include the \code{twoside} functionality you will want to add this yourself.
+Note this is in addition to loading and configuring the package in your class's \code{_init()} function.
 
 \begin{verbatim}
 \line
-function myClass:endPage ()
-  self:outputInsertions()
-  return plain.endPage(self)
+function myClass:newPage ()
+  self:switchPage()
+  return plain.newPage(self)
 end
 \line
 \end{verbatim}

--- a/packages/footnotes.lua
+++ b/packages/footnotes.lua
@@ -1,6 +1,3 @@
--- Exports: The \footnote command
---          outputInsertions (call this in endPage)
-
 local function init (class, args)
 
   class:loadPackage("counters")

--- a/packages/insertions.lua
+++ b/packages/insertions.lua
@@ -260,6 +260,7 @@ end
 local function init (_, _)
 
   local typesetter = SILE.typesetter
+
   if not typesetter.noinsertion_getTargetLength then
     typesetter.noinsertion_getTargetLength = typesetter.getTargetLength
     typesetter.getTargetLength = function (self)

--- a/packages/insertions.lua
+++ b/packages/insertions.lua
@@ -268,12 +268,12 @@ local function init (_, _)
     end
   end
 
-  SILE.typesetter:registerFrameBreakHook(function (_, nl)
+  typesetter:registerFrameBreakHook(function (_, nodelist)
     pl.tablex.foreach(insertionsThisPage, SILE.insertions.commitShrinkage)
-    return nl
+    return nodelist
   end)
 
-  SILE.typesetter:registerPageEndHook(function (_, nl)
+  typesetter:registerPageEndHook(function (_)
     pl.tablex.foreach(insertionsThisPage, SILE.insertions.increaseInsertionFrame)
     for class, insertionlist in pairs(insertionsThisPage) do
       insertionlist:outputYourself()
@@ -282,7 +282,6 @@ local function init (_, _)
     if SU.debugging("insertions") then
       for _, frame in pairs(SILE.frames) do SILE.outputter:debugFrame(frame) end
     end
-    return nl
   end)
 
 end

--- a/packages/masters.lua
+++ b/packages/masters.lua
@@ -1,7 +1,3 @@
-if not SILE.scratch.masters then
-  SILE.scratch.masters = {}
-end
-
 local _currentMaster
 
 local function defineMaster (_, args)
@@ -20,10 +16,10 @@ local function defineMaster (_, args)
   SILE.scratch.masters[args.id].firstContentFrame = SILE.scratch.masters[args.id].frames[args.firstContentFrame]
 end
 
-local function defineMasters (self, list)
+local function defineMasters (class, list)
   if list then
     for i = 1, #list do
-      defineMaster(self, list[i])
+      class:defineMaster(list[i])
     end
   end
 end
@@ -36,7 +32,11 @@ local function doswitch (frames)
   end
 end
 
-local function switchMasterOnePage (id)
+local function switchMasterOnePage (class, id)
+  if not id then
+    id = class
+    SU.deprecated("class.switchMasterOnePage", "class:switchMasterOnePage", "0.13.0", "0.14.0")
+  end
   if not SILE.scratch.masters[id] then
     SU.error("Can't find master "..id)
   end
@@ -46,55 +46,78 @@ local function switchMasterOnePage (id)
   SILE.typesetter:initFrame(SILE.scratch.masters[id].firstContentFrame)
 end
 
-local function switchMaster (id)
+local function switchMaster (class, id)
+  if not id then
+    id, class = class, SILE.documentState.documentClass
+    SU.deprecated("class.switchMaster", "class:switchMaster", "0.13.0", "0.14.0")
+  end
   _currentMaster = id
   if not SILE.scratch.masters[id] then
     SU.error("Can't find master "..id)
   end
-  SILE.documentState.documentClass.pageTemplate = SILE.scratch.masters[id]
-  SILE.documentState.thisPageTemplate = pl.tablex.deepcopy(SILE.documentState.documentClass.pageTemplate)
+  class.pageTemplate = SILE.scratch.masters[id]
+  SILE.documentState.thisPageTemplate = pl.tablex.deepcopy(class.pageTemplate)
   doswitch(SILE.scratch.masters[id].frames)
   SILE.typesetter:initFrame(SILE.scratch.masters[id].firstContentFrame)
 end
 
-SILE.registerCommand("define-master-template", function(options, content)
-  SU.required(options, "id", "defining a master")
-  SU.required(options, "first-content-frame", "defining a master")
-  -- Subvert the <frame> functionality from baseclass
-  local spare = SILE.documentState.thisPageTemplate.frames
-  local sp2 = SILE.frames
-  SILE.frames = { page = SILE.frames.page }
-  SILE.documentState.thisPageTemplate.frames = {}
-  SILE.process(content)
-  SILE.scratch.masters[options.id] = {}
-  SILE.scratch.masters[options.id].frames = SILE.documentState.thisPageTemplate.frames
-  if not SILE.scratch.masters[options.id].frames[options["first-content-frame"]] then
-    SU.error("first-content-frame "..options["first-content-frame"].." not found")
+local function currentMaster (_)
+  return _currentMaster
+end
+
+local function init (class, args)
+
+  if not SILE.scratch.masters then
+    SILE.scratch.masters = {}
   end
-  SILE.scratch.masters[options.id].firstContentFrame = SILE.scratch.masters[options.id].frames[options["first-content-frame"]]
-  SILE.documentState.thisPageTemplate.frames = spare
-  SILE.frames = sp2
-end)
 
-SILE.registerCommand("switch-master-one-page", function (options, _)
-  SU.required(options, "id", "switching master")
-  switchMasterOnePage(options.id)
-  SILE.typesetter:leaveHmode()
-end, "Switches the master for the current page")
+  defineMasters(class, args)
 
-SILE.registerCommand("switch-master", function (options, _)
-  SU.required(options, "id", "switching master")
-  switchMaster(options.id)
-end, "Switches the master for the current page")
+end
+
+local function registerCommands (class)
+
+  SILE.registerCommand("define-master-template", function(options, content)
+    SU.required(options, "id", "defining a master")
+    SU.required(options, "first-content-frame", "defining a master")
+    -- Subvert the <frame> functionality from baseclass
+    local spare = SILE.documentState.thisPageTemplate.frames
+    local sp2 = SILE.frames
+    SILE.frames = { page = SILE.frames.page }
+    SILE.documentState.thisPageTemplate.frames = {}
+    SILE.process(content)
+    SILE.scratch.masters[options.id] = {}
+    SILE.scratch.masters[options.id].frames = SILE.documentState.thisPageTemplate.frames
+    if not SILE.scratch.masters[options.id].frames[options["first-content-frame"]] then
+      SU.error("first-content-frame "..options["first-content-frame"].." not found")
+    end
+    SILE.scratch.masters[options.id].firstContentFrame = SILE.scratch.masters[options.id].frames[options["first-content-frame"]]
+    SILE.documentState.thisPageTemplate.frames = spare
+    SILE.frames = sp2
+  end)
+
+  SILE.registerCommand("switch-master-one-page", function (options, _)
+    SU.required(options, "id", "switching master")
+    switchMasterOnePage(class, options.id)
+    SILE.typesetter:leaveHmode()
+  end, "Switches the master for the current page")
+
+  SILE.registerCommand("switch-master", function (options, _)
+    SU.required(options, "id", "switching master")
+    switchMaster(class, options.id)
+  end, "Switches the master for the current page")
+
+end
 
 return {
-  init = defineMasters,
+  init = init,
+  registerCommands = registerCommands,
   exports = {
     switchMasterOnePage = switchMasterOnePage,
     switchMaster = switchMaster,
     defineMaster = defineMaster,
     defineMasters = defineMasters,
-    currentMaster = function () return _currentMaster end
+    currentMaster = currentMaster,
   },
   documentation = [[
 \begin{document}

--- a/packages/masters.lua
+++ b/packages/masters.lua
@@ -17,13 +17,14 @@ local function defineMaster (_, args)
       SILE.scratch.masters[args.id].frames[frame] = SILE.newFrame(spec)
     end
   end
-  SILE.frames = { page = SILE.frames.page }
   SILE.scratch.masters[args.id].firstContentFrame = SILE.scratch.masters[args.id].frames[args.firstContentFrame]
 end
 
 local function defineMasters (self, list)
   if list then
-    for i = 1, #list do defineMaster(self, list[i]) end
+    for i = 1, #list do
+      defineMaster(self, list[i])
+    end
   end
 end
 

--- a/packages/twoside.lua
+++ b/packages/twoside.lua
@@ -29,10 +29,10 @@ end
 local function switchPage (class)
   if class:oddPage() then
     tp = "even"
-    class.switchMaster(class.evenPageMaster)
+    class:switchMaster(class.evenPageMaster)
   else
     tp = "odd"
-    class.switchMaster(class.oddPageMaster)
+    class:switchMaster(class.oddPageMaster)
   end
 end
 

--- a/packages/twoside.lua
+++ b/packages/twoside.lua
@@ -1,6 +1,6 @@
 local tp = "odd"
 
-local mirrorMaster = function(_, existing, new)
+local mirrorMaster = function (_, existing, new)
   -- Frames in one master can't "see" frames in another, so we have to get creative
   -- XXX This knows altogether too much about the implementation of masters
   if not SILE.scratch.masters[new] then SILE.scratch.masters[new] = {frames={}} end
@@ -22,35 +22,53 @@ local mirrorMaster = function(_, existing, new)
   end
 end
 
-SILE.registerCommand("open-double-page", function()
-  SILE.typesetter:leaveHmode()
-  SILE.call("supereject")
-  if SILE.documentState.documentClass:oddPage() then
-    SILE.typesetter:typeset("")
+local function oddPage ()
+  return tp == "odd"
+end
+
+local function switchPage (class)
+  if class:oddPage() then
+    tp = "even"
+    class.switchMaster(class.evenPageMaster)
+  else
+    tp = "odd"
+    class.switchMaster(class.oddPageMaster)
+  end
+end
+
+local function init (class, args)
+  if not SILE.scratch.masters then
+    SU.error("Cannot load twoside package before masters.")
+  end
+  class.oddPageMaster = args.oddPageMaster
+  class.evenPageMaster = args.evenPageMaster
+  mirrorMaster(nil, args.oddPageMaster, args.evenPageMaster)
+end
+
+local function registerCommands (class)
+
+  SILE.registerCommand("open-double-page", function()
     SILE.typesetter:leaveHmode()
     SILE.call("supereject")
-  end
-  SILE.typesetter:leaveHmode()
-end)
+    if class:oddPage() then
+      SILE.typesetter:typeset("")
+      SILE.typesetter:leaveHmode()
+      SILE.call("supereject")
+    end
+    SILE.typesetter:leaveHmode()
+  end)
+
+end
 
 return {
-  init = function (class, args)
-    class.oddPageMaster = args.oddPageMaster
-    class.evenPageMaster = args.evenPageMaster
-  end,
+  init = init,
+  registerCommands = registerCommands,
   exports = {
-    oddPage = function () return tp == "odd" end,
+    oddPage = oddPage,
     mirrorMaster = mirrorMaster,
-    switchPage = function (self)
-      if self:oddPage() then
-        tp = "even"
-        self.switchMaster(self.evenPageMaster)
-      else
-        tp = "odd"
-        self.switchMaster(self.oddPageMaster)
-      end
-    end
-  }, documentation = [[
+    switchPage = switchPage,
+  },
+  documentation = [[
 \begin{document}
 The \code{book} class described in chapter 4 sets up left and right mirrored
 page masters; the \autodoc:package{twoside} package is responsible for swapping between


### PR DESCRIPTION
After breaking changes to the class inheritance system I'm working through some of my projects as tests getting as many of them going with support shims as possible. This gets a few more projects building without needing to port yet—just warnings no errors.

At this point I'm about to start updating CaSILE classes to the new system because they are too complex to shim.
