### PR TITLE
textsubsuper package (real or fake super/subscripts)

### DIFF
--- a/packages/raiselower/init.lua
+++ b/packages/raiselower/init.lua
@@ -32,10 +32,12 @@ end
 
 package.documentation = [[
 \begin{document}
-If you don’t want your images, rules or text to be placed along the baseline, you can use the \autodoc:package{raiselower} package to move them up and down.
-(The \autodoc:package{footnote} package uses this to superscript the footnote reference numbers.)
+If you don’t want your images, rules or text to be placed along the baseline,
+you can use the \autodoc:package{raiselower} package to move them up and down.
 
-It provides two simple commands, \autodoc:command{\raise} and \autodoc:command{\lower} which both take a \autodoc:parameter{height=<dimension>} parameter.
+It provides two simple commands, \autodoc:command{\raise} and
+\autodoc:command{\lower} which both take a \autodoc:parameter{height=<dimension>}
+parameter.
 They will respectively raise or lower their argument by the given height.
 The raised or lowered content will not alter the height or depth of the line.
 

--- a/packages/textsubsuper/init.lua
+++ b/packages/textsubsuper/init.lua
@@ -1,0 +1,366 @@
+--
+-- Text superscript and subscript package for SILE
+-- using OpenType features when available.
+-- 2021-2022, Didier Willis
+-- Derived from an idea sketched by Simon Cozens
+-- in https://github.com/sile-typesetter/sile/issues/1258
+-- License: MIT
+--
+local inputfilter = require("packages/inputfilter").exports
+
+local textFeatCache = {}
+
+local _key = function (options, text)
+  -- We don't use the size in the cache key, as we don't expect it to
+  -- change whether features are supported or not...
+  return table.concat({
+      text,
+      options.family,
+      ("%d"):format(options.weight or 0),
+      options.style,
+      options.variant,
+      options.features,
+      options.filename,
+    }, ";")
+end
+
+local function textFeatCaching (options, text, status)
+  local key = _key(options, text)
+  if textFeatCache[key] == nil then
+    textFeatCache[key] = status
+  end
+  return status
+end
+
+local function checkFontFeatures (features, content)
+  local text = SU.contentToString(content)
+  if tonumber(text) ~= nil then
+    -- Avoid caching any sequence of digits. Plus, we want
+    -- consistency here.
+    text="0123456789"
+  end
+  local fontOptions = SILE.font.loadDefaults({ features = features })
+  local supported = textFeatCache[_key(fontOptions, text)]
+  if supported ~= nil then
+    return supported
+  end
+
+  local items1 = SILE.shaper:shapeToken(text, fontOptions)
+  local items2 = SILE.shaper:shapeToken(text, SILE.font.loadDefaults({}))
+
+  -- Don't mix up characters supporting the features with those
+  -- not supporting them, as it would be ugly in most cases.
+  if #items1 ~= #items2 then
+    return textFeatCaching(fontOptions, text, false)
+  end
+  for i = 1, #items1 do
+    if items1[i].width == items2[i].width and items1[i].height == items2[i].height then
+      return textFeatCaching(fontOptions, text, false)
+    end
+  end
+  return textFeatCaching(fontOptions, text, true)
+end
+
+local function getItalicAngle ()
+  local ot = require("core.opentype-parser")
+  local fontoptions = SILE.font.loadDefaults({})
+  local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+  local font = ot.parseFont(face)
+  return font.post.italicAngle
+end
+
+local function getWeightClass ()
+  -- Provided we return it in the font parser, maybe we could
+  -- rather do:
+  -- local ot = require("core.opentype-parser")
+  -- local fontoptions = SILE.font.loadDefaults({})
+  -- local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+  -- local font = ot.parseFont(face)
+  -- return font.os2.usWeightClass
+  return SILE.settings:get("font.weight")
+end
+
+local function rescaleFilter (node, content, args)
+  if type(node) == "table" then return node end
+  local result = {}
+  local chars = SU.splitUtf8(node)
+  for _, char in ipairs(chars) do
+    if not tonumber(char) then
+      result[#result+1] = inputfilter.createCommand(
+        content.pos, content.col, content.line,
+        "textsubsuper:scale", {
+          xRatio = args.xScale,
+          yRatio = args.yScaleOther
+        }, { char }
+      )
+    else
+      result[#result+1] = inputfilter.createCommand(
+        content.pos, content.col, content.line,
+        "textsubsuper:scale", {
+          xRatio = args.xScale,
+          yRatio = args.yScaleNumber
+        }, { char }
+      )
+    end
+  end
+  return result
+end
+
+local function rescaleContent(content)
+  local transformed
+  if SILE.outputter ~= SILE.outputters.libtexpdf then
+    -- Not supported
+    transformed = content
+  else
+    transformed = inputfilter.transformContent(content, rescaleFilter, {
+      xScale = 1,
+      yScaleNumber = SILE.settings:get("textsubsuper.vscale.number"),
+      yScaleOther = SILE.settings:get("textsubsuper.vscale.other"),
+    })
+  end
+  SILE.process(transformed)
+ end
+
+local function declareSettings (_)
+  SILE.settings:declare({
+    parameter = "textsubsuper.scale",
+    type = "integer",
+    default = 0.66,
+    help = "Size scaling ratio of a fake superscript or subsscript"
+  })
+
+  SILE.settings:declare({
+    parameter = "textsubsuper.bolder",
+    type = "integer",
+    default = 200,
+    help = "Weight increase of a fake superscript or subsscript (e.g. 200 for normal to semibold)"
+  })
+
+  SILE.settings:declare({
+    parameter = "textsubsuper.vscale.number",
+    type = "number",
+    default = 0.90,
+    help = "Vertical ratio applied to numbers in fake superscript or subsscript"
+  })
+
+  SILE.settings:declare({
+    parameter = "textsubsuper.vscale.other",
+    type = "number",
+    default = 0.95,
+    help = "Vertical ratio applied to numbers in fake superscript or subsscript"
+  })
+
+  SILE.settings:declare({
+    parameter = "textsubsuper.offset.superscript",
+    type = "measurement",
+    default = SILE.measurement("0.70ex"),
+    help = "Offset of a fake superscript above the baseline (logically in a font-relative unit such as ex)"
+  })
+
+  SILE.settings:declare({
+    parameter = "textsubsuper.offset.subscript",
+    type = "measurement",
+    default = SILE.measurement("0.25ex"),
+    help = "Offset of a fake subscript below the baseline (logically in a font-relative unit such as ex)"
+  })
+end
+
+local function registerCommands (_)
+  -- REAL SUPERSCRIPT / SUBSCRIPT WHEN AVAILABLE
+
+  SILE.registerCommand("textsuperscript", function (options, content)
+    if type(content) ~= "table" then SU.error("Expected a table content in textsuperscript") end
+    if SU.boolean(options.fake, false) then
+      SILE.call("textsuperscript:fake", {}, content)
+      return
+    end
+    if checkFontFeatures("+sups", content) then
+      SILE.call("font", { features="+sups" }, content)
+    else
+      SU.debug("textsubsuper", "No true superscripts for '"..SU.contentToString(content).."', fallback to scaling")
+      SILE.call("textsuperscript:fake", {}, content)
+    end
+  end, "Typeset a superscript text content.")
+
+  SILE.registerCommand("textsubscript", function (options, content)
+    if type(content) ~= "table" then SU.error("Expected a table content in textsubscript") end
+    if SU.boolean(options.fake, false) then
+      SILE.call("textsubscript:fake", {}, content)
+      return
+    end
+    if checkFontFeatures("+subs", content) then
+      SILE.call("font", { features="+subs" }, content)
+    elseif checkFontFeatures("+sinf", content) then
+      SU.debug("textsubsuper", "No true subscripts for '"..SU.contentToString(content).."', fallback to scientific inferiors")
+      SILE.call("font", { features="+sinf" }, content)
+    else
+      SU.debug("textsubsuper", "No true subscripts for '"..SU.contentToString(content).."', fallback to scaling")
+      SILE.call("textsubscript:fake", {}, content)
+    end
+  end, "Typeset a subscript text content.")
+
+  -- FAKE (SCALED AND RAISED) SUPERSCRIPT OR SUBSCRIPT
+
+  SILE.registerCommand("textsuperscript:fake", function (_, content)
+    SILE.require("packages/raiselower")
+    local italicAngle = getItalicAngle()
+    local weight = getWeightClass()
+
+    local ratio = SILE.settings:get("textsubsuper.scale")
+    local ySize = ratio * SILE.settings:get("font.size")
+    local yOffset = SILE.settings:get("textsubsuper.offset.superscript")
+    local xOffset = -math.sin(italicAngle * math.pi / 180) * yOffset
+    SILE.call("kern", { width = xOffset:absolute() + SILE.measurement("0.1pt") })
+    SILE.call("raise", { height = yOffset }, function ()
+      -- Some font have +onum enabled by default...
+      -- Some don't even have it (e.g. Brill), but support +lnum for enforcing lining
+      -- figures. We try to ensure we are not using oldstyle numbers...
+      SILE.call("font", {
+        size = ySize,
+        weight = weight == 400 and (weight + SILE.settings:get("textsubsuper.bolder")) or weight,
+        features = "+lnum -onum",
+      }, function ()
+        rescaleContent(content)
+      end)
+    end)
+    SILE.call("kern", { width = -xOffset / 2 })
+  end, "Typeset a fake (raised, scaled) superscript content.")
+
+  SILE.registerCommand("textsubscript:fake", function (_, content)
+    SILE.require("packages/raiselower")
+    local italicAngle = getItalicAngle()
+    local weight = getWeightClass()
+
+    local ratio = SILE.settings:get("textsubsuper.scale")
+    local ySize = ratio * SILE.settings:get("font.size")
+    local yOffset = SILE.settings:get("textsubsuper.offset.subscript")
+    local xOffset = -math.sin(italicAngle * math.pi / 180) * yOffset:absolute()
+    SILE.call("kern", { width = -xOffset })
+    SILE.call("lower", { height = yOffset }, function ()
+      SILE.call("font", {
+        size = ySize,
+        weight = weight == 400 and (weight + SILE.settings:get("textsubsuper.bolder")) or weight,
+        features = "+lnum +onum",
+      }, function ()
+        rescaleContent(content)
+      end)
+    end)
+    SILE.call("kern", { width = xOffset })
+  end, "Typeset a fake (lowered, scaled) subscript content.")
+
+  -- RE-SCALING BY SOME RATIOS
+
+  SILE.registerCommand("textsubsuper:scale", function (options, content)
+    -- Here assume the ouputter to be libtexpdf
+    -- This is supposed to be checked earlier above.
+    local pdf = require("justenoughlibtexpdf")
+
+    local hbox = SILE.call("hbox", {}, content)
+    table.remove(SILE.typesetter.state.nodes) -- Remove the box from queue
+
+    local xRatio, yRatio = options.xRatio, options.yRatio
+    SILE.typesetter:pushHbox({
+      width = hbox.width * xRatio,
+      height = SILE.length(),
+      depth = SILE.length(),
+      outputYourself = function(self, typesetter, line)
+        local X = typesetter.frame.state.cursorX
+        local Y = typesetter.frame.state.cursorY
+        local x0 = X:tonumber()
+        local y0 = -Y:tonumber()
+        typesetter.frame.state.cursorY = Y
+        pdf:gsave()
+        pdf.setmatrix(1, 0, 0, 1, x0, y0)
+        pdf.setmatrix(xRatio, 0, 0, yRatio, 0, 0)
+        pdf.setmatrix(1, 0, 0, 1, -x0, -y0)
+        hbox.outputYourself(hbox, typesetter, line)
+        pdf:grestore()
+        typesetter.frame.state.cursorX = X
+        typesetter.frame.state.cursorY = Y
+        typesetter.frame:advanceWritingDirection(self.width)
+      end
+    })
+  end, "Scale content by some horizontal and vertical ratios")
+end
+
+return {
+  declareSettings = declareSettings,
+  registerCommands = registerCommands,
+  documentation = [[\begin{document}
+\script[src=packages/textsubsuper]% SILE 0.13 needs a big big FIXME, it's 0xDEADBEEF
+Superscripts are sometimes needed for numbers (e.g. in footnote calls),
+but also for letters (e.g. in French, century references such as
+\font[features=+smcp]{xiv}\textsuperscript{e}, issue numbers such
+as n\textsuperscript{os} 5–6; likewise in English, sequences such
+as 14\textsuperscript{th}).
+As of subscripts, chemical formulas are the most familiar example, for example
+H\textsubscript{2}O or C\textsubscript{6}H\textsubscript{12}O\textsubscript{6}.
+
+In his \em{Elements of Typographic Style} (3\textsuperscript{rd} edition, §4.3.2),
+Robert Bringhurst writes: “Many fonts include sets of superscript numbers, but
+these are not always of satisfactory size and design. Text numerals set at a
+reduced size and elevated baseline are sometimes the best or only choice.”
+
+Most of the time, however, assuming the font designers did their job well, such
+“real” characters ought to look much better than scaled and raised characters.
+SILE thrives at good typography. The \autodoc:package{textsubsuper} package
+provides two commands, \autodoc:command{\textsuperscript{<content>}} and
+\autodoc:command{\textsubscript{<content>}}, which aim at using these characters,
+when available.
+
+These commands achieve their goal by trying the \code{+sups} font feature for
+superscripts, and the \code{+subs} or \code{+sinf} feature for subscripts.
+If the output is not different than \em{without} the feature, it implies that
+the corresponding OpenType feature is not supported by the font (such as the
+default Gentium font, which does not have these features\footnote{Though it does
+include some of the Unicode superscript and subscript characters, but this very
+package does not try to address such a case.}). In that case, it relies on
+scaling and raising (or lowering) the characters, so as to build “fake”
+superscripts (or subscripts).
+
+By nature, this package is \em{not} intended to work with multiple levels of
+superscripts or subscripts. Also note that it tries not to mix up characters
+supporting the features with those not supporting them, as it would be somewhat
+ugly in most cases. Fake superscripts or superscripts will also be used if such
+a case occurs.
+
+Would you actually prefer this fake variant, the \autodoc:parameter{fake=true}
+option on the above-mentioned commands enforces it.
+
+In his afterword, Bringhurst also notes: “It remains the case that I have
+never yet tested a perfect font, no matter whether it came in the form of
+foundry metal, a matrix case, a strip of film or digital information.”
+In our case here, if font designers had done their job all right again,
+the OpenType OS2 table could have been used to retrieve the recommended
+offset, scaling and sizing parameters for a given font face. However, these
+parameters are seldom properly set and they lead to a poor (not to say
+utterly wrong) result for many fonts, including well-known ones…
+
+This package therefore relies on its own settings,
+\autodoc:setting{textsubsuper.scale},
+\autodoc:setting{textsubsuper.offset.superscript}
+and \autodoc:setting{textsubsuper.offset.subscript}.
+Their default values are, by nature, empirical.
+
+Bringhurst goes on: “In many faces, smaller numbers in semibold look better
+than larger numbers of regular weight.” Hence,
+the \autodoc:setting{textsubsuper.bolder} setting defaults to 200,
+so that in a text in normal weight (400), superscripts and subscripts
+are set in semibold (600). This setting is ignored if the input text
+is not in normal weight.
+
+Would the text be set in italic, the package relies on the italic
+angle from the font properties to improve the superscript or
+subscript placement.
+
+Still, this is not sufficient to give the best possible output.
+Smaller numbers are usually scaled vertically to a proportion of the
+full height they would take at regular size. This is also often the case
+for letters, albeit to a smaller amount.
+Settings \autodoc:setting{textsubsuper.vscale.number} and
+\autodoc:setting{textsubsuper.vscale.other} are thus available
+to obtain that effect\footnote{This feature is currently only supported
+with the \code{libtexpdf} backend.}.
+Their default values, again, are obviously empirical.
+\end{document}]]
+}

--- a/packages/textsubsuper/init.lua
+++ b/packages/textsubsuper/init.lua
@@ -293,7 +293,7 @@ end
 
 package.documentation = [[
 \begin{document}
-\script[src=packages/textsubsuper]% SILE 0.13 needs a big big FIXME, it's 0xDEADBEEF
+\use[module=packages.textsubsuper]
 Superscripts are sometimes needed for numbers (e.g. in footnote calls),
 but also for letters (e.g. in French, century references such as
 \font[features=+smcp]{xiv}\textsuperscript{e}, issue numbers such

--- a/packages/textsubsuper/init.lua
+++ b/packages/textsubsuper/init.lua
@@ -93,28 +93,28 @@ function package.declareSettings (_)
     parameter = "textsubsuper.scale",
     type = "integer",
     default = 0.66,
-    help = "Size scaling ratio of a fake superscript or subsscript"
+    help = "Size scaling ratio of a fake superscript or subscript"
   })
 
   SILE.settings:declare({
     parameter = "textsubsuper.bolder",
     type = "integer",
     default = 200,
-    help = "Weight increase of a fake superscript or subsscript (e.g. 200 for normal to semibold)"
+    help = "Weight increase of a fake superscript or subscript (e.g. 200 for normal to semibold)"
   })
 
   SILE.settings:declare({
     parameter = "textsubsuper.vscale.number",
     type = "number",
     default = 0.90,
-    help = "Vertical ratio applied to numbers in fake superscript or subsscript"
+    help = "Vertical ratio applied to numbers in fake superscript or subscript"
   })
 
   SILE.settings:declare({
     parameter = "textsubsuper.vscale.other",
     type = "number",
     default = 0.95,
-    help = "Vertical ratio applied to numbers in fake superscript or subsscript"
+    help = "Vertical ratio applied to numbers in fake superscript or subscript"
   })
 
   SILE.settings:declare({
@@ -327,7 +327,7 @@ superscripts (or subscripts).
 By nature, this package is \em{not} intended to work with multiple levels of
 superscripts or subscripts. Also note that it tries not to mix up characters
 supporting the features with those not supporting them, as it would be somewhat
-ugly in most cases. Fake superscripts or superscripts will also be used if such
+ugly in most cases. Fake superscripts or subscripts will also be used if such
 a case occurs.
 
 Would you actually prefer this fake variant, the \autodoc:parameter{fake=true}

--- a/tests/feat-textsubsuper.expected
+++ b/tests/feat-textsubsuper.expected
@@ -6,21 +6,21 @@ Set font 	Gentium Plus;10;400;;normal;;LTR
 T	11 w=3.1689	(()
 Mx 	18.0508
 T	39 72 73 68 88 79 87 w=29.6973	(Default)
-Mx 	50.4117
+Mx 	50.4118
 T	73 82 81 87 w=17.0996	(font)
-Mx 	67.5113
+Mx 	67.5114
 T	12 w=3.1689	())
-Mx 	73.3439
+Mx 	73.3440
 T	43 w=6.5381	(H)
-Mx 	79.8820
+Mx 	79.8821
 My 	29.9241
 Set font 	Gentium Plus;6.6;600;;normal;+lnum +onum;LTR
-T	21 w=3.3387	(2)
-Mx 	83.2207
+T	21 w=3.0970	(2)
+Mx 	82.9790
 My 	28.7889
 Set font 	Gentium Plus;10;400;;normal;;LTR
 T	50 w=6.0010	(O)
-Mx 	89.2217
+Mx 	88.9800
 T	17 w=2.2900	(.)
 Mx 	14.8819
 My 	40.7889
@@ -28,36 +28,25 @@ T	20 25 w=9.3848	(16)
 Mx 	24.3667
 My 	37.6102
 Set font 	Gentium Plus;6.6;600;;normal;+lnum -onum;LTR
-T	87 75 w=6.2777	(th)
-Mx 	33.3054
+T	87 75 w=5.9136	(th)
+Mx 	32.9412
 My 	40.7889
 Set font 	Gentium Plus;10;400;;normal;;LTR
-Mx 	4.3701
-Mx 	4.6191
-Mx 	5.5176
-Mx 	3.4424
-Mx 	5.2979
-Mx 	3.9600
-Mx 	3.9502
-T	70 a=4.3701 72 a=4.6191 81 a=5.5176 87 a=3.4424 88 a=5.2979 85 a=3.9600 92 a=4.9316	(century)
+T	70 72 81 87 88 85 92 w=32.1387	(century)
+Mx 	65.0799
 T	15 w=2.2900	(,)
-Mx 	69.4137
+Mx 	70.0309
 Set font 	Gentium Plus;10;400;;normal;+smcp;LTR
-T	4026 4004 3694 w=14.6875	(xvi)
-Mx 	84.2012
+T	4100 4080 3783 w=14.6875	(xvi)
+Mx 	84.8184
 My 	37.6102
 Set font 	Gentium Plus;6.6;600;;normal;+lnum -onum;LTR
-T	72 w=3.1937	(e)
-Mx 	90.0559
+T	72 w=3.0486	(e)
+Mx 	90.5280
 My 	40.7889
 Set font 	Gentium Plus;10;400;;normal;;LTR
-Mx 	3.8623
-Mx 	2.7100
-Mx 	4.6191
-Mx 	4.2188
-Mx 	2.7100
-Mx 	4.6191
-T	86 a=3.8623 76 a=2.7100 113 a=4.6191 70 a=4.3701 79 a=2.7100 72 a=4.6191	(siècle)
+T	86 76 113 70 79 72 w=22.8906	(siècle)
+Mx 	113.4186
 T	17 w=2.2900	(.)
 Mx 	14.8819
 My 	52.7889
@@ -65,8 +54,8 @@ T	54 88 83 72 85 86 70 85 76 83 87 w=47.5781	(Superscript)
 Mx 	62.5600
 My 	49.6102
 Set font 	Gentium Plus;6.6;600;;normal;+lnum -onum;LTR
-T	20 21 22 w=10.0160	(123)
-Mx 	72.5760
+T	20 21 22 w=9.2909	(123)
+Mx 	71.8509
 My 	52.7889
 Set font 	Gentium Plus;10;400;;normal;;LTR
 T	17 w=2.2900	(.)
@@ -78,21 +67,21 @@ Mx 	17.8311
 T	39 72 73 68 88 79 87 w=27.0313	(Default)
 Mx 	47.2825
 T	73 82 81 87 w=14.9609	(font)
-Mx 	64.6635
+Mx 	64.6636
 T	76 87 68 79 76 70 w=18.7256	(italic)
-Mx 	83.3891
+Mx 	83.3892
 T	12 w=2.9492	())
-Mx 	88.7584
+Mx 	88.7585
 T	43 w=6.0303	(H)
-Mx 	94.6297
+Mx 	94.6298
 My 	65.9315
 Set font 	Gentium Plus;6.6;600;italic;normal;+lnum +onum;LTR
-T	21 w=3.0035	(2)
-Mx 	97.7922
+T	21 w=2.6522	(2)
+Mx 	97.4411
 My 	64.7889
 Set font 	Gentium Plus;10;400;italic;normal;;LTR
 T	50 w=5.4492	(O)
-Mx 	103.2414
+Mx 	102.8903
 T	17 w=2.0020	(.)
 Mx 	14.8819
 My 	76.7889
@@ -100,31 +89,25 @@ T	20 25 w=8.0371	(16)
 Mx 	23.4642
 My 	73.5897
 Set font 	Gentium Plus;6.6;600;italic;normal;+lnum -onum;LTR
-T	87 75 w=5.7009	(th)
-Mx 	31.3626
+T	87 75 w=5.2884	(th)
+Mx 	30.9501
 My 	76.7889
 Set font 	Gentium Plus;10;400;italic;normal;;LTR
-Mx 	3.8818
-Mx 	3.9307
-Mx 	4.9414
-Mx 	3.0713
-Mx 	4.9902
-Mx 	3.5498
-Mx 	3.9307
-T	70 a=3.8818 72 a=3.9307 81 a=4.9414 87 a=3.0713 88 a=4.9902 85 a=3.5498 92 a=4.5215	(century)
+T	70 72 81 87 88 85 92 w=28.8867	(century)
+Mx 	59.8368
 T	15 w=2.0020	(,)
-Mx 	64.0806
+Mx 	64.2589
 Set font 	Gentium Plus;10;400;italic;normal;+smcp;LTR
-T	4026 4004 3694 w=13.5791	(xvi)
-Mx 	78.2049
+T	4100 4080 3783 w=13.5791	(xvi)
+Mx 	78.3833
 My 	73.5897
 Set font 	Gentium Plus;6.6;600;italic;normal;+lnum -onum;LTR
-T	72 w=2.7876	(e)
-Mx 	83.1900
+T	72 w=2.5942	(e)
+Mx 	83.1750
 My 	76.7889
 Set font 	Gentium Plus;10;400;italic;normal;;LTR
 T	86 76 113 70 79 72 w=20.0244	(siècle)
-Mx 	103.2144
+Mx 	103.1994
 T	17 w=2.0020	(.)
 Mx 	14.8819
 My 	88.7889
@@ -132,8 +115,8 @@ T	54 88 83 72 85 86 70 85 76 83 87 w=42.7197	(Superscript)
 Mx 	58.1469
 My 	85.5897
 Set font 	Gentium Plus;6.6;600;italic;normal;+lnum -onum;LTR
-T	20 21 22 w=9.0105	(123)
-Mx 	66.9348
+T	20 21 22 w=7.9567	(123)
+Mx 	65.8810
 My 	88.7889
 Set font 	Gentium Plus;10;400;italic;normal;;LTR
 T	17 w=2.0020	(.)

--- a/tests/feat-textsubsuper.expected
+++ b/tests/feat-textsubsuper.expected
@@ -1,0 +1,349 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	14.8819
+My 	28.7889
+Set font 	Gentium Plus;10;400;;normal;;LTR
+T	11 w=3.1689	(()
+Mx 	18.0508
+T	39 72 73 68 88 79 87 w=29.6973	(Default)
+Mx 	50.4117
+T	73 82 81 87 w=17.0996	(font)
+Mx 	67.5113
+T	12 w=3.1689	())
+Mx 	73.3439
+T	43 w=6.5381	(H)
+Mx 	79.8820
+My 	29.9241
+Set font 	Gentium Plus;6.6;600;;normal;+lnum +onum;LTR
+T	21 w=3.3387	(2)
+Mx 	83.2207
+My 	28.7889
+Set font 	Gentium Plus;10;400;;normal;;LTR
+T	50 w=6.0010	(O)
+Mx 	89.2217
+T	17 w=2.2900	(.)
+Mx 	14.8819
+My 	40.7889
+T	20 25 w=9.3848	(16)
+Mx 	24.3667
+My 	37.6102
+Set font 	Gentium Plus;6.6;600;;normal;+lnum -onum;LTR
+T	87 75 w=6.2777	(th)
+Mx 	33.3054
+My 	40.7889
+Set font 	Gentium Plus;10;400;;normal;;LTR
+Mx 	4.3701
+Mx 	4.6191
+Mx 	5.5176
+Mx 	3.4424
+Mx 	5.2979
+Mx 	3.9600
+Mx 	3.9502
+T	70 a=4.3701 72 a=4.6191 81 a=5.5176 87 a=3.4424 88 a=5.2979 85 a=3.9600 92 a=4.9316	(century)
+T	15 w=2.2900	(,)
+Mx 	69.4137
+Set font 	Gentium Plus;10;400;;normal;+smcp;LTR
+T	4026 4004 3694 w=14.6875	(xvi)
+Mx 	84.2012
+My 	37.6102
+Set font 	Gentium Plus;6.6;600;;normal;+lnum -onum;LTR
+T	72 w=3.1937	(e)
+Mx 	90.0559
+My 	40.7889
+Set font 	Gentium Plus;10;400;;normal;;LTR
+Mx 	3.8623
+Mx 	2.7100
+Mx 	4.6191
+Mx 	4.2188
+Mx 	2.7100
+Mx 	4.6191
+T	86 a=3.8623 76 a=2.7100 113 a=4.6191 70 a=4.3701 79 a=2.7100 72 a=4.6191	(siècle)
+T	17 w=2.2900	(.)
+Mx 	14.8819
+My 	52.7889
+T	54 88 83 72 85 86 70 85 76 83 87 w=47.5781	(Superscript)
+Mx 	62.5600
+My 	49.6102
+Set font 	Gentium Plus;6.6;600;;normal;+lnum -onum;LTR
+T	20 21 22 w=10.0160	(123)
+Mx 	72.5760
+My 	52.7889
+Set font 	Gentium Plus;10;400;;normal;;LTR
+T	17 w=2.2900	(.)
+Mx 	14.8819
+My 	64.7889
+Set font 	Gentium Plus;10;400;italic;normal;;LTR
+T	11 w=2.9492	(()
+Mx 	17.8311
+T	39 72 73 68 88 79 87 w=27.0313	(Default)
+Mx 	47.2825
+T	73 82 81 87 w=14.9609	(font)
+Mx 	64.6635
+T	76 87 68 79 76 70 w=18.7256	(italic)
+Mx 	83.3891
+T	12 w=2.9492	())
+Mx 	88.7584
+T	43 w=6.0303	(H)
+Mx 	94.6297
+My 	65.9315
+Set font 	Gentium Plus;6.6;600;italic;normal;+lnum +onum;LTR
+T	21 w=3.0035	(2)
+Mx 	97.7922
+My 	64.7889
+Set font 	Gentium Plus;10;400;italic;normal;;LTR
+T	50 w=5.4492	(O)
+Mx 	103.2414
+T	17 w=2.0020	(.)
+Mx 	14.8819
+My 	76.7889
+T	20 25 w=8.0371	(16)
+Mx 	23.4642
+My 	73.5897
+Set font 	Gentium Plus;6.6;600;italic;normal;+lnum -onum;LTR
+T	87 75 w=5.7009	(th)
+Mx 	31.3626
+My 	76.7889
+Set font 	Gentium Plus;10;400;italic;normal;;LTR
+Mx 	3.8818
+Mx 	3.9307
+Mx 	4.9414
+Mx 	3.0713
+Mx 	4.9902
+Mx 	3.5498
+Mx 	3.9307
+T	70 a=3.8818 72 a=3.9307 81 a=4.9414 87 a=3.0713 88 a=4.9902 85 a=3.5498 92 a=4.5215	(century)
+T	15 w=2.0020	(,)
+Mx 	64.0806
+Set font 	Gentium Plus;10;400;italic;normal;+smcp;LTR
+T	4026 4004 3694 w=13.5791	(xvi)
+Mx 	78.2049
+My 	73.5897
+Set font 	Gentium Plus;6.6;600;italic;normal;+lnum -onum;LTR
+T	72 w=2.7876	(e)
+Mx 	83.1900
+My 	76.7889
+Set font 	Gentium Plus;10;400;italic;normal;;LTR
+T	86 76 113 70 79 72 w=20.0244	(siècle)
+Mx 	103.2144
+T	17 w=2.0020	(.)
+Mx 	14.8819
+My 	88.7889
+T	54 88 83 72 85 86 70 85 76 83 87 w=42.7197	(Superscript)
+Mx 	58.1469
+My 	85.5897
+Set font 	Gentium Plus;6.6;600;italic;normal;+lnum -onum;LTR
+T	20 21 22 w=9.0105	(123)
+Mx 	66.9348
+My 	88.7889
+Set font 	Gentium Plus;10;400;italic;normal;;LTR
+T	17 w=2.0020	(.)
+Mx 	14.8819
+My 	100.7889
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+T	9 w=2.9800	(()
+Mx 	17.8619
+Mx 	5.2800
+Mx 	2.7100
+Mx 	5.0300
+Mx 	4.4700
+Mx 	3.7200
+Mx 	3.1600
+Mx 	2.7100
+Mx 	5.4200
+Mx 	5.3100
+Mx 	3.9000
+T	45 a=5.2800 74 a=2.7100 67 a=4.9300 70 a=4.4700 83 a=3.7200 85 a=3.1600 74 a=2.7100 79 a=5.4200 86 a=5.3100 84 a=3.9000	(Libertinus)
+T	13 w=2.2000	(,)
+Mx 	64.7851
+T	71 80 79 85 w=16.7200	(font)
+Mx 	84.5184
+T	84 86 67 w=14.1400	(sub)
+Mx 	98.6584
+T	16 w=3.2300	(/)
+Mx 	101.8884
+Mx 	3.9000
+Mx 	5.3100
+Mx 	5.2600
+Mx 	4.4700
+Mx 	3.7200
+Mx 	3.9000
+Mx 	4.2800
+Mx 	3.7200
+Mx 	2.7100
+Mx 	5.1900
+Mx 	3.1600
+Mx 	3.9000
+T	84 a=3.9000 86 a=5.3100 81 a=5.1900 70 a=4.4700 83 a=3.7200 84 a=3.9000 68 a=4.2800 83 a=3.7200 74 a=2.7100 81 a=5.1900 85 a=3.1600 84 a=3.9000	(superscripts)
+T	10 w=2.9800	())
+Mx 	157.4017
+T	41 w=7.3000	(H)
+Mx 	164.7017
+Set font 	Libertinus Serif;10;400;italic;normal;+subs;LTR
+T	1813 w=3.0700	(2)
+Mx 	167.7717
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+Mx 	6.7300
+T	48 a=7.0200	(O)
+T	15 w=2.2000	(.)
+Mx 	14.8819
+My 	112.7889
+T	18 23 w=9.3000	(16)
+Mx 	24.1819
+Set font 	Libertinus Serif;10;400;italic;normal;+sups;LTR
+T	1225 624 w=5.2300	(th)
+Mx 	32.4330
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+Mx 	4.2800
+Mx 	4.4700
+Mx 	5.4200
+Mx 	3.1600
+Mx 	5.3100
+Mx 	3.8700
+Mx 	4.5600
+T	68 a=4.2800 70 a=4.4700 79 a=5.4200 85 a=3.1600 86 a=5.3100 83 a=3.7200 90 a=5.1500	(century)
+T	13 w=2.2000	(,)
+Mx 	68.7242
+Set font 	Libertinus Serif;10;400;italic;normal;+smcp;LTR
+T	2418 2416 2404 w=13.9100	(xvi)
+Mx 	82.6342
+Set font 	Libertinus Serif;10;400;italic;normal;+sups;LTR
+T	1211 w=3.1700	(e)
+Mx 	88.8254
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+Mx 	3.9000
+Mx 	2.7100
+Mx 	4.5700
+Mx 	4.2800
+Mx 	2.6400
+Mx 	4.3700
+T	84 a=3.9000 74 a=2.7100 168 a=4.4700 68 a=4.2800 77 a=2.6400 70 a=4.4700	(siècle)
+T	15 w=2.2000	(.)
+Mx 	14.8819
+My 	124.7889
+Mx 	4.8500
+Mx 	5.3100
+Mx 	5.2600
+Mx 	4.4700
+Mx 	3.7200
+Mx 	3.9000
+Mx 	4.2800
+Mx 	3.7200
+Mx 	2.7100
+Mx 	5.1900
+Mx 	3.1600
+T	52 a=4.8500 86 a=5.3100 81 a=5.1900 70 a=4.4700 83 a=3.7200 84 a=3.9000 68 a=4.2800 83 a=3.7200 74 a=2.7100 81 a=5.1900 85 a=3.1600	(Superscript)
+Set font 	Libertinus Serif;10;400;italic;normal;+sups;LTR
+T	121 114 115 w=9.2100	(123)
+Mx 	70.6619
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+T	15 w=2.2000	(.)
+Mx 	14.8819
+My 	136.7889
+T	9 w=2.9800	(()
+Mx 	17.8619
+Mx 	5.2800
+Mx 	2.7100
+Mx 	5.0300
+Mx 	4.4700
+Mx 	3.7200
+Mx 	3.1600
+Mx 	2.7100
+Mx 	5.4200
+Mx 	5.3100
+Mx 	3.9000
+T	45 a=5.2800 74 a=2.7100 67 a=4.9300 70 a=4.4700 83 a=3.7200 85 a=3.1600 74 a=2.7100 79 a=5.4200 86 a=5.3100 84 a=3.9000	(Libertinus)
+T	13 w=2.2000	(,)
+Mx 	64.7851
+T	71 66 76 70 w=17.2600	(fake)
+Mx 	85.0583
+T	84 86 67 w=14.1400	(sub)
+Mx 	99.1983
+T	16 w=3.2300	(/)
+Mx 	102.4283
+Mx 	3.9000
+Mx 	5.3100
+Mx 	5.2600
+Mx 	4.4700
+Mx 	3.7200
+Mx 	3.9000
+Mx 	4.2800
+Mx 	3.7200
+Mx 	2.7100
+Mx 	5.1900
+Mx 	3.1600
+Mx 	3.9000
+T	84 a=3.9000 86 a=5.3100 81 a=5.1900 70 a=4.4700 83 a=3.7200 84 a=3.9000 68 a=4.2800 83 a=3.7200 74 a=2.7100 81 a=5.1900 85 a=3.1600 84 a=3.9000	(superscripts)
+T	10 w=2.9800	())
+Mx 	157.9415
+T	41 w=7.3000	(H)
+Mx 	165.2415
+My 	137.8664
+Set font 	Libertinus Serif;6.6;600;italic;normal;+lnum +onum;LTR
+T	19 w=3.0690	(2)
+Mx 	168.3105
+My 	136.7889
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+Mx 	6.7300
+T	48 a=7.0200	(O)
+T	15 w=2.2000	(.)
+Mx 	14.8819
+My 	148.7889
+T	18 23 w=9.3000	(16)
+Mx 	24.2819
+My 	145.7719
+Set font 	Libertinus Serif;6.6;600;italic;normal;+lnum -onum;LTR
+T	85 73 w=5.6364	(th)
+Mx 	32.9394
+My 	148.7889
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+Mx 	4.2800
+Mx 	4.4700
+Mx 	5.4200
+Mx 	3.1600
+Mx 	5.3100
+Mx 	3.8700
+Mx 	4.5600
+T	68 a=4.2800 70 a=4.4700 79 a=5.4200 85 a=3.1600 86 a=5.3100 83 a=3.7200 90 a=5.1500	(century)
+T	13 w=2.2000	(,)
+Mx 	69.2305
+Set font 	Libertinus Serif;10;400;italic;normal;+smcp;LTR
+T	2418 2416 2404 w=13.9100	(xvi)
+Mx 	83.2405
+My 	145.7719
+Set font 	Libertinus Serif;6.6;600;italic;normal;+lnum -onum;LTR
+T	70 w=2.9502	(e)
+Mx 	89.2118
+My 	148.7889
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+Mx 	3.9000
+Mx 	2.7100
+Mx 	4.5700
+Mx 	4.2800
+Mx 	2.6400
+Mx 	4.3700
+T	84 a=3.9000 74 a=2.7100 168 a=4.4700 68 a=4.2800 77 a=2.6400 70 a=4.4700	(siècle)
+T	15 w=2.2000	(.)
+Mx 	14.8819
+My 	160.7889
+Mx 	4.8500
+Mx 	5.3100
+Mx 	5.2600
+Mx 	4.4700
+Mx 	3.7200
+Mx 	3.9000
+Mx 	4.2800
+Mx 	3.7200
+Mx 	2.7100
+Mx 	5.1900
+Mx 	3.1600
+T	52 a=4.8500 86 a=5.3100 81 a=5.1900 70 a=4.4700 83 a=3.7200 84 a=3.9000 68 a=4.2800 83 a=3.7200 74 a=2.7100 81 a=5.1900 85 a=3.1600	(Superscript)
+Mx 	61.5519
+My 	157.7719
+Set font 	Libertinus Serif;6.6;600;italic;normal;+lnum -onum;LTR
+T	18 19 20 w=9.2070	(123)
+Mx 	70.7589
+My 	160.7889
+Set font 	Libertinus Serif;10;400;italic;normal;;LTR
+T	15 w=2.2000	(.)
+End page
+Finish

--- a/tests/feat-textsubsuper.sil
+++ b/tests/feat-textsubsuper.sil
@@ -1,0 +1,37 @@
+\begin[papersize=a6]{document}
+\nofolios
+\neverindent
+\use[module=packages.textsubsuper]
+
+% 1. Test with default font.
+(Default font) H\textsubscript{2}O.
+
+16\textsuperscript{th} century, \font[features=+smcp]{xvi}\textsuperscript{e} siècle.
+
+Superscript\textsuperscript{123}.
+
+% 2. Test with default font, italic
+\font[style=italic]
+
+(Default font italic)  H\textsubscript{2}O.
+
+16\textsuperscript{th} century, \font[features=+smcp]{xvi}\textsuperscript{e} siècle.
+
+Superscript\textsuperscript{123}.
+
+% 3. Test with a font having true sub/superscripted characters
+\font[family=Libertinus Serif]
+
+(Libertinus, font sub/superscripts) H\textsubscript{2}O.
+
+16\textsuperscript{th} century, \font[features=+smcp]{xvi}\textsuperscript{e} siècle.
+
+Superscript\textsuperscript{123}.
+
+(Libertinus, fake sub/superscripts) H\textsubscript[fake=true]{2}O.
+
+16\textsuperscript[fake=true]{th} century, \font[features=+smcp]{xvi}\textsuperscript[fake=true]{e} siècle.
+
+Superscript\textsuperscript[fake=true]{123}.
+
+\end{document}


### PR DESCRIPTION
Closes #1258 (or rather, addresses the core need expressed in it).
Rationale:
- It uses @simoncozens 's suggestion for "real" super/subscripts,
- It uses clever inputfilter logic and a bit of PDF re-scaling for "fake" ones - perhaps another nice example for class/package designers of things that may be done with SILE.
- There's a bit of Bringhurst's interesting comments and ideas taken into account there (see package documentation).

Short story: In the course of making my book with SILE, I wanted nice footnote calls etc. I used a lighter version of this proposal, based on the code mentioned in the original issue. Libertinus' real superscripts are somewhat decent (esp. compared to those in other fonts...), time was running short, so I ended up using them. They were still looking better (IMHO) than the naively scaled and raised version from the footnotes package... But still, I wasn't fully satisfied and I made several other attempts (including trying the OS2 table parameters, which proved to be wrong on almost all fonts I checked...). I was in kind of a rush however and, at some point, I thought I had lost those attempts... Until I found them just lying in a some lost git stash. Doh. A bit of clean-up and here we are. (So it's a greatly enhanced version of my own current package by the same name in my repo).

Should this go to SILE, though? Oh, after all, why not... I am proposing it, anyway...

The real question is:

![image](https://user-images.githubusercontent.com/18075640/178385274-9453c208-953f-41bc-81dd-38ab84965d5d.png)

Which line is the best?

And I would have to be fully honest, so...

![image](https://user-images.githubusercontent.com/18075640/178385303-64bcae59-9933-439e-8256-f55f861e1cfe.png)

(The Brill font has pretty good real superscripts... It's hard to compete here :baby_chick: )

Would you accept it,
- I have not updated the footnote package to use it... It breaks several tests involving footnotes, so the effort has to be worth it. **N.B.** This could be addressed separately later, anyway.
- Likewise, inclusion in the SILE manual would have to be addressed.