### PR TITLE
Add API so packages know their basedir and can load relative assets

### DIFF
--- a/packages/base.lua
+++ b/packages/base.lua
@@ -8,11 +8,18 @@ package.class = nil
 -- For shimming packages that used to have legacy exports
 package.exports = {}
 
+local function script_path ()
+  local src = debug.getinfo(3, "S").source:sub(2)
+  local base = src:match("(.*[/\\])")
+  return base
+end
+
 function package:_init (_)
   self.class = SILE.scratch.half_initialized_class or SILE.documentState.documentClass
   if not self.class then
     SU.error("Attempted to initialize package before class, should have been queued in the preamble", true)
   end
+  self.basedir = script_path()
   self:declareSettings()
   self:registerRawHandlers()
   self:registerCommands()


### PR DESCRIPTION
Some packages may bundle non-Lua resources (images, SIL, XML, etc).
Given the packages themselves are loaded with Lua's module loader using
`package.path` it can be tricky to then find the other assets. Rather
than letting ever package author re-invent this wheel this just gives
a little API that can be used any time later to recover the path where
the package was loaded from.
