### PR TITLE
Non-RGB colors shall not cause an error with the debug outputter

### DIFF
--- a/core/debug-output.lua
+++ b/core/debug-output.lua
@@ -89,7 +89,13 @@ SILE.outputters.debug = {
 
   pushColor = function (self, color)
     _deprecationCheck(self)
-    writeline("Push color", _round(color.r), _round(color.g), _round(color.b))
+    if color.r then
+      writeline("Push color", _round(color.r), _round(color.g), _round(color.b))
+    elseif color.c then
+      writeline("Push color (CMYK)", _round(color.c), _round(color.m), _round(color.y), _round(color.k))
+    elseif color.l then
+      writeline("Push color (grayscale)", _round(color.l))
+    end
   end,
 
   popColor = function (self)


### PR DESCRIPTION
A no-brainer, but seen in passing while generating a debug file (`sile -b debug`) for a test.
```
SILE v0.13.2 (Lua 5.4)
<experiments/background.sil>

Error detected:
	./core/debug-output.lua:33: attempt to compare number with nil
stack traceback:
	./core/debug-output.lua:33: in upvalue '_round'
	./core/debug-output.lua:92: in method 'pushColor'
(...)
```

Turned out my color was in grayscale (`\color[color=220]`) and the debug outputter only knows RGB...

Output kept unchanged for RGB (not to affect existing tests), but fixed for other color schemes (CMYK, Grayscale)