### PR TITLE
Correct coverage stats

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,6 +72,6 @@ jobs:
       - name: Report test coverage
         if: success()
         continue-on-error: true
-        run: luacov-coveralls -e .luarocks -e lua_modules -e lua-libraries -e /home/runner
+        run: luacov-coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,10 @@
+exclude = {
+	".luarocks",
+	"lua_modules",
+	"lua%-libraries",
+	"home/runner",
+	"usr/share",
+	".+_spec",
+	"tests"
+}
+includeuntestedfiles = true


### PR DESCRIPTION
It turns out I got coverage reporting working again lately but it was only calculating coverage based on the files that actually reported some coverage. Files that didn't get loaded at all during testing didn't get included in the total. This should give us a better idea of where we are at percentage wise but also the reports detail what files aren't being tested at all and hence need tests to be added.