### PR TITLE
Minor cleanup to class code, catch some init stuff not in classes not covered by tests

### DIFF
--- a/classes/bible.lua
+++ b/classes/bible.lua
@@ -296,5 +296,4 @@ bible.registerCommands = function (self)
 
 end
 
-SILE.classes.bible = bible
 return bible

--- a/classes/diglot.lua
+++ b/classes/diglot.lua
@@ -1,4 +1,5 @@
 local plain = require("classes.plain")
+
 local diglot = pl.class(plain)
 diglot._name = "diglot"
 

--- a/classes/docbook.lua
+++ b/classes/docbook.lua
@@ -1,4 +1,5 @@
 local plain = require("classes.plain")
+
 local docbook = pl.class(plain)
 docbook._name = "docbook"
 

--- a/classes/pecha.lua
+++ b/classes/pecha.lua
@@ -1,4 +1,5 @@
 local plain = require("classes.plain")
+
 local pecha = pl.class(plain)
 pecha._name = "pecha"
 

--- a/classes/pecha.lua
+++ b/classes/pecha.lua
@@ -39,10 +39,12 @@ pecha.defaultFrameset = {
 function pecha:_init(options)
   self._init(self, options)
   self:loadPackage("rotate")
-  SILE.call("language", { main = "bo" })
-  SILE.settings:set("document.lskip", SILE.nodefactory.hfillglue())
-  SILE.settings:set("typesetter.parfillskip", SILE.nodefactory.glue())
-  SILE.settings:set("document.parindent", SILE.nodefactory.glue())
+  self:registerPostinit(function ()
+    SILE.call("language", { main = "bo" })
+    SILE.settings:set("document.lskip", SILE.nodefactory.hfillglue())
+    SILE.settings:set("typesetter.parfillskip", SILE.nodefactory.glue())
+    SILE.settings:set("document.parindent", SILE.nodefactory.glue())
+  end)
   return self
 end
 

--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -369,5 +369,4 @@ function plain:endPage ()
   return base.endPage(self)
 end
 
-SILE.classes.plain = plain
 return plain

--- a/classes/triglot.lua
+++ b/classes/triglot.lua
@@ -1,4 +1,5 @@
 local book = require("classes.book")
+
 local triglot = pl.class(book)
 triglot._name = "triglot"
 

--- a/documentation/c12-tricks.sil
+++ b/documentation/c12-tricks.sil
@@ -27,7 +27,7 @@ local plain = require("classes.plain");
 local diglot = pl.class(plain)
 diglot._name = "diglot"
 
-function diglot:_init(options)
+function diglot:_init (options)
   plain._init(self, options)
   self:loadPackage("counters")
     SILE.scratch.counters.folio = \{ value = 1, display = "arabic" \};
@@ -124,10 +124,10 @@ we need to ensure, at the start of each document and the start of each page,
 that each typesetter is linked to the appropriate frame:
 
 \begin{verbatim}
-diglot.init = function(self)
-  diglot.leftTypesetter:init(SILE.getFrame("a"))
-  diglot.rightTypesetter:init(SILE.getFrame("b"))
-  return SILE.classes.base.init(self)
+function diglot:_init (options)
+  self.leftTypesetter:init(SILE.getFrame("a"))
+  self.rightTypesetter:init(SILE.getFrame("b"))
+  return plain.init(self)
 end
 \end{verbatim}
 


### PR DESCRIPTION
- chore(classes): Remove obsolete stashing of classes in globals
- docs(classes): Update egregiously outdated code example
- chore(classes): Make sure all typestter-y bits get called after init
