### PR TITLE
fix(math): Fix insertion order of MathML children

### DIFF
--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -124,10 +124,10 @@ local objType = {
   str = 2
 }
 
-local function inferArgTypes_aux (acc, typeRequired, body)
+local function inferArgTypes_aux (accumulator, typeRequired, body)
   if type(body) == "table" then
     if body.id == "argument" then
-      local ret = acc
+      local ret = accumulator
       table.insert(ret, body.index, typeRequired)
       return ret
     elseif body.id == "command" then
@@ -139,33 +139,33 @@ local function inferArgTypes_aux (acc, typeRequired, body)
             #cmdArgTypes .. ")")
         else
           for i = 1, #cmdArgTypes do
-            acc = inferArgTypes_aux(acc, cmdArgTypes[i], body[i])
+            accumulator = inferArgTypes_aux(accumulator, cmdArgTypes[i], body[i])
           end
         end
-        return acc
+        return accumulator
       elseif body.command == "mi" or body.command == "mo" or body.command == "mn" then
         if #body ~= 1 then
           SU.error("Wrong number of arguments ("..#body..") for command "..
             body.command.." (should be 1)")
         end
-        acc = inferArgTypes_aux(acc, objType.str, body[1])
-        return acc
+        accumulator = inferArgTypes_aux(accumulator, objType.str, body[1])
+        return accumulator
       else
         -- Not a macro, recurse on children assuming tree type for all
         -- arguments
         for _, child in ipairs(body) do
-          acc = inferArgTypes_aux(acc, objType.tree, child)
+          accumulator = inferArgTypes_aux(accumulator, objType.tree, child)
         end
-        return acc
+        return accumulator
       end
     elseif body.id == "atom" then
-      return acc
+      return accumulator
     else
       -- Simply recurse on children
       for _, child in ipairs(body) do
-        acc = inferArgTypes_aux(acc, typeRequired, child)
+        accumulator = inferArgTypes_aux(accumulator, typeRequired, child)
       end
-      return acc
+      return accumulator
     end
   else SU.error("invalid argument to inferArgTypes_aux") end
 end
@@ -174,25 +174,22 @@ local inferArgTypes = function (body)
   return inferArgTypes_aux({}, objType.tree, body)
 end
 
-local function registerCommand (name, argTypes, fun)
-  commands[name] = {argTypes, fun}
+local function registerCommand (name, argTypes, func)
+  commands[name] = { argTypes, func }
 end
 
--- Computes fun(fun(... fun(init, k1, v1), k2, v2)..., k_n, v_n), i.e. applies
--- fun on every key-value pair in the table. Keys with numeric indices are
--- processed in order. This is an important property for MathML compilation
--- below.
-local function fold_pairs (fun, init, table)
-  local acc = init
-  for k,x in pairs(table) do
-    if type(k) ~= "number" then
-      acc = fun(acc, k, x)
-    end
+-- Computes func(func(... func(init, k1, v1), k2, v2)..., k_n, v_n), i.e. applies
+-- func on every key-value pair in the table. Keys with numeric indices are
+-- processed in order. This is an important property for MathML compilation below.
+local function fold_pairs (func, table)
+  local accumulator = {}
+  for k, v in pl.utils.kpairs(table) do
+    accumulator = func(v, k, accumulator)
   end
-  for i,x in ipairs(table) do
-    acc = fun(acc, i, x)
+  for i, v in ipairs(table) do
+    accumulator = func(v, i, accumulator)
   end
-  return acc
+  return accumulator
 end
 
 local function forall (pred, list)
@@ -227,17 +224,17 @@ end
 
 local function compileToMathML_aux (_, arg_env, tree)
   if type(tree) == "string" then return tree end
-  tree = fold_pairs(function (acc, key, child)
+  local function compile_and_insert (child, key, accumulator)
     if type(key) ~= "number" then
-      acc[key] = child
-      return acc
+      accumulator[key] = child
+      return accumulator
     -- Compile all children, except if this node is a macro definition (no
     -- evaluation "under lambda") or the application of a registered macro
     -- (since evaluating the nodes depends on the macro's signature, it is more
     -- complex and done below)..
     elseif tree.id == "def" or (tree.id == "command" and commands[tree.command]) then
       -- Conserve unevaluated child
-      table.insert(acc, child)
+      table.insert(accumulator, child)
     else
       -- Compile next child
       local comp = compileToMathML_aux(nil, arg_env, child)
@@ -245,15 +242,16 @@ local function compileToMathML_aux (_, arg_env, tree)
         if comp.id == "wrapper" then
           -- Insert all children of the wrapper node
           for _, inner_child in ipairs(comp) do
-            table.insert(acc, inner_child)
+            table.insert(accumulator, inner_child)
           end
         else
-          table.insert(acc, comp)
+          table.insert(accumulator, comp)
         end
       end
     end
-    return acc
-  end, {}, tree)
+    return accumulator
+  end
+  tree = fold_pairs(compile_and_insert, tree)
   if tree.id == "texlike_math" then
     tree.command = "math"
     -- If the outermost `mrow` contains only other `mrow`s, remove it

--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -178,10 +178,19 @@ local function registerCommand (name, argTypes, fun)
   commands[name] = {argTypes, fun}
 end
 
+-- Computes fun(fun(... fun(init, k1, v1), k2, v2)..., k_n, v_n), i.e. applies
+-- fun on every key-value pair in the table. Keys with numeric indices are
+-- processed in order. This is an important property for MathML compilation
+-- below.
 local function fold_pairs (fun, init, table)
   local acc = init
   for k,x in pairs(table) do
-    acc = fun(acc, k, x)
+    if type(k) ~= "number" then
+      acc = fun(acc, k, x)
+    end
+  end
+  for i,x in ipairs(table) do
+    acc = fun(acc, i, x)
   end
   return acc
 end


### PR DESCRIPTION
I noticed a strange behaviour when typesetting math tables with 11 rows or more:

```
\begin[class=plain]{document}
\script[src=packages/math]

\math[mode=display]{
  \table{
    0 & 0 & 0 \\
    1 & 1 & 1 \\
    2 & 2 & 2 \\
    3 & 3 & 3 \\
    4 & 4 & 4 \\
    5 & 5 & 5 \\
    6 & 6 & 6 \\
    7 & 7 & 7 \\
    8 & 8 & 8 \\
    9 & 9 & 9 \\
    10 & 10 & 10 \\
  }
}
```

Some of the rows are permuted non-deterministically, depending on the execution… it turns out that I make the mistake of relying on the iteration order of `pairs()` when compiling to MathML. This PR fixes it.

