### PR TITLE
Cleanup inputter AST nesting expectations

### DIFF
--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -382,7 +382,6 @@ But be warned that since GitHub rebuilds containers from scratch on every such i
 Pulling the prebuilt Docker images is recommended instead.
 
 With these ideas in mind, other CI systems should be easy to support as well.
-\end{document}
 
 \section{Installing third-party packages}
 
@@ -412,3 +411,4 @@ To get your Lua version which is used for the execution of SILE:
 $ export LUA_VERSION=$(sile -e 'print(SILE.lua_version);os.exit()' 2> /dev/null)
 $ luarocks install --lua-version $LUA_VERSION ...
 \end{raw}
+\end{document}

--- a/inputters/base.lua
+++ b/inputters/base.lua
@@ -33,28 +33,18 @@ end
 
 function inputter:requireClass (tree)
   local root = SILE.documentState.documentClass == nil
-  local document
   if root then
-    for _, leaf in ipairs(tree) do
-      if leaf.lno then
-        if document then
-          SU.error("Document has more than one parent node!")
-        end
-        if leaf.command == "sile" or leaf.command == "document" then
-          document = leaf
-        end
-      end
-    end
-    if not document then
+    if tree.command ~= "sile" and tree.command ~= "document" then
       SU.error("This isn't a SILE document!")
     end
-    self:classInit(document.options or {})
+    self:classInit(tree.options or {})
     self:preamble()
   end
 end
 
 function inputter:process (doc)
-  local tree = self:parse(doc)
+  -- Input parsers can already return multiple ASTs, but so far we only process one
+  local tree = self:parse(doc)[1]
   self:requireClass(tree)
   return SILE.process(tree)
 end

