### PR TITLE
Fix minor typos in the SILE book

### DIFF
--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -15,7 +15,7 @@ Trying to create these files in a word processor such as Word will not work as t
 
 Lots of good text editors exist (many of them for free) and any of them will work for SILE documents so which one you use is entirely a matter of preference.
 You can get started with even the most basic text editors built into your desktop environment such as Notepad on Windows, TextEdit on macOS, Gedit on Gnome, Kate on KDE, etc.
-However more advanced text editors (sometimes catagorized as code editors) can offer a lot of features that make the editing process more robust.
+However more advanced text editors (sometimes categorized as code editors) can offer a lot of features that make the editing process more robust.
 Editors are typically either graphical (GUI) or terminal (TUI) oriented and range from relatively simple to extremely complex integrated development environments (IDE).
 Examples of popular cross-platform GUI oriented editors include VS Code, Sublime Text, and Atom\footnote{Still relatively popular, but will be discontinued in October 2022.}.
 Examples of popular terminal based editors include VIM\footnote{VIM & NeoVIM users can benefit from syntax highlighting and other features via the \code{vim-sile} plugin at \url{https://github.com/sile-typesetter/vim-sile}.}, Emacs, and GNU Nano.

--- a/documentation/c03-input.sil
+++ b/documentation/c03-input.sil
@@ -237,7 +237,7 @@ The example above, in XML flavor, would look like this:
 \line
 \end{verbatim}
 
-We don’t expect humans to write their documents in SILE’s XML flavor—the TeX-like SIL flavor is much better for that—but having an XML flavor allows for computers to deal with SILE a lot more easily.
+We don’t expect humans to write their documents in SILE’s XML flavor—the TeX-like SILE flavor is much better for that—but having an XML flavor allows for computers to deal with SILE a lot more easily.
 One could create graphical user interfaces to edit SILE documents, or convert other XML formats to SILE.
 
 However, there is an even smarter way of processing XML with SILE.

--- a/documentation/c04-useful.sil
+++ b/documentation/c04-useful.sil
@@ -307,7 +307,7 @@ there must be no instances of \code{\\end\{script\}} inside the Lua code block,
 even inside a string that would otherwise be valid Lua code, (e.g. if it was
 inside a quoted string or Lua comment). The first instance of such an end tag
 terminates the block, and there is currently no way to escape it. For the inline
-comand form (\code{\\script}) an exact matching number of open and closing
+command form (\code{\\script}) an exact matching number of open and closing
 braces may appear in the Lua code — the next closing brace at the same level as
 the opening brace will close the tag, even if it happens to be inside some
 quoted string in the Lua code. Including any number of nested opening and closing

--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -207,7 +207,7 @@ SILE is able to use packages installed via the LuaRocks package manager.
 It can also be configured to read packages from any directory of your choosing.
 
 A SILE compatible LuaRock simply installs the relevant class, package, language, i18n, or similar files in a \code{sile} directory.
-This diroctory could be in your system Lua direcory, in your user directory, or any other location you specify.
+This directory could be in your system Lua directory, in your user directory, or any other location you specify.
 
 By default SILE will look for packages in:
 
@@ -229,7 +229,7 @@ $ sile ...
 \end{verbatim}
 
 Depending on your system, this probably requires root permissions.
-If you either don’t have root permisisons or don’t want to polute your system’s root file system, you can also install as a user.
+If you either don’t have root permissions or don’t want to pollute your system’s root file system, you can also install as a user.
 To use packages installed as a user you will need to have LuaRocks add it’s user tree to your Lua search path before running SILE.
 
 \begin{verbatim}

--- a/documentation/c06-macroscommands.sil
+++ b/documentation/c06-macroscommands.sil
@@ -17,7 +17,7 @@ that you need to keep entering again and again.
 \define[command=SILE]{\font[family=Gentium Plus]{% Book Basic has no +smcp, but readers don't need to know, since we're only using Book Basic as a holdover from old SILE which did.
 S\lower[height=0.5ex]{I}L\kern[width=-.2em]\raise[height=0.6ex]{\font[features=+smcp]{e}}}}
 For instance, let’s suppose that we want to design a nice little
-“bumpy road” logo for SILE. (Afficionados of T\kern[width=-.1667em]\lower[height=0.5ex]{E}\kern[width=-.125em]X and friends will be familar with the concept of
+“bumpy road” logo for SILE. (Afficionados of T\kern[width=-.1667em]\lower[height=0.5ex]{E}\kern[width=-.125em]X and friends will be familiar with the concept of
 bumpy road logos.) Our logo will look like this: \SILE. It’s not a great
 logo, but we’ll use it as \SILE’s logo for the purposes of this section.
 

--- a/documentation/c07-settings.sil
+++ b/documentation/c07-settings.sil
@@ -16,7 +16,7 @@ the setting which changes how the typesetter penalizes orphan (end-of-paragraph)
 lines.
 
 The interface to changing settings from within a SILE document is the
-\code{\\set} commmand. It takes several options, the most basic one being
+\code{\\set} command. It takes several options, the most basic one being
 \em{parameter}, which expresses which setting is being changed. The \em{value}
 option expresses the value to which the setting is being changed. As an
 example:
@@ -69,7 +69,7 @@ SILE.call("set", { parameter = "typesetter.orphanpenalty", value = 250 })
 
 There is nothing wrong with this and it allows you to optionally pass content
 that is wrapped in those settings. However there is also a slightly lower level
-function that is more ideomatic of Lua code than SILE that uses positional
+function that is more idiomatic of Lua code than SILE that uses positional
 arguments instead of named options:
 
 \begin{verbatim}

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -29,7 +29,7 @@ Language support may include and combination of:
 
 \noindent{}• choice of glyphs within a font,
 
-\noindent{}• localization of programatially inserted strings,
+\noindent{}• localization of programatically inserted strings,
 
 \noindent{}• and more.
 
@@ -120,13 +120,13 @@ The command \code{\\nohyphenation\{…\}} is provided as a shortcut for
 
 The hyphenator uses the same algorithm as TeX and can use TeX hyphenation
 pattern files if they are converted to Lua format. To implement hyphenation
-for a new language, first check to see if TeX hyphenation directionaries
+for a new language, first check to see if TeX hyphenation dictionaries
 are available; if not, work through the resources at
 \url{http://tug.org/docs/liang/}.
 
 \section{Localization}
 
-A small handfull of strings may be programatically added to documents depending on language, context, and options.
+A small handful of strings may be programatically added to documents depending on language, context, and options.
 For example by default in English the \code{book} class will prepend “Chapter ” before chapter numbers output by the \code{\\chapter} command.
 These localized strings are managed internally using the Fluent localization system.
 See Project Fluent (\url{https://projectfluent.org}) for details on the data format and uses.

--- a/documentation/c09-concepts.sil
+++ b/documentation/c09-concepts.sil
@@ -72,7 +72,7 @@ local vglue = SILE.nodefactory.vglue(\{ height = l\})
 \end{verbatim}
 
 SILE’s typesetting is organised by the \code{SILE.typesetter} object; it
-maintains two queues of material that it is still working on: the node queue
+maintains two queues of material that it is still working on: the node queue and
 the output queue. Material in these queues is content that has been parsed but
 not yet rendered to the canvas and can still be manipulated. The node queue
 (\code{SILE.typesetter.state.nodes}) contains new horizontal boxes and glue
@@ -81,27 +81,27 @@ that have not yet been broken up into lines. The output queue
 (lines) which have not yet been broken up into pages. Line breaking and page
 breaking happen when the typesetter moves between horizontal and vertical mode.
 
-As new content is parsed is is added to the node queue in as small chunks as
+As new content is parsed it is added to the node queue in as small chunks as
 possible—chunks that must remain together no matter where they end up on
-a line. For example this might individual symbols, sylables, or objects such as
+a line. For example this might include individual symbols, syllables, or objects such as
 images. As soon as new content which requires a vertical break is encountered,
-the node queue is processed to derivce any missing shaping information about
+the node queue is processed to derive any missing shaping information about
 each node, then the sequence of node is broken up into  lines. Once all the
 "horizontal mode" nodes are broken into lines and those lines are added to the
 output queue, the other new vertical content can be processed. At any point you
-can force the current queue of horizantal content (the node queue) to be shaped
+can force the current queue of horizontal content (the node queue) to be shaped
 into lines and added to the vertical output queue by calling the function
 \code{SILE.typesetter:leaveHmode()}. This is a handy move for writing custom
 functions, but it is a fairly low level control (i.e. it is unlikely to be
 useful while writing a document). A related but higher level command,
-\code{\\par}, is more frequently used when writing a document and embeded in
+\code{\\par}, is more frequently used when writing a document and embedded in
 the content. The \code{\\par} command first calls
 \code{SILE.typesetter:leaveHmode()}, then inserts a vertical skip according to
 the \autodoc:setting{document.parskip} setting, then goes on to reset a number of
 settings that are typically paragraph related such as hanging indents.
 
 When writing a custom command, if you want to manually add a vertical space to
-the output first ensure that material in the current paragraph has been all
+the output first ensure that the material in the current paragraph has been all
 properly boxed-up and moved onto the output queue by calling
 \code{SILE.typesetter:leaveHmode()}; then add your desired glue to the output
 queue.

--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -156,7 +156,7 @@ If all we want to do in our new class is to create a different page shape,
 this is all we need.
 The init function inherited from the book class will take care of setting these frames up with mirrored masters.
 
-If we had wanted to load additionall packages into our class as, say, the \code{bible} class does,
+If we had wanted to load additional packages into our class as, say, the \code{bible} class does,
 we would need to define our own init function and call our parent class’s init function as well.
 For example to load the \code{infonode} package into our class, we could add this init function:
 
@@ -173,7 +173,7 @@ end
 \end{verbatim}
 
 Note that the official SILE classes have some extra tooling to handle legacy class models trying to inherit from them.
-You don't need those deprecation shims if your own classes when following these examples.
+You don't need those deprecation shims in your own classes when following these examples.
 
 \section{Defining Commands}
 
@@ -245,7 +245,7 @@ functions to output text and call other commands.
 
 \note{If you do need to do something with a dimension, you can use \code{SILE.measurement()} to parse a basic length and
 \code{SILE.parseComplexFrameDimension} to parse a frame dimension,
-and if necessary the \code{:tonumber()} method of dimentions turn them into numbers (in points).}
+and if necessary the \code{:tonumber()} method of dimensions turn them into numbers (in points).}
 
 \section{Output Routines}
 
@@ -260,22 +260,20 @@ The key methods for defining the \em{output routine} are:
 \item{\code{newPar} and \code{endPar} are called at the start and end of
       each paragraph.}
 \item{\code{newPage} and \code{endPage} are called at the start
-      and each of each page.}
+      and end of each page.}
 \item{\code{init} and \code{finish} are called at the start and
       end of the document.}
 \end{itemize}
-
-\noindent{}• \code{init} and \code{finish} are called at the start and end of the document.
 
 Once again this is done in an object-oriented way,
 with derived classes overriding their superclass’ methods where necessary.
 
 Some packages may provide functions that need to be run as part of the class output routines.
-One way packages can accomplish this is registering hook functions that get run an known locations in the provided classes.
+One way packages can accomplish this is registering hook functions that get run at known locations in the provided classes.
 Class authors may also provide their own hook locations for packages, or run any set of registered hooks in their own outputs.
 The other way is to export functions that get added to the class itself and can be run manually from the class.
 
-For examples check out the \autodoc:package{tableofcontents} package for the hooks it sets, but also the \autodoc:command{\tocentry} command it registeres that gets called manually in the \code{book} class.
+For examples check out the \autodoc:package{tableofcontents} package for the hooks it sets, but also the \autodoc:command{\tocentry} command it registered that gets called manually in the \code{book} class.
 
 Let’s demonstrate roughly how the \code{tableofcontents} package works.
 We’ll be using the \code{infonodes} package to collect the information about which pages contain table of content items.
@@ -363,7 +361,7 @@ How do we do that?
 
 \section{Exports}
 
-Packages which are primarily used for providing functionality to other classes and packages need a way of supplying these composible bits of functionality to the code which is going to use them.
+Packages which are primarily used for providing functionality to other classes and packages need a way of supplying these composable bits of functionality to the code which is going to use them.
 This is called the \em{export mechanism}.
 
 As well as defining commands, each package may also return a Lua table consisting of two entries,

--- a/documentation/c11-xmlproc.sil
+++ b/documentation/c11-xmlproc.sil
@@ -14,14 +14,14 @@ The class initalization for DocBoox isn't too fancy, it just loads up a couple p
 
 Now we can start defining SILE commands to render XML elements.
 Most of these are fairly straightforward so we will not dwell on them too much.
-For instance, DocBook has a tags like \code{<code>}, \code{<filename>}, \code{<guimenu>} which should all be rendered in a monospaced typewriter font.
+For instance, DocBook has tags like \code{<code>}, \code{<filename>}, \code{<guimenu>} which should all be rendered in a monospaced typewriter font.
 To make it easier to customize the class, we abstract out the font change into a single command:
 
 \begin{note}
 Much of the example code in this chapter is in SIL format using macros.
 The actual docbook class currently uses Lua functions to specify these commands.
 The functionality is the same, but the Lua syntax is more flexible and recommended for most use cases.
-The SILE define macros show here can still be usen in a preamble file if desired.
+The SILE define macros shown here can still be used in a preamble file if desired.
 \end{note}
 
 \begin{verbatim}
@@ -52,11 +52,11 @@ We have already seen an example of the \code{<link>} tag where we also need to p
 Let’s look at another area of complexity: the apparently-simple \code{<title>} tag.
 The reason this is complex is that it occurs in different contexts, sometimes more than once within a context; it should often be rendered differently in different contexts.
 So for instance \code{<article><title>...} will look different to \code{<section><title>...}.
-Inside an \code{<example>} tag, the title will be preferenced by an example number; inside a \code{<bibliomixed>} bibliography entry the title should not be set off as a new block but should be part of the running text; and so on.
+Inside an \code{<example>} tag, the title will be prefixed by an example number; inside a \code{<bibliomixed>} bibliography entry the title should not be set off as a new block but should be part of the running text; and so on.
 
 What we will do to deal with this situation is provide a very simple definition of \code{<title>}, but when processing the containing elements of \code{<title>} (such as \code{<article>}, \code{<example>}), we will process the title ourselves.
 
-For instance, let’s look at \code{<example>}, which has the added complexity of needed to keep track of an article number.
+For instance, let’s look at \code{<example>}, which has the added complexity of needing to keep track of an article number.
 
 \begin{verbatim}
 \line

--- a/documentation/c12-tricks.sil
+++ b/documentation/c12-tricks.sil
@@ -427,7 +427,7 @@ After this, all the usual API calls will work: \code{SILE.call},
 SILE.typesetter:typeset(data)
 \end{verbatim}
 
-The only thing to be careful is the need to call the \code{finish} method
+The only thing to be careful of is the need to call the \code{finish} method
 on your document class at the end of processing to finish off the final page:
 
 \begin{verbatim}


### PR DESCRIPTION
Here’s a patch that fixes some minor typos I found while going through the SILE manual.
Thanks for your work on SILE, I’m excited to start using it!