### PR TITLE
Minor href regression and grid fix

### DIFF
--- a/packages/grid/init.lua
+++ b/packages/grid/init.lua
@@ -53,6 +53,7 @@ local function pushExplicitVglue (typesetter, spec)
 end
 
 local function startGridInFrame (typesetter)
+  if not SILE.typesetter.state.grid then return end -- Ensure the frame hook isn't effective when grid is off
   local queue = typesetter.state.outputQueue
   typesetter.frame.state.totals.gridCursor = SILE.measurement(0)
   if #queue == 0 then

--- a/packages/url/init.lua
+++ b/packages/url/init.lua
@@ -48,7 +48,15 @@ end
 function package:registerCommands ()
 
   self:registerCommand("href", function (options, content)
-    if not pdf then return SILE.process(content) end
+    if not pdf then
+      if options.src then
+        SILE.process(content)
+      else
+        SILE.call("url", { language = options.language }, content)
+      end
+      return -- DONE.
+    end
+
     if options.src then
       SILE.call("pdf:link", { dest = options.src, external = true,
         borderwidth = options.borderwidth,

--- a/packages/url/init.lua
+++ b/packages/url/init.lua
@@ -23,7 +23,7 @@ function package:_init ()
   base._init(self)
   self.class:loadPackage("verbatim")
   self.class:loadPackage("inputfilter")
-  pdf = SILE.outputter == SILE.outputters.libtexpdf
+  pdf = SILE.outputter._name == "libtexpdf"
   if pdf then self.class:loadPackage("pdf") end
 end
 


### PR DESCRIPTION
- Seen in passing, an issue introduced in 0.13
  When pdf is supported, `\href[src=uri]{text}` outputs the text in current font and `\href{uri}` delegates the content to `\url`, with additional breakpoints and possibly a different font. The formatting behavior shall be the same when pdf is not supported (i.e., same visual output, whether the hyperlink is active or not).
- From [discussion here](https://github.com/sile-typesetter/sile/pull/1334#issuecomment-1200125592)
  Incorrect detection of the backend.
- From [analysis here](https://github.com/sile-typesetter/sile/issues/1174#issuecomment-1173141699)
  Ensuring the grid frame hook is ineffective when the grid is off. That might not be a true fix, rather a workaround, but the immediate benefit is that some long-reported vertical issues in the SILE manual are solved.