### PR TITLE
Setup and use cleaner API for package exports

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -99,7 +99,7 @@ function class:registerCommands ()
     local number
     if SU.boolean(options.numbering, true) then
       SILE.call("increment-multilevel-counter", { id = "sectioning", level = level })
-      number = self:formatMultilevelCounter(self:getMultilevelCounter("sectioning"))
+      number = self.packages.counters:formatMultilevelCounter(self:getMultilevelCounter("sectioning"))
     end
     if SU.boolean(options.toc, true) then
       SILE.call("tocentry", { level = level, number = number }, SU.subContent(content))

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -227,9 +227,9 @@ SILE.process = function (ast)
       local pId = SILE.traceStack:pushContent(content, "texlike_stuff")
       SILE.process(content)
       SILE.traceStack:pop(pId)
-    else
+    elseif type(content) ~= "nil" then
       local pId = SILE.traceStack:pushContent(content)
-      SU.error("Unknown command "..(content.command or content.id))
+      SU.error("Unknown command "..(tostring(content.command or content.id)))
       SILE.traceStack:pop(pId)
     end
   end

--- a/core/tracestack.lua
+++ b/core/tracestack.lua
@@ -60,7 +60,7 @@ end
 
 function traceStack.commandFrame:__tostring ()
   local opts = (pl.tablex.size(self.options) > 0 and tostring(self.options):gsub("^{", "["):gsub("}$", "]") or "")
-  return "\\" .. self.command .. opts
+  return "\\" .. tostring(self.command) .. opts
 end
 
 traceStack.contentFrame = pl.class(traceStack.commandFrame)

--- a/packages/autodoc/init.lua
+++ b/packages/autodoc/init.lua
@@ -69,7 +69,7 @@ local function typesetAST (options, content)
         for iOpt, option in ipairs(sortedOpts) do
           SILE.call("autodoc:code:style", { type = "parameter" }, { option })
           SILE.typesetter:typeset("=")
-          SILE.call("penalty", { penalty = 100 }, nil) -- Quite decent to break here if need be.
+          SILE.call("penalty", { penalty = 100 }) -- Quite decent to break here if need be.
           SILE.call("autodoc:value", {}, { ast.options[option] })
           if iOpt == #sortedOpts then
             SILE.typesetter:typeset("]")
