### PR TITLE
Add hfill-command parameter to TOC

### DIFF
--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -97,6 +97,15 @@ function package:_init ()
   self:deprecatedExport("moveTocNodes", self.moveTocNodes)
 end
 
+function package.declareSettings (_)
+  SILE.settings:declare({
+    parameter = "tableofcontents.hfill-command",
+    type = "string",
+    default = "dotfill",
+    help = "The sile command used to fill the space between a TOC entry and the corresponding page number"
+  })
+end
+
 function package:registerCommands ()
 
   self:registerCommand("tableofcontents", function (options, _)
@@ -136,7 +145,7 @@ function package:registerCommands ()
           end
         end)
         SILE.process(content)
-        SILE.call("dotfill")
+        SILE.call(SILE.settings:get("tableofcontents.hfill-command"))
         SILE.typesetter:typeset(options.pageno)
       end)
       )


### PR DESCRIPTION
This PR adds the parameter `tableofcontents.hfill-command` to control the way the space between the TOC entry and the page number is filled.
By default this is `dotfill` which is the original behavior. But now it is trivially to change the setting inside e.g. `tableofcontents:level1item` to create different fill styles for the TOC levels:

![image](https://user-images.githubusercontent.com/15750438/206566601-826b7e25-b2c5-4a50-9fbf-48acde05e6a2.png)
