### PR TITLE
fix(classes): Clarify the scopes of `tate` and `jplain`

### DIFF
--- a/classes/jbook.lua
+++ b/classes/jbook.lua
@@ -1,47 +1,19 @@
-local book = require("classes.book")
-local jplain = require("classes.jplain")
+local tbook = require("classes.tbook")
 
-local jbook = pl.class(book)
+local jbook = pl.class(tbook)
 jbook._name = "jbook"
-
-jbook.defaultFrameset = {
-  runningHead = {
-    left = "left(content) + 9pt",
-    right = "right(content) - 9pt",
-    height = "20pt",
-    bottom = "top(content)-9pt"
-  },
-  content = {
-    left = "8.3%pw",
-    top = "12%ph",
-    gridsize = 10,
-    linegap = 7,
-    linelength = 40,
-    linecount = 35
-  },
-  folio = {
-    left = "left(content)",
-    right = "right(content)",
-    top = "bottom(footnotes)+3%ph",
-    bottom = "bottom(footnotes)+5%ph"
-  },
-  footnotes = {
-    left="left(content)",
-    right = "right(content)",
-    height = "0",
-    bottom="83.3%ph"
-  }
-}
 
 function jbook:_init (options)
   if self._legacy and not self._deprecated then return self:_deprecator(jbook) end
-  book._init(self, options)
-  jplain._j_common(self)
+  tbook._init(self, options)
+  SILE.languageSupport.loadLanguage("ja")
+  SILE.settings:set("document.language", "ja", true)
+  SILE.settings:set("font.family", "Noto Sans CJK JP", true)
   return self
 end
 
-jbook.declareOptions = jplain.declareOptions
+jbook.declareOptions = tbook.declareOptions
 
-jbook.setOptions = jplain.setOptions
+jbook.setOptions = tbook.setOptions
 
 return jbook

--- a/classes/jplain.lua
+++ b/classes/jplain.lua
@@ -17,13 +17,21 @@ function jplain:_j_common ()
   self:loadPackage("font-fallback")
   self:loadPackage("hanmenkyoshi")
   self:registerPostinit(function (class)
-      class:bidiDisableTypesetter(SILE.typesetter)
-      class:bidiDisableTypesetter(SILE.defaultTypesetter)
-      SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
-    end)
+    class:bidiDisableTypesetter(SILE.typesetter)
+    class:bidiDisableTypesetter(SILE.defaultTypesetter)
+  end)
   self.defaultFrameset.content.tate = self.options.layout == "tate"
   self:declareHanmenFrame("content", self.defaultFrameset.content)
   SILE.settings:set("document.parindent", SILE.nodefactory.glue("10pt"))
+  if SILE.settings:get("document.language") ~= "ja" then
+    SU.deprecated("document.language ≠ \"ja\" & jplain:…", nil, "0.13.2", "0.14.0", "Prior to SILE v0.13.2, `jplain`, despite its name, did not enforce the use of Japanese in its documents. To use a class like `jplain` for other languages, please base a  *new* custom class off of `jplain`; do not use `jplain` itself. To use `jplain` for Japanese, you *must* specify \\language[main=ja]. This will become a hard error in SILE v0.14.")
+    --[[ @alerque — Remove these lines post v0.14.0! ]]
+    self:registerPostinit(function (_)
+      SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
+    end)
+    SILE.settings:set("document.language", "ja")
+    SILE.languageSupport.loadLanguage("ja")
+  end
 end
 
 function jplain:_init (options)

--- a/classes/jplain.lua
+++ b/classes/jplain.lua
@@ -24,13 +24,17 @@ function jplain:_j_common ()
   self:declareHanmenFrame("content", self.defaultFrameset.content)
   SILE.settings:set("document.parindent", SILE.nodefactory.glue("10pt"))
   if SILE.settings:get("document.language") ~= "ja" then
