### PR TITLE
Parse height argument to in raiselower package as measurement

### DIFF
--- a/packages/raiselower/init.lua
+++ b/packages/raiselower/init.lua
@@ -3,29 +3,33 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "raiselower"
 
+local function raise (height, content)
+  SILE.typesetter:pushHbox({
+    outputYourself = function (_, typesetter, _)
+      typesetter.frame:advancePageDirection(-height)
+    end
+  })
+  SILE.process(content)
+  SILE.typesetter:pushHbox({
+    outputYourself = function (_, typesetter, _)
+      if (type(typesetter.state.cursorY)) == "table" then
+        typesetter.state.cursorY = typesetter.state.cursorY.length
+      end
+      typesetter.frame:advancePageDirection(height)
+    end
+  })
+end
+
 function package:registerCommands ()
 
   self:registerCommand("raise", function (options, content)
-    local height = options.height or 0
-    height = SILE.parseComplexFrameDimension(height)
-    SILE.typesetter:pushHbox({
-        outputYourself = function (_, typesetter, _)
-          typesetter.frame:advancePageDirection(-height)
-        end
-      })
-    SILE.process(content)
-    SILE.typesetter:pushHbox({
-        outputYourself = function (_, typesetter, _)
-          if (type(typesetter.state.cursorY)) == "table" then
-            typesetter.state.cursorY = typesetter.state.cursorY.length
-          end
-          typesetter.frame:advancePageDirection(height)
-        end
-      })
+    local height = SU.cast("measurement", options.height)
+    raise(height:absolute(), content)
   end, "Raises the contents of the command by the amount specified in the <height> option")
 
   self:registerCommand("lower", function (options, content)
-    SILE.call("raise", { height = "-" .. options.height }, content)
+    local height = SU.cast("measurement", options.height)
+    raise(-height:absolute(), content)
   end, "Lowers the contents of the command by the amount specified in the <height> option")
 
 end


### PR DESCRIPTION
Fixes #1504

This is an old function that predates our SILE.length / SILE.measurement
logic and units like `%fh` that are relative to the frame or page. It
was being parsed as a frame dimension, which I assume was just a way to
get user friendly string input and perhaps some expressiveness.
I couldn't actually think of a use case for making this a full frame
string and not accepting our standardized measurement types comes with
lots of downfalls especially in programmatic usage.

I'm not marking this as breaking because in most cases I think the new
behavior will be expected and I doubt the edge cases where they differ
are seeing much use.