@@ -79,7 +79,7 @@ local function typesetAST (options, content)
         end
       end
       if (#ast >= 1) then
-        SILE.call("penalty", { penalty = 200 }, nil) -- Less than optimal break.
+        SILE.call("penalty", { penalty = 200 }) -- Less than optimal break.
         SILE.typesetter:typeset("{")
         typesetAST(options, ast)
         SILE.typesetter:typeset("}")
@@ -139,9 +139,9 @@ function package:registerCommands ()
         result[#result+1] = token.string
       else
         result[#result+1] = token.separator
-        result[#result+1] = class.createCommand(
+        result[#result+1] = class.packages.inputfilter:createCommand(
         content.pos, content.col, content.line,
-        "penalty", { penalty = 100 }, nil
+        "penalty", { penalty = 100 }
         )
       end
     end

--- a/packages/base.lua
+++ b/packages/base.lua
@@ -5,6 +5,9 @@ package._name = "base"
 package._initialized = false
 package.class = nil
 
+-- For shimming packages that used to have legacy exports
+package.exports = {}
+
 function package:_init (_)
   self.class = SILE.documentState.documentClass or SILE.scratch.half_initialized_class
   if not self.class then
@@ -29,6 +32,52 @@ function package.registerCommands (_) end
 -- un-export them if we ever need to unload modules and revert functions
 function package:export (name, func)
   self.class[name] = func
+end
+
+-- Shims for two possible kinds of legacy exports: blind direct stuffing into
+-- the class but not expecting to be called as a method AND the exports table
+-- to package modules...
+
+local _deprecate_class_funcs = [[
+  Please explicitly use functions provided by packages by referencing
+  them in the document class's list of loaded packages rather than the
+  legacy solution that added non-method functions to the class.]]
+
+local _deprecate_exports_table = [[
+  Please explicitly use functions provided by packages by referencing
+  them in the document class's list of loaded packages rather than the
+  legacy solution of calling them from an exports table.]]
+
+function package:deprecatedExport (name, func, noclass, notable)
+
+  if not noclass then
+    self.class[name] = function (...)
+      -- http://lua-users.org/wiki/VarargTheSecondClassCitizen
+      local inputs = {...}
+      -- local inputs = table.unpack({...}, 1, select("#", ...))
+      if type(inputs[1]) ~= "table" or inputs[1].type ~= "class" then
+        table.insert(inputs, 1, self.class)
+      end
+      SU.deprecated(("class.%s"):format(name),
+                    ("class.packages[%s]:%s"):format(self._name, name),
+                    "0.14.0", "0.16.0", _deprecate_class_funcs)
+      return func(table.unpack(inputs, 1, select("#", ...) + 1))
+    end
+  end
+
+  if not notable then
+    self.exports[name] = function (...)
+      local inputs = {...}
+      if type(inputs[1]) ~= "table" or inputs[1].type ~= "package" then
+        table.insert(inputs, 1, self)
+      end
+      SU.deprecated(("require('packages.%s').exports.%s"):format(self._name, name),
+                    ("class.packages[%s]:%s"):format(self._name, name),
+                    "0.14.0", "0.16.0", _deprecate_exports_table)
+      return func(table.unpack(inputs, 1, select("#", ...) + 1))
+    end
+  end
+
 end
 
 return package

--- a/packages/base.lua
+++ b/packages/base.lua
@@ -25,4 +25,10 @@ function package.registerRawHandlers (_) end
 
 function package.registerCommands (_) end
 
+-- Using this rather than doing the work directly will give us a way to
+-- un-export them if we ever need to unload modules and revert functions
+function package:export (name, func)
+  self.class[name] = func
+end
+
 return package

--- a/packages/base.lua
+++ b/packages/base.lua
@@ -1,11 +1,11 @@
-local class = pl.class()
-class.type = "package"
-class._name = "base"
+local package = pl.class()
+package.type = "package"
+package._name = "base"
 
-class._initialized = false
-class.class = nil
+package._initialized = false
+package.class = nil
 
-function class:_init (_)
+function package:_init (_)
   self.class = SILE.documentState.documentClass or SILE.scratch.half_initialized_class
   if not self.class then
     SU.error("Attempted to initialize package before class, should have been queued in the preamble", true)
@@ -15,14 +15,14 @@ function class:_init (_)
   self:registerCommands()
 end
 
-function class:_post_init ()
+function package:_post_init ()
   self._initialized = true
 end
 
-function class.declareSettings (_) end
+function package.declareSettings (_) end
 
-function class.registerRawHandlers (_) end
+function package.registerRawHandlers (_) end
 
-function class.registerCommands (_) end
+function package.registerCommands (_) end
 
-return class
+return package

--- a/packages/break-firstfit/init.lua
+++ b/packages/break-firstfit/init.lua
@@ -38,7 +38,6 @@ function package:_init ()
 
   base._init(self)
 
-  -- exports
   SILE.typesetter._breakIntoLines_firstfit = firstfit
 
 end

--- a/packages/chordmode/init.lua
+++ b/packages/chordmode/init.lua
@@ -58,7 +58,7 @@ function package:registerCommands ()
     local processText, processChordName, processChordText
 
     local function insertChord()
-      table.insert(result, class.createCommand(
+      table.insert(result, class.packages.inputfilter:createCommand(
       content.pos, content.col, content.line,
       "ch", { name = chordName }, currentText
       ))

--- a/packages/counters/init.lua
+++ b/packages/counters/init.lua
@@ -3,52 +3,52 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "counters"
 
-local function getCounter (class, id)
-  if not id then
-    SU.deprecated("class.getCounter", "class:getCounter", "0.13.0", "0.15.0")
-    class, id = SILE.documentState.documentClass, class
-  end
+SILE.formatCounter = function (counter)
+  SU.deprecated("SILE.formatCounter", "class:formatCounter", "0.13.0", "0.15.0")
+  return package.formatCounter(nil, counter)
+end
+
+SILE.formatMultilevelCounter = function (counter, options)
+  SU.deprecated("SILE.formatMultilevelCounter", "class:formatMultilevelCounter", "0.13.0", "0.15.0")
+  return package.formatMultilevelCounter(nil, counter, options)
+end
+
+local function getCounter (_, id)
   if not SILE.scratch.counters[id] then
-    SILE.scratch.counters[id] = { value = 0, display = "arabic", format = class.formatCounter }
+    SILE.scratch.counters[id] = {
+      value = 0,
+      display = "arabic",
+      format = package.formatCounter
+    }
   end
   return SILE.scratch.counters[id]
 end
 
-local function getMultilevelCounter (class, id)
-  if not id then
-    SU.deprecated("class.getMultilevelCounter", "class:getMultilevelCounter", "0.13.0", "0.15.0")
-    class, id = SILE.documentState.documentClass, class
-  end
+local function getMultilevelCounter (_, id)
   local counter = SILE.scratch.counters[id]
   if not counter then
-    counter = { value= { 0 }, display= { "arabic" }, format = class.formatMultilevelCounter }
+    counter = {
+      value= { 0 },
+      display= { "arabic" },
+      format = package.formatMultilevelCounter
+    }
     SILE.scratch.counters[id] = counter
   end
   return counter
 end
 
-local function formatCounter (_, counter)
+function package.formatCounter (_, counter)
   return SU.formatNumber(counter.value, counter.display)
 end
 
-local function formatMultilevelCounter (_, counter, options)
+function package:formatMultilevelCounter (counter, options)
   local maxlevel = options and options.level or #counter.value
   local minlevel = options and options.minlevel or 1
   local out = {}
   for x = minlevel, maxlevel do
-    out[x - minlevel + 1] = formatCounter(nil, { display = counter.display[x], value = counter.value[x] })
+    out[x - minlevel + 1] = self:formatCounter({ display = counter.display[x], value = counter.value[x] })
   end
   return table.concat(out, ".")
-end
-
-SILE.formatCounter = function (counter)
-  SU.deprecated("SILE.formatCounter", "class:formatCounter", "0.13.0", "0.15.0")
-  return formatCounter(nil, counter)
-end
-
-SILE.formatMultilevelCounter = function (counter, options)
-  SU.deprecated("SILE.formatMultilevelCounter", "class:formatMultilevelCounter", "0.13.0", "0.15.0")
-  return formatMultilevelCounter(nil, counter, options)
 end
 
 function package:_init ()
@@ -59,11 +59,11 @@ function package:_init ()
     SILE.scratch.counters = {}
   end
 
-  --exports
-  self.class.formatCounter = formatCounter
-  self.class.formatMultilevelCounter = formatMultilevelCounter
-  self.class.getCounter = getCounter
-  self.class.getMultilevelCounter = getMultilevelCounter
+  self:export("getCounter", getCounter)
+  self:export("getMultilevelCounter", getMultilevelCounter)
+
+  self:deprecatedExport("formatCounter", self.formatCounter)
+  self:deprecatedExport("formatMultilevelCounter", self.formatMultilevelCounter)
 
 end
 
@@ -91,7 +91,7 @@ function package:registerCommands ()
   class:registerCommand("show-counter", function (options, _)
     local counter = class:getCounter(options.id)
     if options.display then counter.display = options.display end
-    SILE.typesetter:setpar(class:formatCounter(counter))
+    SILE.typesetter:setpar(self:formatCounter(counter))
   end, "Outputs the value of counter <id>, optionally displaying it with the <display> format.")
 
   class:registerCommand("increment-multilevel-counter", function (options, _)
@@ -121,7 +121,7 @@ function package:registerCommands ()
     local counter = class:getMultilevelCounter(options.id)
     if options.display then counter.display[#counter.value] = options.display end
 
-    SILE.typesetter:typeset(class:formatMultilevelCounter(counter, options))
+    SILE.typesetter:typeset(self:formatMultilevelCounter(counter, options))
   end, "Outputs the value of the multilevel counter <id>, optionally displaying it with the <display> format.")
 
 end

--- a/packages/date/init.lua
+++ b/packages/date/init.lua
@@ -8,11 +8,7 @@ local localeify = function (lang)
   return lang .. "_" .. string.upper(lang) ..  ".utf-8"
 end
 
-local date = function (class, options)
-  if not options then
-    SU.deprecated("class.date", "class:date", "0.13.0", "0.15.0")
-    options = class
-  end
+function package.date (_, options)
   options.format = options.format or "%c"
   options.time = options.time or os.time()
   options.locale = options.locale or localeify(SILE.settings:get("document.language"))
@@ -24,15 +20,14 @@ function package:_init ()
 
   base._init(self)
 
-  --exports
-  self.class.date = date
+  self:deprecatedExport("date", self.date)
 
 end
 
 function package:registerCommands ()
 
   self.class:registerCommand("date", function (options, _)
-    local datestring = self.class:date(options)
+    local datestring = self:date(options)
     SILE.typesetter:typeset(datestring)
   end, "Output a timestamp using the system date function")
 

--- a/packages/folio/init.lua
+++ b/packages/folio/init.lua
@@ -41,14 +41,14 @@ function package:outputFolio (frame)
   end
 end
 
-function package:_init ()
+function package:_init (options)
 
   base._init(self)
 
   self.class:loadPackage("counters")
   SILE.scratch.counters.folio = { value = 1, display = "arabic" }
   self.class:registerHook("newpage", function() self:incrementFolio() end)
-  self.class:registerHook("endpage", function () self:outputFolio() end)
+  self.class:registerHook("endpage", function () self:outputFolio(options and options.frame) end)
 
   self:export("outputFolio", self.outputFolio)
 end

--- a/packages/folio/init.lua
+++ b/packages/folio/init.lua
@@ -9,7 +9,7 @@ end
 
 function package:outputFolio (frame)
   if not frame then frame = "folio" end
-  local folio = self.class:formatCounter(SILE.scratch.counters.folio)
+  local folio = self.class.packages.counters:formatCounter(SILE.scratch.counters.folio)
   io.stderr:write("[" .. folio .. "] ")
   if SILE.scratch.counters.folio.off then
     if SILE.scratch.counters.folio.off == 2 then
@@ -33,7 +33,7 @@ function package:outputFolio (frame)
           SILE.settings:set(v, SILE.settings.defaults[v])
         end
 
-        SILE.call("foliostyle", {}, { self.class:formatCounter(SILE.scratch.counters.folio) })
+        SILE.call("foliostyle", {}, { self.class.packages.counters:formatCounter(SILE.scratch.counters.folio) })
         SILE.typesetter:leaveHmode()
         SILE.settings:popState()
       end)

--- a/packages/hanmenkyoshi/init.lua
+++ b/packages/hanmenkyoshi/init.lua
@@ -72,8 +72,8 @@ function package:_init ()
 
   self.class:loadPackage("tate")
 
-  -- exports
-  self.class.declareHanmenFrame = declareHanmenFrame
+  self:export("declareHanmenFrame", declareHanmenFrame)
+
 end
 
 function package:registerCommands ()

--- a/packages/indexer/init.lua
+++ b/packages/indexer/init.lua
@@ -3,7 +3,7 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "indexer"
 
-local moveNodes = function (class)
+local buildIndex = function (class)
   local nodes = SILE.scratch.info.thispage.index
   local thisPage = class:formatCounter(SILE.scratch.counters.folio)
   if not nodes then return end
@@ -33,8 +33,7 @@ function package:_init ()
     SILE.scratch.index = {}
   end
 
-  -- exports
-  self.class.buildIndex = moveNodes
+  self:deprecatedExport("buildIndex", buildIndex)
 
 end
 
@@ -60,7 +59,7 @@ function package:registerCommands ()
   end)
 
   class:registerCommand("printindex", function (options, _)
-    moveNodes(class)
+    class:buildIndex()
     if not options.index then options.index = "main" end
     local index = SILE.scratch.index[options.index]
     local sortedIndex = {}

--- a/packages/infonode/init.lua
+++ b/packages/infonode/init.lua
@@ -29,7 +29,7 @@ function _info:outputYourself ()
   end
 end
 
-local function _newPageInfo (_)
+local function newPageInfo (_)
   SILE.scratch.info = { thispage = {} }
 end
 
@@ -49,13 +49,12 @@ function package:_init ()
     SILE.scratch.info = { thispage = {} }
   end
 
-  self.class:registerHook("newpage", _newPageInfo)
+  self.class:registerHook("newpage", newPageInfo)
 
-  -- exports
-  self.class.newPageInfo = function (self_)
+  self:deprecatedExport("newPageInfo", function (class)
     SU.deprecated("class:newPageInfo", nil, "0.13.0", "0.15.0", _deprecate)
-    return _newPageInfo(self_)
-  end
+    return class:newPageInfo()
+  end)
 
 end
 

--- a/packages/inputfilter/init.lua
+++ b/packages/inputfilter/init.lua
@@ -3,7 +3,7 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "inputfilter"
 
-local function transformContent (content, transformFunction, extraArgs)
+function package:transformContent (content, transformFunction, extraArgs)
   local newContent = {}
   for k, v in SU.sortedpairs(content) do
     if type(k) == "number" then
@@ -15,7 +15,7 @@ local function transformContent (content, transformFunction, extraArgs)
           newContent[#newContent+1] = transformed
         end
       else
-        newContent[#newContent+1] = transformContent(v, transformFunction, extraArgs)
+        newContent[#newContent+1] = self:transformContent(v, transformFunction, extraArgs)
       end
     else
       newContent[k] = v
@@ -24,7 +24,7 @@ local function transformContent (content, transformFunction, extraArgs)
   return newContent
 end
 
-local function createCommand (pos, col, line, command, options, content)
+function package.createCommand (_, pos, col, line, command, options, content)
   local result = { content }
   result.col = col
   result.line = line
@@ -39,9 +39,8 @@ function package:_init ()
 
   base._init(self)
 
-  -- exports
-  self.class.createCommand = createCommand
-  self.class.transformContent = transformContent
+  self:deprecatedExport("createCommand", self.createCommand)
+  self:deprecatedExport("transformContent", self.transformContent)
 
 end
 
@@ -55,20 +54,5 @@ Loading \autodoc:package{inputfilter} into your class with \code{class:loadPacka
 See \url{https://sile-typesetter.org/examples/inputfilter.sil} for a simple example, and \url{https://sile-typesetter.org/examples/chordmode.sil} for a more complete one.
 \end{document}
 ]]
-
-local _deprecated = [[
-  Please use the function attatched to the document class rather
-  than the deprecated direct exports table.]]
-
-package.exports = {
-  createCommand = function (pos, col, line, command, options, content)
-    SU.deprecated("require('packages.inputfilter').exports.createCommand", "class.createCommand", "0.14.0", "0.16.0", _deprecated)
-    return createCommand(pos, col, line, command, options, content)
-  end,
-  transformContent = function (content, transformFunction, extraArgs)
-    SU.deprecated("require('packages.inputfilter').exports.transformContent", "class.transformContent", "0.14.0", "0.16.0", _deprecated)
-    return transformContent(content, transformFunction, extraArgs)
-  end,
-}
 
 return package

--- a/packages/insertions/init.lua
+++ b/packages/insertions/init.lua
@@ -447,10 +447,9 @@ function package:_init ()
 
   end)
 
-  -- exports
-  self.class.initInsertionClass = initInsertionClass
-  self.class.thisPageInsertionBoxForClass = thisPageInsertionBoxForClass
-  self.class.insert = insert
+  self:export("initInsertionClass", initInsertionClass)
+  self:export("thisPageInsertionBoxForClass", thisPageInsertionBoxForClass)
+  self:export("insert", insert)
 
 end
 

--- a/packages/masters/init.lua
+++ b/packages/masters/init.lua
@@ -78,12 +78,11 @@ function package:_init (options)
     SILE.scratch.masters = {}
   end
 
-  -- exports
-  self.class.switchMasterOnePage = switchMasterOnePage
-  self.class.switchMaster = switchMaster
-  self.class.defineMaster = defineMaster
-  self.class.defineMasters = defineMasters
-  self.class.currentMaster = currentMaster
+  self:export("switchMasterOnePage", switchMasterOnePage)
+  self:export("switchMaster", switchMaster)
+  self:export("defineMaster", defineMaster)
+  self:export("defineMasters", defineMasters)
+  self:export("currentMaster", currentMaster)
 
   if options then
     self.class:defineMasters(options)

--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -11,7 +11,7 @@ local function _moveTocNodes (class)
   local node = SILE.scratch.info.thispage.toc
   if node then
     for i = 1, #node do
-      node[i].pageno = class:formatCounter(SILE.scratch.counters.folio)
+      node[i].pageno = class.packages.counters:formatCounter(SILE.scratch.counters.folio)
       table.insert(SILE.scratch.tableofcontents, node[i])
     end
   end

--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -69,16 +69,6 @@ if not SILE.scratch.pdf_destination_counter then
   SILE.scratch.pdf_destination_counter = 1
 end
 
-
-local _deprecate  = [[
-  Directly calling tableofcontents handling functions is no longer necessary.
-  All the SILE core classes and anything inheriting from them will take care of
-  this automatically using hooks. Custom classes that override the
-  class:endPage() and class:finish() functions may need to handle this in other
-  ways. By calling these hooks directly you are likely causing them to run
-  twice and duplicate entries.
-]]
-
 function package:_init ()
 
   base._init(self)
@@ -93,13 +83,8 @@ function package:_init ()
   self.class:registerHook("endpage", _moveTocNodes)
   self.class:registerHook("finish", _writeToc)
 
-  --exports
-  self.class.writeToc = function (_)
-    SU.deprecated("class:writeToc", nil, "0.13.0", "0.14.0", _deprecate)
-  end
-  self.class.moveTocNodes = function (_)
-    SU.deprecated("class:moveTocNodes", nil, "0.13.0", "0.14.0", _deprecate)
-  end
+  self:deprecatedExport("writeToc", _writeToc)
+  self:deprecatedExport("moveTocNodes", _moveTocNodes)
 end
 
 function package:registerCommands ()

--- a/packages/textcase/init.lua
+++ b/packages/textcase/init.lua
@@ -5,21 +5,30 @@ package._name = "tetxcase"
 
 local icu = require("justenoughicu")
 
-local uppercase = function (input, extraArgs)
+local uppercase = function (class, input, extraArgs)
+  if type(class) ~= "table" or class.type ~= "class" then
+    input, extraArgs = class, input
+  end
   if not extraArgs then extraArgs = {} end
   if not extraArgs.options then extraArgs.options = {} end
   local lang = extraArgs.options.language or SILE.settings:get("document.language")
   return icu.case(input, lang, "upper")
 end
 
-local lowercase = function (input, extraArgs)
+local lowercase = function (class, input, extraArgs)
+  if type(class) == "table" and class.type ~= "class" then
+    input, extraArgs = class, input
+  end
   if not extraArgs then extraArgs = {} end
   if not extraArgs.options then extraArgs.options = {} end
   local lang = extraArgs.options.language or SILE.settings:get("document.language")
   return icu.case(input, lang, "lower")
 end
 
-local titlecase = function (input, extraArgs)
+local titlecase = function (class, input, extraArgs)
+  if type(class) == "table" and class.type ~= "class" then
+    input, extraArgs = class, input
+  end
   if not extraArgs then extraArgs = {} end
   if not extraArgs.options then extraArgs.options = {} end
   local lang = extraArgs.options.language or SILE.settings:get("document.language")
@@ -32,10 +41,9 @@ function package:_init ()
 
   self.class:loadPackage("inputfilter")
 
-  -- exports
-  self.class.uppercase = uppercase
-  self.class.lowercase = lowercase
-  self.class.titlecase = titlecase
+  self:deprecatedExport("uppercase", uppercase)
+  self:deprecatedExport("lowercase", lowercase)
+  self:deprecatedExport("titlecase", titlecase)
 
 end
 

--- a/packages/twoside/init.lua
+++ b/packages/twoside/init.lua
@@ -31,7 +31,7 @@ local function oddPage ()
   return tp == "odd"
 end
 
-local function _switchPage (class)
+local function switchPage (class)
   if class:oddPage() then
     tp = "even"
     class:switchMaster(class.evenPageMaster)
@@ -57,20 +57,19 @@ function package:_init (options)
     SU.error("Cannot load twoside package before masters.")
   end
 
-  -- exports
-  self.class.oddPage = oddPage
-  self.class.mirrorMaster = mirrorMaster
-  self.class.switchPage = function (class)
+  self:export("oddPage", oddPage)
+  self:export("mirrorMaster", mirrorMaster)
+  self:export("switchPage", function (class)
     SU.deprecated("class:switchPage", nil, "0.13.0", "0.15.0", _deprecate)
-    return _switchPage(class)
-  end
+    return class:switchPage()
+  end)
 
   self.class.oddPageMaster = options.oddPageMaster
   self.class.evenPageMaster = options.evenPageMaster
-  self.class:registerPostinit(function (self_)
-    self_:mirrorMaster(options.oddPageMaster, options.evenPageMaster)
+  self.class:registerPostinit(function (class)
+    class:mirrorMaster(options.oddPageMaster, options.evenPageMaster)
   end)
-  self.class:registerHook("newpage", _switchPage)
+  self.class:registerHook("newpage", switchPage)
 
 end
 

--- a/packages/url/init.lua
+++ b/packages/url/init.lua
@@ -85,32 +85,32 @@ function package:registerCommands ()
       else
         if string.find(preferBreakBefore, escapeRegExpMinimal(token.separator)) then
           -- Accepts breaking before, and at the extreme worst after.
-          result[#result+1] = class.createCommand(
+          result[#result+1] = class.packages.inputfilter:createCommand(
           content.pos, content.col, content.line,
-          "penalty", { penalty = options.primaryPenalty }, nil
+          "penalty", { penalty = options.primaryPenalty }
           )
           result[#result+1] = token.separator
-          result[#result+1] = class.createCommand(
+          result[#result+1] = class.packages.inputfilter:createCommand(
           content.pos, content.col, content.line,
-          "penalty", { penalty = options.worsePenalty }, nil
+          "penalty", { penalty = options.worsePenalty }
           )
         elseif token.separator == alwaysBreakAfter then
           -- Accept breaking after (only).
           result[#result+1] = token.separator
-          result[#result+1] = class.createCommand(
+          result[#result+1] = class.packages.inputfilter:createCommand(
           content.pos, content.col, content.line,
-          "penalty", { penalty = options.primaryPenalty }, nil
+          "penalty", { penalty = options.primaryPenalty }
           )
         else
           -- Accept breaking after, but tolerate breaking before.
-          result[#result+1] = class.createCommand(
+          result[#result+1] = class.packages.inputfilter:createCommand(
           content.pos, content.col, content.line,
-          "penalty", { penalty = options.secondaryPenalty }, nil
+          "penalty", { penalty = options.secondaryPenalty }
           )
           result[#result+1] = token.separator
-          result[#result+1] = class.createCommand(
+          result[#result+1] = class.packages.inputfilter:createCommand(
           content.pos, content.col, content.line,
-          "penalty", { penalty = options.primaryPenalty }, nil
+          "penalty", { penalty = options.primaryPenalty }
           )
         end
       end


### PR DESCRIPTION
This is follow up to #1487 which made all packages into classes inheriting some standardized package functions (and more importantly going forward, scope!) but left some "exports" table stuff around to shim old usage. The old usage is still shimmed here but with a standardized API for new usage going forward.
