### PR TITLE
fix(core): Move the zenkaku width (全角幅; `zw`) unit into core

### DIFF
--- a/core/base-shaper.lua
+++ b/core/base-shaper.lua
@@ -59,21 +59,14 @@ SILE.shapers.base = pl.class({
       return shapespace(width and width.length or items[1].width)
     end,
 
-    measureChar = function (self, char, fallible)
+    measureChar = function (self, char)
       local options = SILE.font.loadDefaults({})
       options.tracking = SILE.settings:get("shaper.tracking")
       local items = self:shapeToken(char, options)
-      local error_func
-      if fallible == nil or fallible == false then -- default
-        error_func = SU.error
-      else
-        error_func = SU.warn
-      end
       if #items > 0 then
         return { height = items[1].height, width = items[1].width }
       else
-        error_func("Unable to measure character", char)
-        return nil
+        SU.error("Unable to measure character", char)
       end
     end,
 

--- a/core/base-shaper.lua
+++ b/core/base-shaper.lua
@@ -59,14 +59,21 @@ SILE.shapers.base = pl.class({
       return shapespace(width and width.length or items[1].width)
     end,
 
-    measureChar = function (self, char)
+    measureChar = function (self, char, fallible)
       local options = SILE.font.loadDefaults({})
       options.tracking = SILE.settings:get("shaper.tracking")
       local items = self:shapeToken(char, options)
+      local error_func
+      if fallible == nil or fallible == false then -- default
+        error_func = SU.error
+      else
+        error_func = SU.warn
+      end
       if #items > 0 then
         return { height = items[1].height, width = items[1].width }
       else
-        SU.error("Unable to measure character", char)
+        error_func("Unable to measure character", char)
+        return nil
       end
     end,
 

--- a/core/settings.lua
+++ b/core/settings.lua
@@ -68,6 +68,13 @@ function settings:_init()
     help = "Skip to be added to left side of line"
   })
 
+  self:declare({
+    parameter = "document.zenkakuchar",
+    default = "あ",
+    type = "string",
+    help = "The character measured to determine the length of a zenkaku width (全角幅)"
+  })
+
   SILE.registerCommand("set", function(options, content)
     local parameter = SU.required(options, "parameter", "\\set command")
     local makedefault = SU.boolean(options.makedefault, false)

--- a/core/units.lua
+++ b/core/units.lua
@@ -201,4 +201,24 @@ units["en"] = {
   definition = "0.5em"
 }
 
+-- jlreq measures distances in units of 1em, but also assumes that an em is the
+-- width of a full-width character. In SILE terms it isn't: measuring an "m" in
+-- a 10pt Japanese font gets you 5 points. So we measure a full-width character
+-- and use that as a unit. We call it zw following ptex (zenkaku width)
+units["zw"] = {
+  relative = true,
+  definition = function (v)
+    local zenkaku = SILE.settings:get("document.zenkakuchar")
+    local measure_zenkaku = SILE.shaper:measureChar(zenkaku, true)
+    if measure_zenkaku ~= nil then
+      measure_zenkaku = measure_zenkaku.width
+    else
+      measure_zenkaku = 1
+      SU.warn("Zenkaku width (全角幅) unit zw is falling back to 1em == 1zw as we cannot measure " .. zenkaku ..
+              ". Either change this char to one suitable for your language, or load a font that has it.")
+    end
+    return v * measure_zenkaku
+  end
+}
+
 return units

--- a/core/units.lua
+++ b/core/units.lua
@@ -208,16 +208,15 @@ units["en"] = {
 units["zw"] = {
   relative = true,
   definition = function (v)
-    local zenkaku = SILE.settings:get("document.zenkakuchar")
-    local measure_zenkaku = SILE.shaper:measureChar(zenkaku, true)
-    if measure_zenkaku ~= nil then
-      measure_zenkaku = measure_zenkaku.width
-    else
-      measure_zenkaku = 1
-      SU.warn("Zenkaku width (全角幅) unit zw is falling back to 1em == 1zw as we cannot measure " .. zenkaku ..
-              ". Either change this char to one suitable for your language, or load a font that has it.")
+    local zenkakuchar = SILE.settings:get("document.zenkakuchar")
+    local measureable, zenkaku = pcall(SILE.shaper.measureChar, SILE.shaper, zenkakuchar)
+    if not measureable then
+      SU.warn(string.format([[Zenkaku width (全角幅) unit zw is falling back to 1em == 1zw as we
+    cannot measure %s. Either change this char to one suitable for your
+    language, or load a font that has it.]], zenkakuchar))
     end
-    return v * measure_zenkaku
+    local width = measureable and zenkaku.width or 1
+    return v * width
   end
 }
 

--- a/languages/ja.lua
+++ b/languages/ja.lua
@@ -183,16 +183,5 @@ return {
       SILE.call("medskip")
     end)
 
-    -- jlreq measures distances in units of 1em, but also assumes that an em is the
-    -- width of a full-width character. In SILE terms it isn't: measuring an "m" in
-    -- a 10pt Japanese font gets you 5 points. So we measure a full-width character
-    -- and use that as a unit. We call it zw following ptex (zenkaku width)
-    SILE.units["zw"] = {
-      relative = true,
-      definition = function (v)
-        return v * SILE.shaper:measureChar("あ").width
-      end
-    }
-
   end
 }

--- a/packages/ruby/init.lua
+++ b/packages/ruby/init.lua
@@ -119,7 +119,6 @@ The \autodoc:package{ruby} package provides the
 \autodoc:command[check=false]{\ruby[reading=<ruby text>]{<base text>}} command
 which sets a piece of ruby above or beside the base text. For example:
 
-% Unit zw throws errors if there is not way to shape あ
 \font:add-fallback[family=Noto Sans CJK JP]
 
 \set[parameter=ruby.height,value=12pt]


### PR DESCRIPTION
Where it belongs.

This touches on #1245.

This is blocking #1444, somehow (the manual is extremely brittle as all know well):

```
[font-fallback] Glyph あ not found in Gentium Book Basic
! Some glyph(s) not available in any fallback font, run with '-d font-fallback' for more detail at documentation/c08-language.sil:244:1: in \subsection after in \book:subsectionfont

! Unable to measure character at:
	documentation/c08-language.sil:244:1: in \subsection after in \book:subsectionfont
	documentation/c08-language.sil: in <file> (\)
	documentation/c07-settings.sil:51:1: in \includetable: 0x40ddce50
	! debug.traceback() did not identify code location
make: *** [Makefile:1451: documentation/sile.pdf] Error 1
make: *** Deleting file 'documentation/sile.pdf'
```

After much ado I discovered that the problem is that the unit `zw` (which stands for the width of a zenkaku—i.e. 全角幅) was popping in and out of existence based on the language setting of the document. Of course this won't work.

All units must be permanent. The concept of a zenkaku is not even Japanese-only.