### PR TITLE
Image resolution and PDF page selection with libtexpdf backend

### DIFF
--- a/documentation/c12-tricks.sil
+++ b/documentation/c12-tricks.sil
@@ -186,7 +186,7 @@ One SILE project needed two different kinds of sidenotes, margin notes and gutte
 notes.
 
 \line
-\img[src=documentation/discovery.png,width=width(content)]
+\img[src=documentation/discovery.png,width=100%fw]
 \line
 
 Sidenotes can be seen as a simplified form of

--- a/outputters/debug.lua
+++ b/outputters/debug.lua
@@ -139,8 +139,8 @@ end
 
 function outputter.getImageSize (_, src)
   local pdf = require("justenoughlibtexpdf")
-  local llx, lly, urx, ury = pdf.imagebbox(src)
-  return (urx-llx), (ury-lly)
+  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src)
+  return (urx-llx), (ury-lly), xresol, yresol
 end
 
 function outputter:drawSVG (figure, _, x, y, width, height, scalefactor)

--- a/outputters/debug.lua
+++ b/outputters/debug.lua
@@ -137,9 +137,9 @@ function outputter:drawImage (src, x, y, width, height)
   self:_writeline("Draw image", src, _round(x), _round(y), _round(width), _round(height))
 end
 
-function outputter.getImageSize (_, src)
+function outputter.getImageSize (_, src, pageno)
   local pdf = require("justenoughlibtexpdf")
-  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src)
+  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src, pageno)
   return (urx-llx), (ury-lly), xresol, yresol
 end
 

--- a/outputters/libtexpdf.lua
+++ b/outputters/libtexpdf.lua
@@ -161,8 +161,8 @@ end
 
 function outputter:getImageSize (src)
   self:_ensureInit() -- in case it's a PDF file
-  local llx, lly, urx, ury = pdf.imagebbox(src)
-  return (urx-llx), (ury-lly)
+  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src)
+  return (urx-llx), (ury-lly), xresol, yresol
 end
 
 function outputter:drawSVG (figure, x, y, _, height, scalefactor)

--- a/outputters/libtexpdf.lua
+++ b/outputters/libtexpdf.lua
@@ -150,18 +150,18 @@ function outputter:setFont (options)
   return _font
 end
 
-function outputter:drawImage (src, x, y, width, height)
+function outputter:drawImage (src, x, y, width, height, pageno)
   x = SU.cast("number", x)
   y = SU.cast("number", y)
   width = SU.cast("number", width)
   height = SU.cast("number", height)
   self:_ensureInit()
-  pdf.drawimage(src, x, y, width, height)
+  pdf.drawimage(src, x, y, width, height, pageno or 1)
 end
 
-function outputter:getImageSize (src)
+function outputter:getImageSize (src, pageno)
   self:_ensureInit() -- in case it's a PDF file
-  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src)
+  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src, pageno or 1)
   return (urx-llx), (ury-lly), xresol, yresol
 end
 

--- a/packages/image/init.lua
+++ b/packages/image/init.lua
@@ -9,8 +9,9 @@ function package:registerCommands ()
     SU.required(options, "src", "including image file")
     local width =  SILE.parseComplexFrameDimension(options.width or 0) or 0
     local height = SILE.parseComplexFrameDimension(options.height or 0) or 0
+    local pageno = SU.cast("integer", options.page or 1)
     local src = SILE.resolveFile(options.src) or SU.error("Couldn't find file "..options.src)
-    local box_width, box_height = SILE.outputter:getImageSize(src)
+    local box_width, box_height, _, _ = SILE.outputter:getImageSize(src, pageno)
     local sx, sy = 1, 1
     if width > 0 or height > 0 then
       sx = width > 0 and box_width / width
@@ -25,7 +26,7 @@ function package:registerCommands ()
       depth= 0,
       value= src,
       outputYourself = function (node, typesetter, _)
-        SILE.outputter:drawImage(node.value, typesetter.frame.state.cursorX, typesetter.frame.state.cursorY-node.height, node.width, node.height)
+        SILE.outputter:drawImage(node.value, typesetter.frame.state.cursorX, typesetter.frame.state.cursorY-node.height, node.width, node.height, pageno)
         typesetter.frame:advanceWritingDirection(node.width)
     end})
 
