### PR TITLE
fix(packages): Text conversion in bookmarks has spacing issues

### DIFF
--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -83,7 +83,7 @@ local function _nodesToText (nodes)
     end
   end
   -- Trim leading and trailing spaces, and simplify internal spaces.
-  return string:match("^%s*(.-)%s*$"):gsub("%s+", " ")
+  return pl.stringx.strip(string):gsub("%s%s+", " ")
 end
 
 if not SILE.scratch.pdf_destination_counter then


### PR DESCRIPTION
Several small points:
 - Kerns were overlooked and ignored with a warning.
 - Kerns and glues were always converted to a space, but "small" enough kerns/glues should rather be ignored. E.g. using a small adjustement kern for pseudo-italic correction shouldn't result in a space, although the logic cannot be anything else but heuristic.
 - Resulting string was not trimmed, and could contain repeated internal spaces.

N.B. back-porting this from a bunch of pending fixes I have for my resilient.tableofcontents too.
(I really think the nodeToText function should be moved into the utilities, but this is a separate topic.)