### PR TITLE
bibtex package: Fix \cite{key}

### DIFF
--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -90,7 +90,7 @@ function package:registerCommands ()
   end)
 
   self:registerCommand("cite", function (options, content)
-    if not options.key then options.key = content[1] end
+    if not options.key then options.key = SU.contentToString(content) end
     local style = SILE.settings:get("bibtex.style")
     local bibstyle = require("packages.bibtex.styles." .. style)
     local cite = Bibliography.produceCitation(options, SILE.scratch.bibtex.bib, bibstyle)


### PR DESCRIPTION
Really tiny code change to make the bibtex packe work with LaTeX-style citations.
Before, `\cite{abc}` errored with:
`Using code at: ./packages/bibtex/init.lua:98: attempt to concatenate a table value (field 'key')`

Unsure if this is the right approach to fix this, so I am open to further suggestions.