@@ -40,6 +41,8 @@ As well as processing text, SILE can also include images.
 Loading the \autodoc:package{image} package gives you the \autodoc:command{\img} command, fashioned after the HTML equivalent.
 It takes the following parameters: \autodoc:parameter{src=<file>} must be the path to an image file; you may also give \autodoc:parameter{height} and/or \autodoc:parameter{width} parameters to specify the output size of the image on the paper.
 If the size parameters are not given, then the image will be output at its ‘natural’ size, honoring its resolution if available.
+The command also supports a \autodoc:parameter{page=<number>} option, to specify the selected page in formats supporting
+several pages (such as PDF).
 
 \begin{note}
 With the libtexpdf backend (the default), the images can be in JPEG, PNG, EPS or PDF formats.

--- a/packages/image/init.lua
+++ b/packages/image/init.lua
@@ -7,8 +7,8 @@ function package:registerCommands ()
 
   self:registerCommand("img", function (options, _)
     SU.required(options, "src", "including image file")
-    local width =  SILE.parseComplexFrameDimension(options.width or 0) or 0
-    local height = SILE.parseComplexFrameDimension(options.height or 0) or 0
+    local width =  SU.cast("measurement", options.width or 0):tonumber()
+    local height = SU.cast("measurement", options.height or 0):tonumber()
     local pageno = SU.cast("integer", options.page or 1)
     local src = SILE.resolveFile(options.src) or SU.error("Couldn't find file "..options.src)
     local box_width, box_height, _, _ = SILE.outputter:getImageSize(src, pageno)

--- a/src/imagebbox.c
+++ b/src/imagebbox.c
@@ -28,7 +28,7 @@ int get_pdf_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) {
   return 0;
 }
 
-int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) {
+int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury, double* xresol, double* yresol) {
   int width, height;
   uint32_t w2, h2;
   double xdensity, ydensity;
@@ -52,6 +52,8 @@ int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) 
     width = w2;
     height = h2;
   } else if (texpdf_check_for_pdf(f)) {
+    *xresol = 0;
+    *yresol = 0;
     return get_pdf_bbox(f, llx, lly, urx, ury);
   } else {
     return -1;
@@ -59,8 +61,12 @@ int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) 
 
   *llx = 0;
   *lly =0;
+  // pixels -> pt
   *urx = width * xdensity;
   *ury = height * ydensity;
+  // texpdf density is in pt/in
+  *xresol = xdensity != 0 ? 72 / xdensity : 0;
+  *yresol = ydensity != 0 ? 72 / ydensity : 0;
   return 0;
 }
 

--- a/src/imagebbox.c
+++ b/src/imagebbox.c
@@ -2,9 +2,8 @@
 #include <stdio.h>
 #include "libtexpdf/libtexpdf.h"
 
