### PR TITLE
docs(manual): Improve some bullet lists and apostrophes

### DIFF
--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -274,7 +274,7 @@ Unless you are experienced building software on Windows it is probably best to u
 
 There are persistent rumors from credible users that say they have gotten it working, but the exact steps they used to make it happen are a bit elusive.
 We would be happy to see better support, but none of the current developers are Windows users or developers.
-If anywone wants to help in this department we'd be happy to facilitate contributions.
+If anywone wants to help in this department we’d be happy to facilitate contributions.
 
 According to the rumors, SILE may be built on Windows using CMake and Visual Studio.
 Additionally some Windows executables are supposed to be generated using Azure for every commit.

--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -211,13 +211,12 @@ This directory could be in your system Lua directory, in your user directory, or
 
 By default SILE will look for packages in:
 
-\noindent• The directory where the SILE source file is located
-
-\noindent• The current working directory
-
-\noindent• The default LUA search path
-
-\noindent• The directory where SILE is installed on the system
+\begin{itemize}
+\item{The directory where the SILE source file is located,}
+\item{The current working directory,}
+\item{The default LUA search path,}
+\item{The directory where SILE is installed on the system.}
+\end{itemize}
 
 By default, LuaRocks will install packages to the Lua search path.
 
@@ -252,7 +251,7 @@ $ sile ...
 
 To write a package and publish to LuaRocks, see the package-template.sile repository.
 
-It's worth noting that packages are not limited to just the package interface.
+It’s worth noting that packages are not limited to just the package interface.
 They can include classes, languages, i18n resources, or anything else provided by SILE.
 Also because external locations are searched before SILE itself, they can even override any core part of SILE itself.
 As such you should probably make sure you review what a package does before installing it!

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -19,19 +19,15 @@ Selecting a language by either method loads up the \em{language support} file(s)
 These in turn enable various localization and typesetting conventions.
 Language support may include and combination of:
 
-\noindent{}• hyphenation patterns,
-
-\noindent{}• line breaking and justification schemes,
-
-\noindent{}• frame advance and writing direction,
-
-\noindent{}• spacing,
-
-\noindent{}• choice of glyphs within a font,
-
-\noindent{}• localization of programatically inserted strings,
-
-\noindent{}• and more.
+\begin{itemize}
+\item{hyphenation patterns,}
+\item{line breaking and justification schemes,}
+\item{frame advance and writing direction,}
+\item{spacing,}
+\item{choice of glyphs within a font,}
+\item{localization of programatically inserted strings,}
+\item{and more…}
+\end{itemize}
 
 For example, Sindhi and Urdu users will expect the Arabic letter \em{heh} (\font[family=LateefGR]{ه}) to combine with other letters in different ways to standard Arabic shaping.
 In those cases, you should ensure that you select the appropriate language before processing the text:

--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -173,7 +173,7 @@ end
 \end{verbatim}
 
 Note that the official SILE classes have some extra tooling to handle legacy class models trying to inherit from them.
-You don't need those deprecation shims in your own classes when following these examples.
+You don’t need those deprecation shims in your own classes when following these examples.
 
 \section{Defining Commands}
 

--- a/documentation/c11-xmlproc.sil
+++ b/documentation/c11-xmlproc.sil
@@ -6,11 +6,11 @@ We’ll be looking at the DocBook processor that ships with SILE.
 DocBook is an XML format for structured technical documentation.
 DocBook itself doesn’t encode any presentation information about how its various tags should be rendered on a page, and so we shall have to make all the presentation decisions for ourself.
 
-Since DocDook itself doesn't specify anything about presentation such as papersize, you may need to supply values either on the command line or using a preamble.
+Since DocDook itself doesn’t specify anything about presentation such as papersize, you may need to supply values either on the command line or using a preamble.
 When you use the \code{-c docbook} command line option to SILE, SILE will use the \em{docbook} class in spite of any document declaration.
 In addition options such as paper size could be set with, e.g. \code{-O papersize=legal}.
 
-The class initalization for DocBoox isn't too fancy, it just loads up a couple packages that will get used later.
+The class initalization for DocBoox isn’t too fancy, it just loads up a couple packages that will get used later.
 
 Now we can start defining SILE commands to render XML elements.
 Most of these are fairly straightforward so we will not dwell on them too much.

--- a/documentation/developers.sil
+++ b/documentation/developers.sil
@@ -23,7 +23,7 @@ This book assumes that you’ve already read the SILE Book, and are now looking 
 The SILE cli itself is generated from the \code{sile.in} file and only handles some of the executable lifecycle stuff.
 The main core of SILE including most of the top level API is in \code{core/sile.lua}.
 This is also the file you would require in your own projects to get access to the SILE core as a library.
-It requires a lot of other things on it's own including some other file in \code{core}.
+It requires a lot of other things on its own, including some other file in \code{core}.
 
 Some of the major components, especially those which have alternatives, are in module directories.
 For example classes are in \code{classes}, inputters in \code{inputters}, etc.


### PR DESCRIPTION
The manual should thrive for nice typography, to be convincing for casual readers ;)