### PR TITLE
fix(justenoughlibtexpdf): pdf_metadata

### DIFF
--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -331,6 +331,7 @@ int pdf_metadata(lua_State *L) {
   texpdf_add_dict(p->info,
                texpdf_new_name(key),
                texpdf_new_string(value, len));
+  return 0;
 }
 /* Images */
 


### PR DESCRIPTION
The function is non-void, but it doesn't return anything in the end. Without this, gcc complains with a "return reaches end of non-void function" warning, which is treated as an error on certain Linux distros such as openSUSE.