### PR TITLE
Fixup little issues (mostly with compatibility shims) found in production

### DIFF
--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -151,7 +151,7 @@ then
 # directory, and "git describe" output looks sensible, use that to
 # derive a version string.
 elif test "`git log -1 --pretty=format:x . 2>/dev/null`" = x \
-    && v=`git describe --tags --abbrev=7 --match="$prefix*" HEAD 2>/dev/null \
+    && v=`git describe --tags --abbrev=7 --match="$prefix*\.*\.*" HEAD 2>/dev/null \
           || git describe --tags --abbrev=7 HEAD 2>/dev/null \
           || git log -1 --pretty=format:'v0-HEAD-%h' 2>/dev/null` \
     && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \

--- a/packages/chordmode/init.lua
+++ b/packages/chordmode/init.lua
@@ -115,7 +115,7 @@ function package:registerCommands ()
   end
 
   self:registerCommand("chordmode", function (_, content)
-    SILE.process(self.class.transformContent(content, _addChords))
+    SILE.process(self.class.packages.inputfilter:transformContent(content, _addChords))
   end, "Transform embedded chords to 'ch' commands")
 
   self:registerCommand("chordmode:chordfont", function (_, content)

--- a/packages/textcase/init.lua
+++ b/packages/textcase/init.lua
@@ -5,9 +5,9 @@ package._name = "tetxcase"
 
 local icu = require("justenoughicu")
 
-local uppercase = function (class, input, extraArgs)
-  if type(class) ~= "table" or class.type ~= "class" then
-    input, extraArgs = class, input
+function package:uppercase (input, extraArgs)
+  if type(self) ~= "table" or (self.type ~= "class" and self.type ~= "package") then
+    input, extraArgs = self, input
   end
   if not extraArgs then extraArgs = {} end
   if not extraArgs.options then extraArgs.options = {} end
@@ -15,9 +15,9 @@ local uppercase = function (class, input, extraArgs)
   return icu.case(input, lang, "upper")
 end
 
-local lowercase = function (class, input, extraArgs)
-  if type(class) == "table" and class.type ~= "class" then
-    input, extraArgs = class, input
+function package:lowercase (input, extraArgs)
+  if type(self) ~= "table" or (self.type ~= "class" and self.type ~= "package") then
+    input, extraArgs = self, input
   end
   if not extraArgs then extraArgs = {} end
   if not extraArgs.options then extraArgs.options = {} end
@@ -25,9 +25,9 @@ local lowercase = function (class, input, extraArgs)
   return icu.case(input, lang, "lower")
 end
 
-local titlecase = function (class, input, extraArgs)
-  if type(class) == "table" and class.type ~= "class" then
-    input, extraArgs = class, input
+function package:titlecase (input, extraArgs)
+  if type(self) ~= "table" or (self.type ~= "class" and self.type ~= "package") then
+    input, extraArgs = self, input
   end
   if not extraArgs then extraArgs = {} end
   if not extraArgs.options then extraArgs.options = {} end
@@ -38,23 +38,23 @@ end
 function package:_init ()
   base._init(self)
   self.class:loadPackage("inputfilter")
-  self:deprecatedExport("uppercase", uppercase)
-  self:deprecatedExport("lowercase", lowercase)
-  self:deprecatedExport("titlecase", titlecase)
+  self:deprecatedExport("uppercase", self.uppercase)
+  self:deprecatedExport("lowercase", self.lowercase)
+  self:deprecatedExport("titlecase", self.titlecase)
 end
 
 function package:registerCommands ()
 
   self:registerCommand("uppercase", function(options, content)
-    SILE.process(self.class.packages.inputfilter:transformContent(content, uppercase, options))
+    SILE.process(self.class.packages.inputfilter:transformContent(content, self.uppercase, options))
   end, "Typeset the enclosed text as uppercase")
 
   self:registerCommand("lowercase", function(options, content)
-    SILE.process(self.class.packages.inputfilter:transformContent(content, lowercase, options))
+    SILE.process(self.class.packages.inputfilter:transformContent(content, self.lowercase, options))
   end, "Typeset the enclosed text as lowercase")
 
   self:registerCommand("titlecase", function(options, content)
-    SILE.process(self.class.packages.inputfilter:transformContent(content, titlecase, options))
+    SILE.process(self.class.packages.inputfilter:transformContent(content, self.titlecase, options))
   end, "Typeset the enclosed text as titlecase")
 
 end

--- a/sile.in
+++ b/sile.in
@@ -97,10 +97,6 @@ if SILE.masterFilename then
     ProFi:start()
   end
 
-  for _, spec in ipairs(SILE.input.uses) do
-    SILE.use(spec.module, spec.options)
-  end
-
   -- Deprecated, notice given in core.cli when argument used
   for _, path in ipairs(SILE.input.includes) do
     io.stderr:write("Loading "..path.."\n")
@@ -110,6 +106,10 @@ if SILE.masterFilename then
     else
       SILE.require(path, "classes")
     end
+  end
+
+  for _, spec in ipairs(SILE.input.uses) do
+    SILE.use(spec.module, spec.options)
   end
 
   local main, err = xpcall(function()


### PR DESCRIPTION
The internal uppercase() function was exported using the deprecated
export mechanism, but lowercase() and titlecase() were tripping over
their own shim logic.

This fixes the shim logic but also exports them as package functions
which should be used going forward.