--- a/inputters/sil_spec.lua
+++ b/inputters/sil_spec.lua
@@ -9,13 +9,13 @@ describe("#SIL #inputter", function ()
   describe("should parse", function ()
 
     it("commands with content", function()
-      local t = inputter:parse([[\foo{bar}]])[1]
+      local t = inputter:parse([[\foo{bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("bar", t[1][1])
     end)
 
     it("commands without content", function()
-      local t = inputter:parse([[\foo{\foo bar}]])[1]
+      local t = inputter:parse([[\foo{\foo bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("foo", t[1][1].command)
       assert.is.equal(" bar", t[1][2])
@@ -23,14 +23,14 @@ describe("#SIL #inputter", function ()
     end)
 
     it("commands with arg", function()
-      local t = inputter:parse([[\foo[baz=qiz]{bar}]])[1]
+      local t = inputter:parse([[\foo[baz=qiz]{bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("qiz", t.options.baz)
       assert.is.equal("bar", t[1][1])
     end)
 
     it("commands with multiple args", function()
-      local t = inputter:parse([[\foo[baz=qiz,qiz=baz]{bar}]])[1]
+      local t = inputter:parse([[\foo[baz=qiz,qiz=baz]{bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("qiz", t.options.baz)
       assert.is.equal("baz", t.options.qiz)
@@ -38,14 +38,14 @@ describe("#SIL #inputter", function ()
     end)
 
     it("commands with quoted arg", function()
-      local t = inputter:parse([[\foo[baz="qiz qiz"]{bar}]])[1]
+      local t = inputter:parse([[\foo[baz="qiz qiz"]{bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("qiz qiz", t.options.baz)
       assert.is.equal("bar", t[1][1])
     end)
 
     it("commands with multiple quoted args", function()
-      local t = inputter:parse([[\foo[baz="qiz, qiz",qiz="baz, baz"]{bar}]])[1]
+      local t = inputter:parse([[\foo[baz="qiz, qiz",qiz="baz, baz"]{bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("qiz, qiz", t.options.baz)
       assert.is.equal("baz, baz", t.options.qiz)
@@ -53,7 +53,7 @@ describe("#SIL #inputter", function ()
     end)
 
     it("commands with quoted arg with escape", function()
-      local t = inputter:parse([[\foo[baz="qiz \"qiz\""]{bar}]])[1]
+      local t = inputter:parse([[\foo[baz="qiz \"qiz\""]{bar}]])[1][1]
       assert.is.equal("foo", t.command)
       assert.is.equal("qiz \"qiz\"", t.options.baz)
       assert.is.equal("bar", t[1][1])

--- a/inputters/xml.lua
+++ b/inputters/xml.lua
@@ -78,8 +78,8 @@ function inputter.parse (_, doc)
   -- to supply handling far whatever that element that is in a specific format.
   -- Hence we wrap the actual DOM in an extra element of our own if and only if
   -- it doesn't look like a native SILE one already.
-  local root = tree.command
-  if root ~= "sile" and root ~= "document" then
+  local rootelement = tree.command
+  if rootelement ~= "sile" and rootelement ~= "document" then
     tree = { tree, command = "document" }
   end
   return { tree }

--- a/inputters/xml_spec.lua
+++ b/inputters/xml_spec.lua
@@ -15,10 +15,10 @@ describe("#XML #inputter", function ()
     end)
 
     it("commands without content", function()
-      local t = inputter:parse([[<foo><foo /> bar</foo>]])[1][1]
+      local t = inputter:parse([[<foo><bar /> baz</foo>]])[1][1]
       assert.is.equal("foo", t.command)
-      assert.is.equal("foo", t[1].command)
-      assert.is.equal(" bar", t[2])
+      assert.is.equal("bar", t[1].command)
+      assert.is.equal(" baz", t[2])
       assert.is.equal(nil, t[1][1])
     end)
 

--- a/packages/autodoc/init.lua
+++ b/packages/autodoc/init.lua
@@ -140,7 +140,7 @@ function package:registerCommands ()
       else
         result[#result+1] = token.separator
         result[#result+1] = self.class.packages.inputfilter:createCommand(
-        content.pos, content.col, content.line,
+        content.pos, content.col, content.lno,
         "penalty", { penalty = 100 }
         )
       end

--- a/packages/chordmode/init.lua
+++ b/packages/chordmode/init.lua
@@ -54,7 +54,7 @@ function package:registerCommands ()
 
     local function insertChord()
       table.insert(result, self.class.packages.inputfilter:createCommand(
-      content.pos, content.col, content.line,
+      content.pos, content.col, content.lno,
       "ch", { name = chordName }, currentText
       ))
       chordName = nil

--- a/packages/inputfilter/init.lua
+++ b/packages/inputfilter/init.lua
@@ -24,10 +24,10 @@ function package:transformContent (content, transformFunction, extraArgs)
   return newContent
 end
 
-function package.createCommand (_, pos, col, line, command, options, content)
+function package.createCommand (_, pos, col, lno, command, options, content)
   local result = { content }
   result.col = col
-  result.line = line
+  result.lno = lno
   result.pos = pos
   result.options = options
   result.command = command

--- a/packages/url/init.lua
+++ b/packages/url/init.lua
@@ -87,30 +87,30 @@ function package:registerCommands ()
         if string.find(preferBreakBefore, escapeRegExpMinimal(token.separator)) then
           -- Accepts breaking before, and at the extreme worst after.
           result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.line,
+          content.pos, content.col, content.lno,
           "penalty", { penalty = options.primaryPenalty }
           )
           result[#result+1] = token.separator
           result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.line,
+          content.pos, content.col, content.lno,
           "penalty", { penalty = options.worsePenalty }
           )
         elseif token.separator == alwaysBreakAfter then
           -- Accept breaking after (only).
           result[#result+1] = token.separator
           result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.line,
+          content.pos, content.col, content.lno,
           "penalty", { penalty = options.primaryPenalty }
           )
         else
           -- Accept breaking after, but tolerate breaking before.
           result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.line,
+          content.pos, content.col, content.lno,
           "penalty", { penalty = options.secondaryPenalty }
           )
           result[#result+1] = token.separator
           result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.line,
+          content.pos, content.col, content.lno,
           "penalty", { penalty = options.primaryPenalty }
           )
         end


### PR DESCRIPTION
Closes #1637

Please do sanity check me on this one @Omikhleia. This completely moves the cheese around but I think it makes more sense overall and likely fixes your use case of a different inputter. I moved the check for leading/trailing junk that was specific to SIL to the SIL inputter. I also reworked the check for a document to potentially wrap loose leaves which should make document fragments more viable with no top level tags. It won't necessarily sniff but it should parse if asked to explicitly. In the process the expecations about top level tags changed, so XML no longer has to add an extra level of nesting it just runs with whatever the top level is. Of course this changed all the unit test expecations, but the change seems way saner than the original.

Am I breaking it or fixing it?
