### PR TITLE
Avoid forcing mirrored masters in twoside package

### DIFF
--- a/packages/twoside/init.lua
+++ b/packages/twoside/init.lua
@@ -64,7 +64,10 @@ function package:_init (options)
   self.class.oddPageMaster = options.oddPageMaster
   self.class.evenPageMaster = options.evenPageMaster
   self.class:registerPostinit(function (class)
-    class:mirrorMaster(options.oddPageMaster, options.evenPageMaster)
+    -- TODO: Refactor this to make mirroring a separate package / option
+    if not SILE.scratch.masters[options.evenPageMaster] then
+      class:mirrorMaster(options.oddPageMaster, options.evenPageMaster)
+    end
   end)
   self.class:registerHook("newpage", spreadHook)
   self.class:registerHook("newpage", switchPage)


### PR DESCRIPTION
Closes #1558

Almost everything about this package is gross. It reaches too deep into the masters implementation, the commands it provides shouldn't be scoped to this package, etc. etc. etc. That being said I'm not refactoring it to fix the root issues yet as it will almost certainly mean marking it as a breaking release since classes that inherit from book will likely have to be changed to call `:mirrorMaster()` themselves or otherwise use the correctly scoped APIs. This is just a temporary fix that makes the assumption if the requested odd and even page masters already exist the user probably has them setup the way they want them and don't clobber them by forcing mirroring.
