### PR TITLE
The autodoc package could choke on some inputs

### DIFF
--- a/packages/autodoc/init.lua
+++ b/packages/autodoc/init.lua
@@ -86,8 +86,15 @@ local function typesetAST (options, content)
       else
         seenCommandWithoutArg = true
       end
+    elseif ast.id == "texlike_stuff" or (not ast.command and not ast.id) then
+      -- Due to the way it is implemented, the SILE-inputter may generate such
+      -- nodes in the AST. It's poorly documented, so it's not clear why they
+      -- are even kept there (esp. the "texlike_stuff" nodes), but anyhow, as
+      -- far as autodoc is concerned for presentation purposes, just
+      -- recurse into them.
+      typesetAST(options, ast)
     else
-      SU.error("Unrecognized AST element")
+      SU.error("Unrecognized AST element, type "..type(ast))
     end
   end
 end


### PR DESCRIPTION
Closes #1489 

A case overlooked the AST debugging which inspired the autodoc logic:
![image](https://user-images.githubusercontent.com/18075640/180627043-47b1ac6a-a579-49c6-b8e7-4acb3f33fb76.png)

No idea what it does, but fixes the issue when it occurs.