-    SU.deprecated("document.language ≠ \"ja\" & jplain:…", nil, "0.13.2", "0.14.0", "Prior to SILE v0.13.2, `jplain`, despite its name, did not enforce the use of Japanese in its documents. To use a class like `jplain` for other languages, please base a  *new* custom class off of `jplain`; do not use `jplain` itself. To use `jplain` for Japanese, you *must* specify \\language[main=ja]. This will become a hard error in SILE v0.14.")
-    --[[ @alerque — Remove these lines post v0.14.0! ]]
-    self:registerPostinit(function (_)
-      SILE.call("font:add-fallback", { family = "Noto Sans CJK JP" })
-    end)
-    SILE.settings:set("document.language", "ja")
+    SU.deprecated("document.language ≠ \"ja\" & jplain:…", nil, "0.14.0", "0.16.0", [[
+  Prior to SILE v0.14.0, `jplain`, despite its name, enforced the
+  language being set te Japanese. It no longer makes this assumption.
+  To use a class like `jplain` for other languages, please base a
+  *new* custom class inheriting from `jplain` rather than `jplain`
+  directly. To use `jplain` for Japanese, you *must* specify
+  \\language[main=ja]. (Also you'll probably want to set a font!)
+    ]])
     SILE.languageSupport.loadLanguage("ja")
+    SILE.settings:set("document.language", "ja", true)
+    SILE.settings:set("font.family", "Noto Sans CJK JP", true)
   end
 end
 

--- a/classes/jplain.lua
+++ b/classes/jplain.lua
@@ -1,64 +1,16 @@
 -- Basic! Transitional! In development! Not very good! Don't use it!
-local plain = require("classes.plain")
+local tplain = require("classes.tplain")
 
-local jplain = pl.class(plain)
+local jplain = pl.class(tplain)
 jplain._name = "jplain"
-
-jplain.defaultFrameset.content = {
-  left = "8.3%pw",
-  top = "11.6%ph",
-  gridsize = 10,
-  linegap = 7,
-  linelength = 50,
-  linecount = 30
-}
-
-function jplain:_j_common ()
-  self:loadPackage("font-fallback")
-  self:loadPackage("hanmenkyoshi")
-  self:registerPostinit(function (class)
-    class:bidiDisableTypesetter(SILE.typesetter)
-    class:bidiDisableTypesetter(SILE.defaultTypesetter)
-  end)
-  self.defaultFrameset.content.tate = self.options.layout == "tate"
-  self:declareHanmenFrame("content", self.defaultFrameset.content)
-  SILE.settings:set("document.parindent", SILE.nodefactory.glue("10pt"))
-  if SILE.settings:get("document.language") ~= "ja" then
-    SU.deprecated("document.language ≠ \"ja\" & jplain:…", nil, "0.14.0", "0.16.0", [[
-  Prior to SILE v0.14.0, `jplain`, despite its name, enforced the
-  language being set te Japanese. It no longer makes this assumption.
-  To use a class like `jplain` for other languages, please base a
-  *new* custom class inheriting from `jplain` rather than `jplain`
-  directly. To use `jplain` for Japanese, you *must* specify
-  \\language[main=ja]. (Also you'll probably want to set a font!)
-    ]])
-    SILE.languageSupport.loadLanguage("ja")
-    SILE.settings:set("document.language", "ja", true)
-    SILE.settings:set("font.family", "Noto Sans CJK JP", true)
-  end
-end
 
 function jplain:_init (options)
   if self._legacy and not self._deprecated then return self:_deprecator(jplain) end
-  plain._init(self, options)
-  self:_j_common()
+  tplain._init(self, options)
+  SILE.languageSupport.loadLanguage("ja")
+  SILE.settings:set("document.language", "ja", true)
+  SILE.settings:set("font.family", "Noto Sans CJK JP", true)
   return self
-end
-
-function jplain:declareOptions ()
-  plain.declareOptions(self)
-  self:declareOption("layout", function (_, value)
-    if value then
-      self.layout = value
-      if value == "tate" then self:loadPackage("tate") end
-    end
-    return self.layout
-  end)
-end
-
-function jplain:setOptions (options)
-  options.layout = options.layout or "yoko"
-  plain.setOptions(self, options)
 end
 
 return jplain

--- a/classes/tbook.lua
+++ b/classes/tbook.lua
@@ -1,0 +1,47 @@
+local book = require("classes.book")
+local tplain = require("classes.tplain")
+
+local tbook = pl.class(book)
+tbook._name = "tbook"
+
+tbook.defaultFrameset = {
+  runningHead = {
+    left = "left(content) + 9pt",
+    right = "right(content) - 9pt",
+    height = "20pt",
+    bottom = "top(content)-9pt"
+  },
+  content = {
+    left = "8.3%pw",
+    top = "12%ph",
+    gridsize = 10,
+    linegap = 7,
+    linelength = 40,
+    linecount = 35
+  },
+  folio = {
+    left = "left(content)",
+    right = "right(content)",
+    top = "bottom(footnotes)+3%ph",
+    bottom = "bottom(footnotes)+5%ph"
+  },
+  footnotes = {
+    left="left(content)",
+    right = "right(content)",
+    height = "0",
+    bottom="83.3%ph"
+  }
+}
+
+function tbook:_init (options)
+  if self._legacy and not self._deprecated then return self:_deprecator(tbook) end
+  book._init(self, options)
+  tplain._t_common(self)
+  return self
+end
+
+tbook.declareOptions = tplain.declareOptions
+
+tbook.setOptions = tplain.setOptions
+
+return tbook

--- a/classes/tplain.lua
+++ b/classes/tplain.lua
@@ -1,0 +1,51 @@
+-- Basic! Transitional! In development! Not very good! Don't use it!
+local plain = require("classes.plain")
+
+local tplain = pl.class(plain)
+tplain._name = "tplain"
+
+tplain.defaultFrameset.content = {
+  left = "8.3%pw",
+  top = "11.6%ph",
+  gridsize = 10,
+  linegap = 7,
+  linelength = 50,
+  linecount = 30
+}
+
+function tplain:_t_common ()
+  self:loadPackage("font-fallback")
+  self:loadPackage("hanmenkyoshi")
+  self:registerPostinit(function (class)
+    class:bidiDisableTypesetter(SILE.typesetter)
+    class:bidiDisableTypesetter(SILE.defaultTypesetter)
+  end)
+  self.defaultFrameset.content.tate = self.options.layout == "tate"
+  self:declareHanmenFrame("content", self.defaultFrameset.content)
+  SILE.settings:set("document.parindent", SILE.nodefactory.glue("10pt"))
+end
+
+function tplain:_init (options)
+  if self._legacy and not self._deprecated then return self:_deprecator(tplain) end
+  plain._init(self, options)
+  tplain._t_common(self)
+  return self
+end
+
+function tplain:declareOptions ()
+  plain.declareOptions(self)
+  self:declareOption("layout", function (_, value)
+    if value then
+      self.layout = value
+      if value == "tate" then self:loadPackage("tate") end
+    end
+    return self.layout
+  end)
+end
+
+function tplain:setOptions (options)
+  options.layout = options.layout or "yoko"
+  plain.setOptions(self, options)
+end
+
+return tplain

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -213,13 +213,11 @@ correct space. The size of these spaces is determined by
 
 \subsection{Japanese / Chinese}
 
-SILE aims to conform with the W3G document “Requirements for Japanese Text
-Layout” (\url{https://www.w3.org/TR/jlreq/}) which describes the typographic
-conventions for Japanese (and also Chinese) text. Breaking rules (kinzoku
-shori) and intercharacter spacing is fully supported on selecting the
-Japanese language. The easiest way to set up the other elements of Japanese
-typesetting such as the \em{hanmen} grid and optional vertical typesetting
-support is by using the \code{jplain} class.
+SILE aims to conform with the W3G document “Requirements for Japanese Text Layout”\footnote{\url{https://www.w3.org/TR/jlreq/}} which describes the typographic conventions for Japanese (and also Chinese) text.
+Breaking rules (kinzoku shori) and intercharacter spacing is fully supported on selecting the Japanese language.
+The easiest way to set up the other elements of Japanese typesetting such as the \em{hanmen} grid and optional vertical typesetting support is by using the \code{jplain} or \code{jbook} classes.
+For other languages with similar layout requriements more generic \code{tplain} and \code{tbook} classes are available that setup the layout elements without also setting the default language and font to Japanese specific values.
+These are also good condidates to use as bases classes and extend for more language specific classes.
 
 \package-documentation[src=packages/hanmenkyoshi]
 

--- a/tests/bug-1101.sil
+++ b/tests/bug-1101.sil
@@ -1,6 +1,7 @@
 \begin[class=jplain,layout=tate,papersize=a4]{document}
+\language[main=ja]
 \neverindent\nofolios
-\font[family=Noto Sans CJK JP,language=ja]
+\font[family=Noto Sans CJK JP]
 
 \latin-in-tate{SILE}と\latin-in-tate{Latin}。
 \end{document}

--- a/tests/bug-1101.sil
+++ b/tests/bug-1101.sil
@@ -1,7 +1,6 @@
 \begin[class=jplain,layout=tate,papersize=a4]{document}
-\language[main=ja]
-\neverindent\nofolios
-\font[family=Noto Sans CJK JP]
+\neverindent
+\nofolios
 
 \latin-in-tate{SILE}と\latin-in-tate{Latin}。
 \end{document}

--- a/tests/bug-1171.expected
+++ b/tests/bug-1171.expected
@@ -7,11 +7,10 @@ Set font 	Twemoji Mozilla;10;400;;normal;;TTB
 T	7876 a=10.0000	()
 Pop color
 Push color	0.4000	0.2706	0.0000
-Mx 	10.0000
-T	7893 a=10.0000 7894 a=10.0000	(😉)
+T	7893 a=10.0000	()
+T	7894 w=10.0000	(😉)
 Pop color
 Push color	1.0000	0.7961	0.2980
-Mx 	542.4079
 My 	107.6592
 T	9105 a=10.0000	()
 Pop color

--- a/tests/bug-1171.sil
+++ b/tests/bug-1171.sil
@@ -1,5 +1,4 @@
 \begin[class=jplain,layout=tate]{document}
-\language[main=ja]
 \nofolios
 \noindent
 \font[family=Twemoji Mozilla]

--- a/tests/bug-1171.sil
+++ b/tests/bug-1171.sil
@@ -1,4 +1,5 @@
 \begin[class=jplain,layout=tate]{document}
+\language[main=ja]
 \nofolios
 \noindent
 \font[family=Twemoji Mozilla]

--- a/tests/bug-244.sil
+++ b/tests/bug-244.sil
@@ -1,4 +1,5 @@
 \begin[papersize=a4,class=jplain,layout=tate]{document}
-\font[family=Noto Sans CJK JP,lanaguage=jp]
+\language[main=ja]
+\font[family=Noto Sans CJK JP]
 \latin-in-tate{Hello world.}
 \end{document}

--- a/tests/bug-244.sil
+++ b/tests/bug-244.sil
@@ -1,5 +1,3 @@
 \begin[papersize=a4,class=jplain,layout=tate]{document}
-\language[main=ja]
-\font[family=Noto Sans CJK JP]
 \latin-in-tate{Hello world.}
 \end{document}

--- a/tests/bug-524.sil
+++ b/tests/bug-524.sil
@@ -1,4 +1,5 @@
 \begin[class=jplain]{document}
+\language[main=ja]
 \nofolios
 \set[parameter=document.parindent,value=0pt]
 \show-hanmen

--- a/tests/bug-524.sil
+++ b/tests/bug-524.sil
@@ -1,14 +1,11 @@
 \begin[class=jplain]{document}
-\language[main=ja]
 \nofolios
-\set[parameter=document.parindent,value=0pt]
+\neverindent
 \show-hanmen
 \script[src=packages/ruby]
-\font[family=Noto Sans CJK JP,language=ja]
 私は
 
 {}私は
 
 \ruby[reading=W]{私}は
-
 \end{document}

--- a/tests/bug-525.sil
+++ b/tests/bug-525.sil
@@ -1,4 +1,5 @@
 \begin[class=jplain,papersize=a6]{document}
+\language[main=ja]
 \nofolios
 \set[parameter=document.parindent,value=0pt]
 \script[src=packages/ruby]

--- a/tests/bug-525.sil
+++ b/tests/bug-525.sil
@@ -1,9 +1,7 @@
 \begin[class=jplain,papersize=a6]{document}
-\language[main=ja]
 \nofolios
-\set[parameter=document.parindent,value=0pt]
+\neverindent
 \script[src=packages/ruby]
-\font[family=Noto Sans CJK JP,language=ja]
 \ruby[reading=日本語]{私}\ruby[reading=Latin]{私}
 
 \ruby[reading=Latin]{私}\ruby[reading=日本語]{私}

--- a/tests/bug-915.sil
+++ b/tests/bug-915.sil
@@ -1,9 +1,7 @@
 \begin[papersize=a6,class=jbook]{document}
 \script[src=packages/frametricks]
-\language[main=ja]
 \noindent
 \nofolios
-\font[family=Noto Sans CJK JP]
 よ
 \showframe
 \end{document}

--- a/tests/bug-926.sil
+++ b/tests/bug-926.sil
@@ -1,8 +1,6 @@
 \begin[class=jplain,papersize=a6]{document}
-\language[main=ja]
 \nofolios
-\set[parameter=document.parindent,value=0pt]
-\font[family=Noto Sans CJK JP]
+\neverindent
 \language[main=en]
 \script[src=packages/ruby]
 \ruby[reading=日本語]{私}\ruby[reading=Latin]{私}

--- a/tests/bug-926.sil
+++ b/tests/bug-926.sil
@@ -1,4 +1,5 @@
 \begin[class=jplain,papersize=a6]{document}
+\language[main=ja]
 \nofolios
 \set[parameter=document.parindent,value=0pt]
 \font[family=Noto Sans CJK JP]

--- a/tests/jbook.expected
+++ b/tests/jbook.expected
@@ -1,8 +1,8 @@
 Set paper size 	595.275597	841.8897729
 Begin page
-Mx 	247.0617
-My 	732.6300
-Set font 	Gentium Plus;10;400;;normal;;LTR
-T	20 w=4.6924	(1)
+Mx 	246.6329
+My 	733.8909
+Set font 	Noto Sans CJK JP;10;400;;normal;;LTR
+T	18 w=5.5500	(1)
 End page
 Finish

--- a/tests/vertical.sil
+++ b/tests/vertical.sil
@@ -1,11 +1,10 @@
 \begin[class=jplain,layout=tate]{document}
-\language[main=ja]
 \nofolios
 % Note: differences between Noto font versions make adding more characters to
 % this test brittle. For examle 日本は昔からruns into trouble when the height
 % of 昔 is different. If the tate layout mechanism is working, it’s going
 % to work at two characters, if a longer string fails, it’s likely some other
 % mechanism or value that actually changed.
-\font[family=Noto Sans CJK JP,language=ja,size=24pt]
+\font[size=24pt]
 日本
 \end{document}

--- a/tests/vertical.sil
+++ b/tests/vertical.sil
@@ -1,4 +1,5 @@
 \begin[class=jplain,layout=tate]{document}
+\language[main=ja]
 \nofolios
 % Note: differences between Noto font versions make adding more characters to
 % this test brittle. For examle 日本は昔からruns into trouble when the height


### PR DESCRIPTION
As I've been attempting to enforce through my commits, counter to how
@simoncozens did things:

* `tate` and `ruby`: General purpose libraries that *should not be loading
  any fonts* or *assuming a Japanese document*.
* `jplain`: The Japanese language class, *may* enforce
  `\language[main=ja]` but I didn't for backwards compatibility.

#1452 shows the above backwards compatibility preservation to be ill
advised. Therefore this commit breaks it, closing https://github.com/sile-typesetter/sile/issues/1452.

---

# Note re tests
Also adds `\language[main=ja]` to all jplain tests.

Also fixes a test that was returning bad (tests/bug-1171.sil which tests
for regressions to the issue I reported in #1171) because its behavior
is different in the current Noto font w/ja language. I confirm the new
behavior is not worse, just slightly different.
