### PR TITLE
Enforce slightly better type casts in utilities

### DIFF
--- a/classes/base.lua
+++ b/classes/base.lua
@@ -127,7 +127,7 @@ function class.declareSettings (_)
   })
   SILE.settings:declare({
     parameter = "current.hangIndent",
-    type = "integer or nil",
+    type = "measurement or nil",
     default = nil,
     help = "Size of hanging indent"
   })


### PR DESCRIPTION
Two little proposals:

`SU.boolean` now errors on anything that is not true, false, "true", "false", "yes", "no" and nil --> IMHO, it helps avoid typos to remain unnoticed and possibly evaluated to the default value.

- `SU.cast` now warns on `SU.cast("integer", somefloatvalue)` --> IMHO it helps reporting where the code really expected an integer.
   - But it does not warn, e.g. on "integer or number" (this was implied by the previous code, though it's not that useful!)
   - And it only warns, but does not error, as it's hard to be sure we wouldn't break some packages (and what is the actual issue there, whether integer was really expected or not).

And following upon that, an actual type consistency fix (`current.hangIndent` vs. `linebreak.hangIndent`). It doesn't mean there aren't others, they could have remained unnoticed (for things not covered by tests and not used in the manual).

I found the proposed checks better and handy on my own 3rd party packages (... where I had some unnoticed incorrect types indeed!).