### PR TITLE
feat: Add strikethrough command to the rules package

### DIFF
--- a/core/opentype-parser.lua
+++ b/core/opentype-parser.lua
@@ -445,6 +445,16 @@ local function parsePost(s)
   }
 end
 
+local function parseOs2(s)
+  if s:len() <= 0 then return end
+  local fd = vstruct.cursor(s)
+  local header = vstruct.read(">version:u2 xAvgCharWidth:i2 usWeightClass:u2 usWidthClass:u2 fsType:u2 ySubscriptXSize:i2 ySubscriptYSize:i2 ySubscriptXOffset:i2 ySubscriptYOffset:i2 ySuperscriptXSize:i2 ySuperscriptYSize:i2 ySuperscriptXOffset:i2 ySuperscriptYOffset:i2, yStrikeoutSize:i2 yStrikeoutPosition:i2", fd)
+  return {
+    yStrikeoutPosition = header.yStrikeoutPosition,
+    yStrikeoutSize = header.yStrikeoutSize,
+  }
+end
+
 local parseFont = function(face)
   if not face.font then
     local font = {}
@@ -456,6 +466,7 @@ local parseFont = function(face)
     font.svg  = parseSvg(hb.get_table(face.data, face.index, "SVG"))
     font.math = parseMath(hb.get_table(face.data, face.index, "MATH"))
     font.post = parsePost(hb.get_table(face.data, face.index, "post"))
+    font.os2 = parseOs2(hb.get_table(face.data, face.index, "OS/2"))
     face.font = font
   end
   return face.font

--- a/packages/rules.lua
+++ b/packages/rules.lua
@@ -78,6 +78,38 @@ local function registerCommands (_)
     })
   end, "Underlines some content")
 
+  SILE.registerCommand("strikethrough", function (_, content)
+    local ot = SILE.require("core.opentype-parser")
+    local fontoptions = SILE.font.loadDefaults({})
+    local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+    local font = ot.parseFont(face)
+    local upem = font.head.unitsPerEm
+    local yStrikeoutSize = font.os2.yStrikeoutSize / upem * fontoptions.size
+    local yStrikeoutPosition = font.os2.yStrikeoutPosition / upem * fontoptions.size
+    local hbox = SILE.call("hbox", {}, content)
+    table.remove(SILE.typesetter.state.nodes) -- steal it back...
+
+    -- Re-wrap the hbox in another hbox responsible for boxing it at output
+    -- time, when we will know the line contribution and can compute the scaled width
+    -- of the box, taking into account possible stretching and shrinking.
+    SILE.typesetter:pushHbox({
+      inner = hbox,
+      width = hbox.width,
+      height = hbox.height,
+      depth = hbox.depth,
+      outputYourself = function(self, typesetter, line)
+        local oldX = typesetter.frame.state.cursorX
+        local Y = typesetter.frame.state.cursorY
+        -- Build the original hbox.
+        -- Cursor will be moved by the actual definitive size.
+        self.inner:outputYourself(SILE.typesetter, line)
+        local newX = typesetter.frame.state.cursorX
+        -- Output a line.
+        SILE.outputter:drawRule(oldX, Y - yStrikeoutPosition, newX - oldX, yStrikeoutSize)
+      end
+    })
+  end, "Strikes out some content")
+
   SILE.registerCommand("boxaround", function (_, content)
     -- This command was not documented and lacks feature.
     -- Plan replacement with a better suited package.
@@ -124,25 +156,24 @@ return {
   init = init,
   registerCommands = registerCommands,
   documentation = [[\begin{document}
-The \autodoc:package{rules} package draws lines. It provides three commands.
+The \autodoc:package{rules} package provides several line-drawing commands.
 
-The first command is \autodoc:command{\hrule},
-which draws a blob of ink of a given \autodoc:parameter{width} (length),
-\autodoc:parameter{height} (above the current baseline) and \autodoc:parameter{depth}
-(below the current baseline).
+The \autodoc:command{\hrule} command draws a blob of ink of a given
+\autodoc:parameter{width} (length), \autodoc:parameter{height} (above the
+current baseline) and \autodoc:parameter{depth} (below the current baseline).
 Such rules are horizontal boxes, placed along the baseline of a line of text and treated
 just like other text to be output. So, they can appear in the middle of a paragraph, like this:
 \hrule[width=20pt, height=0.5pt] (that one was generated with
 \autodoc:command{\hrule[width=20pt, height=0.5pt]}.)
 
-The second command provided by this package is \autodoc:command{\underline}, which
-underlines its contents.
+The \autodoc:command{\underline} command \underline{underlines} its contents.
+
+The \autodoc:command{\strikethrough} command \strikethrough{strikes} its content.
 
 \note{
-Underlining is horrible typographic practice, and
-you should \underline{never} do it.}
-
-(That was produced with \autodoc:command{\underline{never}}.)
+  The position and thickness of the underlines and strikethroughs are based on then
+  current font, honoring the values defined by the type designer.
+}
 
 Finally, \autodoc:command{\fullrule} draws a thin line across the width of the current frame.
 \end{document}]] }


### PR DESCRIPTION
"Strikethrough", i.e. striking ~~text like this~~ out, is necessary for Markdown support.

This PR:
- Extracts the necessary parameters from the "OS/2" OpenType table
- Adds a `\strikethrough` command to the **rules** package.
- Updates the package documentation... with, by the way:
  - removal the blurb that said that underlining is a "horrible typographic practice". That's true for book-like regular typography, but there are plenty of fields where this is legit (e.g. editorial annotations, manuscript editing with additions and deletions, linguistic works, etc. - where italic, bold, underlining, striking are kind of all usual...) and we are not here to judge.
  - addition of the information that the position and thickness are based on the font. This is a neat and important feature, and if we redirect users, would they observe a weird placement, to the type designers, they'll understand why :smile_cat: (I have several "free" fonts where the position or the thickness are somewhat a bit off). (N.B. Not to say anything about subscript/superscript offsets and sizes from the OS/2 table, which I tried to check for another package and found to rarely be correct in _many_ fancy fonts I often use... that the reason why I did not expose the whole OS/2 properties in this first proposal)

Since this is compatible with what we have in 0.13.0, I would suggest merging it first *before* #1334, which needs some rework anyway to fix existing conflicts, etc. Then we could resume work on the latter, and if it eventually makes it, refactor the strikethrough to also work for multiple lines.

![image](https://user-images.githubusercontent.com/18075640/173109049-3cde7c4c-931a-44c1-9165-50b00b72d45e.png)




