### PR TITLE
feat(packages): New scalebox package for arbitrary box re-scaling

### DIFF
--- a/packages/scalebox/init.lua
+++ b/packages/scalebox/init.lua
@@ -1,0 +1,80 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "scalebox"
+
+function package:registerCommands ()
+
+  self:registerCommand("scalebox", function(options, content)
+    if SILE.outputter._name ~= "libtexpdf" then
+      SU.warn("Output will not be scaled: \\scalebox only works with the libtexpdf backend")
+      return SILE.process(content)
+    end
+    SILE.outputter:_ensureInit()
+    local pdf = require("justenoughlibtexpdf")
+
+    local hbox = SILE.call("hbox", {}, content)
+    table.remove(SILE.typesetter.state.nodes) -- Remove the box from queue
+    local xratio, yratio = SU.cast("number", options.xratio) or 1, SU.cast("number", options.yratio) or 1
+    if xratio == 0 or yratio == 0 then
+      SU.error("Scaling ratio cannot be null")
+    end
+
+    local W = hbox.width * math.abs(xratio)
+    local H, D
+    if yratio > 0 then
+      H = hbox.height * yratio
+      D = hbox.depth * yratio
+    else
+      H = hbox.depth * -yratio
+      D = hbox.height * -yratio
+    end
+
+    SILE.typesetter:pushHbox({
+      width = W,
+      height = H,
+      depth = D,
+      outputYourself = function(node, typesetter, line)
+        local outputWidth = SU.rationWidth(node.width, node.width, line.ratio)
+        local X = typesetter.frame.state.cursorX
+        local Y = typesetter.frame.state.cursorY
+        local x0 = X:tonumber()
+        local y0 = -Y:tonumber()
+
+        if xratio < 0 then
+          typesetter.frame:advanceWritingDirection(-outputWidth)
+        end
+        pdf:gsave()
+        pdf.setmatrix(1, 0, 0, 1, x0, y0)
+        pdf.setmatrix(xratio, 0, 0, yratio, 0, 0)
+        pdf.setmatrix(1, 0, 0, 1, -x0, -y0)
+        hbox.outputYourself(hbox, typesetter, line)
+        pdf:grestore()
+        typesetter.frame.state.cursorX = X
+        typesetter.frame.state.cursorY = Y
+        typesetter.frame:advanceWritingDirection(outputWidth)
+      end
+    })
+  end, "Scale content by some horizontal and vertical ratios")
+
+end
+
+package.documentation = [[
+\begin{document}
+The \autodoc:package{scalebox} package allows to scale any content by some horizontal
+and vertical ratios, by issuing the command
+\autodoc:command{\scalebox[xratio=<number>, yratio=<number>]{<content>}},
+where the ratios are optional non-null numbers (defaulting to 1).
+The content is placed in a box and scaled.
+
+Here is an \scalebox[xratio=0.75, yratio=1.25]{example}.
+
+The previous line was produced by the following code:
+
+\begin[type=autodoc:codeblock]{raw}
+Here is an \scalebox[xratio=0.75, yratio=1.25]{example}.
+\end{raw}
+\end{document}
+]]
+
+return package


### PR DESCRIPTION
Closes #1178

EDIT: Also Closes #1035 (see comments below)

Box re-scaling via PDF transformation matrix:

`\scalebox[xratio=<number>, yratio=<number>]{<content>}`

_Rationale_

Both @ctrlcctrlv and @alerque in the above-mentioned issue said it should be proposed to the core distribution... So here it is, basic logic extracted from textsubsuper.sile and re-vamped as as standalone package.

_Caveats_
- It's only tested (see below) in LTR writing direction: Checking RTL and vertical writing directions is left as an exercise to readers who know how to use these.
- It's using the "hbox stealing trick": When/if #1702 makes it, it is left as an exercise to adapt the code so that migrating contents are honored.
- It is also left as an exercise where to include the package documentation in the manual.

![image](https://user-images.githubusercontent.com/18075640/216773973-bdabf30b-c23d-4fb4-aeef-2df4b237f9ae.png)

The first series of lines just demonstrate the basic feature. The second series ensures line stretching/shrinking is correctly applied. The very last line is just for the show. 

Example code attached as .txt so it can be uploaded here:
[feat-scalebox.txt](https://github.com/sile-typesetter/sile/files/10608913/feat-scalebox.txt)
