### PR TITLE
fix(build): Make sure `i18n/` dir is actually distributed

### DIFF
--- a/build-aux/list-dist-files.sh
+++ b/build-aux/list-dist-files.sh
@@ -9,6 +9,7 @@ finder () {
 printf '%s' "SILEDATA ="
 finder core classes languages packages -name '*.lua' -not -name 'version.lua'
 finder classes -name '*.sil'
+finder i18n -name '*.ftl'
 
 printf '\n%s' "LUALIBRARIES ="
 finder lua-libraries -name '*.lua'


### PR DESCRIPTION
Fixes this error:

```
! Error loading localizations eo: no localizations for this language at why.sil:2:1: in \languagetable: 0x41510d90
[1] [2]
! No localized message for book-chapter-title-pre found in locale eo at why.sil: in \fluent near 9:1: in \book:sectioningtable: 0x413e6178
```

#1444 is blocked on this being merged.