### PR TITLE
Avoid mktemp during build, breaks opensuse packaging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,7 +140,7 @@ check: selfcheck
 
 .PHONY: selfcheck
 selfcheck: | $(_BUILT_SUBDIRS)
-	output=$$(mktemp -t selfcheck-XXXXXX.pdf)
+	output=selfcheck-$(VERSION).pdf
 	trap 'rm -f $$output' EXIT HUP TERM
 	echo "<sile>foo</sile>" | ./$(SILE) -o $$output -
 	$(PDFINFO) $$output | $(GREP) "SILE v$(VERSION)"


### PR DESCRIPTION
Fixes #1359