-int get_pdf_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) {
+int get_pdf_bbox(FILE* f, long page_no, double* llx, double* lly, double* urx, double* ury) {
   pdf_obj* page;
-  long page_no = 1;
   long count;
   pdf_rect bbox;
   pdf_file* pf = texpdf_open(NULL, f);
@@ -28,7 +27,7 @@ int get_pdf_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) {
   return 0;
 }
 
-int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury, double* xresol, double* yresol) {
+int get_image_bbox(FILE* f, long page_no, double* llx, double* lly, double* urx, double* ury, double* xresol, double* yresol) {
   int width, height;
   uint32_t w2, h2;
   double xdensity, ydensity;
@@ -54,7 +53,7 @@ int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury, 
   } else if (texpdf_check_for_pdf(f)) {
     *xresol = 0;
     *yresol = 0;
-    return get_pdf_bbox(f, llx, lly, urx, ury);
+    return get_pdf_bbox(f, page_no, llx, lly, urx, ury);
   } else {
     return -1;
   }

--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -353,7 +353,7 @@ int pdf_drawimage(lua_State *L) {
   return 0;
 }
 
-extern int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury);
+extern int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury, double* xresol, double* yresol);
 
 int pdf_imagebbox(lua_State *L) {
   const char* filename = luaL_checkstring(L, 1);
@@ -361,13 +361,15 @@ int pdf_imagebbox(lua_State *L) {
   double lly = 0;
   double urx = 0;
   double ury = 0;
+  double xresol = 0;
+  double yresol = 0;
 
   FILE* f = MFOPEN(filename, FOPEN_RBIN_MODE);
   if (!f) {
     return luaL_error(L, "Image file not found %s", filename);
   }
 
-  if ( get_image_bbox(f, &llx, &lly, &urx, &ury) < 0 ) {
+  if ( get_image_bbox(f, &llx, &lly, &urx, &ury, &xresol, &yresol) < 0 ) {
     MFCLOSE(f);
     return luaL_error(L, "Invalid image file %s", filename);
   }
@@ -378,7 +380,17 @@ int pdf_imagebbox(lua_State *L) {
   lua_pushnumber(L, lly);
   lua_pushnumber(L, urx);
   lua_pushnumber(L, ury);
-  return 4;
+  if (xresol == 0) {
+    lua_pushnil(L);
+  } else {
+    lua_pushnumber(L, xresol);
+  }
+  if (yresol == 0) {
+    lua_pushnil(L);
+  } else {
+    lua_pushnumber(L, yresol);
+  }
+  return 6;
 }
 
 int pdf_transform(lua_State *L) {

--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -341,7 +341,8 @@ int pdf_drawimage(lua_State *L) {
   double y = luaL_checknumber(L, 3);
   double w = luaL_checknumber(L, 4);
   double h = luaL_checknumber(L, 5);
-  int form_id = texpdf_ximage_findresource(p, filename, 0, NULL);
+  long page_no = (long)luaL_checkinteger(L, 6);
+  int form_id = texpdf_ximage_findresource(p, filename, page_no, NULL);
 
   texpdf_transform_info_clear(&ti);
   ti.width = w;
@@ -353,10 +354,11 @@ int pdf_drawimage(lua_State *L) {
   return 0;
 }
 
-extern int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury, double* xresol, double* yresol);
+extern int get_image_bbox(FILE* f, long page_no, double* llx, double* lly, double* urx, double* ury, double* xresol, double* yresol);
 
 int pdf_imagebbox(lua_State *L) {
   const char* filename = luaL_checkstring(L, 1);
+  long page_no = (long)luaL_checkinteger(L, 2);
   double llx = 0;
   double lly = 0;
   double urx = 0;
@@ -369,7 +371,7 @@ int pdf_imagebbox(lua_State *L) {
     return luaL_error(L, "Image file not found %s", filename);
   }
 
-  if ( get_image_bbox(f, &llx, &lly, &urx, &ury, &xresol, &yresol) < 0 ) {
+  if ( get_image_bbox(f, page_no, &llx, &lly, &urx, &ury, &xresol, &yresol) < 0 ) {
     MFCLOSE(f);
     return luaL_error(L, "Invalid image file %s", filename);
   }


### PR DESCRIPTION
Three commits touching quite the same bits of code:
* This is the required C support for the possible enhancements evoked in #1346
  Outputters using the libtexpdf backend to compute an image size, such as "debug" and "libtexpdf", also return, as additional results on the `getImageSize()` method, the image resolutions in dots (pixels) per inch.
  This may be used by packages/classes to check images have an appropriate (e.g. print) quality regardless of their claimed size (in pt), or to downsize too resolved images, etc. - but that is a separate concern ; this PR just offers the tooling.
  Ex. with `documentation/gutenberg.png` (200 x 243 pixels) unscaled = 144pt x 174.96 pt at resolution 100 dpi x100 dpi.
  N.B. Libtexpdf's density is in pt/in. It's converted back to dpi, here, as it is more usual for users (who tend to know that decent print quality in the range of 300-600 for printed books, for instance)
* Add ability to select the page on a PDF image, i.e. `\img[src=somepdf, page=2]` (the default is obviously 1, with same behavior as before) = my misunderstanding of question #1515, but the idea is sound nevertheless.
* Additionally, image height and width parsed as `SILE.measurement` rather than complex frame dimensions (as discussed in #1267 and done on the raiselower package in #1506.
