### PR TITLE
fix(shaper): Respect variations when shaping (#1265)

### DIFF
--- a/src/justenoughharfbuzz.c
+++ b/src/justenoughharfbuzz.c
@@ -152,8 +152,6 @@ int shape (lua_State *L) {
     if (strlen(shaper_list_string) > 0) {
       shaper_list = scan_shaper_list(shaper_list_string);
     }
-    hb_segment_properties_t segment_props;
-    hb_shape_plan_t *shape_plan;
 
     hb_direction_t direction;
     hb_feature_t* features;
@@ -198,9 +196,7 @@ int shape (lua_State *L) {
     hb_buffer_set_language(buf, hb_language_from_string(lang,strlen(lang)));
 
     hb_buffer_guess_segment_properties(buf);
-    hb_buffer_get_segment_properties(buf, &segment_props);
-    shape_plan = hb_shape_plan_create_cached(hbFace, &segment_props, features, nFeatures, shaper_list);
-    int res = hb_shape_plan_execute(shape_plan, hbFont, buf, features, nFeatures);
+    int res = hb_shape_full (hbFont, buf, features, nFeatures, shaper_list);
 
     if (direction == HB_DIRECTION_RTL) {
       hb_buffer_reverse(buf); /* URGH */
@@ -282,7 +278,6 @@ int shape (lua_State *L) {
     hb_font_destroy(hbFont);
     hb_face_destroy(hbFace);
     hb_blob_destroy(blob);
-    hb_shape_plan_destroy(shape_plan);
 
     free(features);
     return glyph_count;


### PR DESCRIPTION
Use `hb_shape_full()` instead of fiddling with shape planes as `hb_shape_plan_create_cached()` ignores variations set on the font (one needs to use `hb_shape_plan_create_cached2()`), but `hb_shape_full()` does all that for us and there is no need to re-implement it.

Fixes https://github.com/sile-typesetter/sile/issues/1265