### PR TITLE
Avoid justification issues with relative parindent

### DIFF
--- a/classes/base.lua
+++ b/classes/base.lua
@@ -513,7 +513,19 @@ end
 
 -- WARNING: not called as class method
 function class.newPar (typesetter)
-  typesetter:pushGlue(SILE.settings:get("current.parindent") or SILE.settings:get("document.parindent"))
+  local parindent = SILE.settings:get("current.parindent") or SILE.settings:get("document.parindent")
+  -- See https://github.com/sile-typesetter/sile/issues/1361
+  -- The parindent *cannot* be pushed non-absolutized, as it may be evaluated
+  -- outside the (possibly temporary) setting scope where it was used for line
+  -- breaking.
+  -- Early absolutization can be problematic sometimes, but here we do not
+  -- really have the choice.
+  -- As of problematic cases, consider a parindent that would be defined in a
+  -- frame-related unit (%lw, %fw, etc.). If a frame break occurs and the next
+  -- frame has a different width, the parindent won't be re-evaluated in that
+  -- new frame context. However, defining a parindent in such a unit is quite
+  -- unlikely. And anyway pushback() has plenty of other issues.
+  typesetter:pushGlue(parindent:absolute())
   SILE.settings:set("current.parindent", nil)
   local hangIndent = SILE.settings:get("current.hangIndent")
   if hangIndent then


### PR DESCRIPTION
Closes #1361 

We sat too long without addressing this problem, but it's not acceptable to still fail justifying a text when a font-relative parindent is used (e.g. 1.25em).

Most typographers actually recommend using such a relative parindent, rather than the current default fixed 20pt setting...[^1]

E.g. Lacroux, _Orthotypographie_, discussing Lefevre (1855) and the traditional value of 1em (my quick and approximate translation from French):
> In “ordinary” or balanced compositions (font size, letter spacing and line spacing all well suited for justification, use
> of a "reasonable" font family), the traditional indent of one em-space seems appropriate to me. However, typographic
> art is pleasing in the fact that it combines rigid conventions and the freedom to cheerfully escape them. (...)
> However, in certain "more or less disproportionate" compositions (examples: text block too small for proper justification),
> it makes sense to increase the value of the paragraph indent up to one em-space and a half, or even two em-spaces. (...) 
> The paragraph should not be petty: one will never attribute to the indentation less than one em-space.

Here is therefore, IMHO, a **reasonable** fix for that "(too) late absolutizing" issue.[^2]

[^1]: Why SILE has this idiosyncratic default 20pt value is another question! I will not address it here. As for the default inter-word spacing #1371, changing it now would break some tests... But at one point towards 1.0, revisiting all defaults for sane values would be nice...

[^2]: To be really honest, the only edge case I can imagine is when defining the parindent in some frame-relative unit (e.g. 5%lw) _and_ a page break occurs _and_ the next frame has a different width. But I don't think one would likely use such frame-relative units here (contradicting all typographers for some obscure reasons). It makes a lot of "and" conditions for such an improbable edge case---Our "pushback()" logic already has a lot of troubles to cope with, and trying to solve this weird improbable edge case, a choice of bad taste, is not worth the effort... I tried, though, but I could never work out a more general approach to "late" vs. "early" absolutizing (briefly mentioned in the original issue). It proved too deeply entangled in the inner workings of SILE. 