### PR TITLE
Remove unnecessary stuff from Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654665288,
-        "narHash": "sha256-7blJpfoZEu7GKb84uh3io/5eSJNdaagXD9d15P9iQMs=",
+        "lastModified": 1655034456,
+        "narHash": "sha256-HXXyvGqZLa+2u8IPIRm/uNQiw+gBtTNu58YaXMJtKRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "43ecbe7840d155fa933ee8a500fb00dbbc651fc8",
+        "rev": "72b1ec0a79b1fc50f6cc0694c2f0b1eb384a932e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,33 +36,6 @@
       inherit (gitignore.lib) gitignoreSource;
       # https://discourse.nixos.org/t/passing-git-commit-hash-and-tag-to-build-with-flakes/11355/2
       version_rev = if (self ? rev) then (builtins.substring 0 7 self.rev) else "dirty";
-      # Prepare a different luaEnv to be used in the overridden expression,
-      # this is also the place to choose a different lua interpreter, such as
-      # lua5_3 or luajit
-      luaEnv = pkgs.lua5_3.withPackages(ps: with ps; [
-        cassowary
-        cosmo
-        linenoise
-        lpeg
-        lua-zlib
-        lua_cliargs
-        luaepnf
-        luaexpat
-        luafilesystem
-        luarepl
-        luasec
-        luasocket
-        luautf8
-        penlight
-        stdlib
-        vstruct
-        cldr
-        fluent
-        loadkit
-        # If we want to test things with lua5.2 or an even older lua, we uncomment these
-        #bit32
-        #compat53
-      ]);
       # Use the expression from Nixpkgs instead of rewriting it here.
       sile = pkgs.sile.overrideAttrs(oldAttr: rec {
         version = "${(pkgs.lib.importJSON ./package.json).version}-${version_rev}-flake";
@@ -110,23 +83,6 @@
         nativeBuildInputs = oldAttr.nativeBuildInputs ++ [
           pkgs.autoreconfHook
         ];
-        buildInputs = [
-          # This adds a different `lua` interpreter to the `buildInputs`.
-          luaEnv
-        ] ++ (
-          # We remove the first buildInput from nixpkgs which is the luaEnv
-          # used there. It's not mandatory to do so, because anyway the first
-          # `lua` interpreter that appears in the final `buildInputs` is the
-          # the `lua` that's used in the `$PATH`, and eventually in the built
-          # `sile`, but we'd like to keep the `buildInputs` clean if possible
-          # never the less.
-          pkgs.lib.lists.drop 1 oldAttr.buildInputs
-        );
-        # This is written in Nixpkgs' expression as well, but we need to write
-        # this here so that the overridden luaEnv will be used instead.
-        passthru = {
-          inherit luaEnv;
-        };
         meta = oldAttr.meta // {
           changelog = "https://github.com/sile-typesetter/sile/raw/master/CHANGELOG.md";
         };


### PR DESCRIPTION
Since the relevant PR [has made it through the gauntlet](https://nixpk.gs/pr-tracker.html?pr=177079) and upstream Nix is 0.13.0 all the way we don't need to override anything for the moment. Prior to the v0.14.x release cycle we'll have to introduce this a gain to drop the provision of stdlib, but I'll just keep that in it's own branch (already in #1420).
