### PR TITLE
ci(build): Get libtexpdf into build using flake inputs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,7 +46,7 @@ task:
     - ./bootstrap.sh
   configure_script: |
     ./configure MAKE=gmake \
-      --enable-developer LUAROCKS=false LUACHECK=false BUSTED=false \
+      --enable-developer LUAROCKS=false LUACHECK=false BUSTED=false NIX=false \
       --disable-font-variations \
       --with-system-luarocks \
       --without-manual

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           ./bootstrap.sh
           ./configure \
-            --enable-developer LUACHECK=false \
+            --enable-developer LUACHECK=false NIX=false \
             --disable-font-variations \
             --without-system-luarocks \
             --with-luajit \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           ./bootstrap.sh
           ./configure \
-            --enable-developer LUACHECK=false \
+            --enable-developer LUACHECK=false NIX=false \
             --disable-font-variations \
             --without-system-luarocks \
             --with${{ startsWith(matrix.luaVersion[0], '5') && 'out' || '' }}-luajit \

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ EXTRA_DIST = spec tests documentation sile-dev-1.rockspec fontconfig.conf
 EXTRA_DIST += Makefile-distfiles
 EXTRA_DIST += build-aux/action-updater.js build-aux/decore-automake.sh build-aux/git-version-gen build-aux/list-dist-files.sh
 EXTRA_DIST += Dockerfile build-aux/docker-bootstrap.sh build-aux/docker-fontconfig.conf hooks/build
-EXTRA_DIST += default.nix flake.nix flake.lock libtexpdf.git-rev shell.nix
+EXTRA_DIST += default.nix flake.nix flake.lock shell.nix
 EXTRA_DIST += package.json # imported by both Nix and Docker
 EXTRA_DIST += $(MANUAL)
 
@@ -84,9 +84,6 @@ _BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null ||:
 		./build-aux/git-version-gen "$(srcdir)/.tarball-version" > $@; \
 		cmp -s "$@" "$@-prev" || ( autoreconf configure.ac --force && build-aux/decore-automake.sh ); \
 	fi
-
-libtexpdf.git-rev: $(_BRANCH_REF)
-	$(GIT) submodule status -- libtexpdf | $(AWK) '{ print $$1 }' > $@
 
 dist-hook: $(MANUAL)
 	cd $(distdir)
@@ -130,8 +127,8 @@ sile-%.md: CHANGELOG.md
 update_libtexpdf:
 	$(GIT) diff-index --quiet --cached HEAD || exit 1 # die if anything already staged
 	$(GIT) submodule update --init --remote -- libtexpdf
-	$(GIT) submodule status -- libtexpdf | $(AWK) '{ print $$1 }' > libtexpdf.git-rev
-	$(GIT) add -- libtexpdf libtexpdf.git-rev
+	$(NIX) flake lock --override-input libtexpdf-src github:sile-typesetter/libtexpdf/$(shell $(GIT) submodule status -- libtexpdf | awk '{print $$1}')
+	$(GIT) add -- libtexpdf flake.lock
 	$(GIT) diff-index --quiet --cached HEAD || $(GIT) commit -m "chore(build): Pin latest libtexpdf library submodule"
 
 DEPDIR := .deps

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,7 @@ AM_COND_IF([DEPENDENCY_CHECKS], [
         AX_PROGVAR([busted])
         AX_PROGVAR([luacheck])
         AX_PROGVAR([luarocks])
+        AX_PROGVAR([nix])
         AX_PROGVAR([perl])
     ])
 

--- a/flake.lock
+++ b/flake.lock
@@ -51,6 +51,22 @@
         "type": "github"
       }
     },
+    "libtexpdf-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1662109873,
+        "narHash": "sha256-yThIb+D/m1xeJZESojRd3u4OugbWl7f2s8oJohspwZs=",
+        "owner": "sile-typesetter",
+        "repo": "libtexpdf",
+        "rev": "736a5e7530c13582ea704a061a358d0caa774916",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sile-typesetter",
+        "repo": "libtexpdf",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1674487464,
@@ -72,6 +88,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
+        "libtexpdf-src": "libtexpdf-src",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -69,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674487464,
-        "narHash": "sha256-Jgq50e4S4JVCYpWLqrabBzDp/1mfaxHCh8/OOorHTy0=",
+        "lastModified": 1682109806,
+        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3954218cf613eba8e0dcefa9abe337d26bc48fd0",
+        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
         "type": "github"
       },
       "original": {
@@ -90,6 +93,21 @@
         "gitignore": "gitignore",
         "libtexpdf-src": "libtexpdf-src",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,13 @@
     url = "github:hercules-ci/gitignore.nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
+  # TODO: Should this be replaced with libtexpdf package from nixpkgs? or
+  # should we keep it that way, so that it'd be easy to test new versions
+  # of libtexpdf when developing?
+  inputs.libtexpdf-src = {
+    url = "github:sile-typesetter/libtexpdf";
+    flake = false;
+  };
 
   # https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix
   inputs.flake-compat = {
@@ -20,18 +27,12 @@
     , flake-utils
     , flake-compat
     , gitignore
+    , libtexpdf-src
   }:
   flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs {
         inherit system;
-      };
-      # TODO: Should this be replaced with libtexpdf package from nixpkgs? or
-      # should we keep it that way, so that it'd be easy to test new versions
-      # of libtexpdf when developing?
-      libtexpdf-src = builtins.fetchGit {
-        url = "https://github.com/sile-typesetter/libtexpdf";
-        rev = "${(pkgs.lib.fileContents "${self}/libtexpdf.git-rev")}";
       };
       inherit (gitignore.lib) gitignoreSource;
       # https://discourse.nixos.org/t/passing-git-commit-hash-and-tag-to-build-with-flakes/11355/2

--- a/libtexpdf.git-rev
+++ b/libtexpdf.git-rev
@@ -1,1 +1,0 @@
-d1030b48014adcb09d41dae20cc8fccd4a77a04e


### PR DESCRIPTION
After experimenting with building projects that depend on git submodules, I reached the conclusion that this is the most comfortable way of handling such dependencies. You may like this approach since updating `libtexpdf` for the flakes will only require:

```
nix flake update
```

and the above will also update libtexpdf to it's latest version. Using a specific version of libtexpdf is possible using:

```
nix build --override-input libtexpdf-src "github:sile-typesetter/libtexpdf/my_feature_branch"
```

You can also do the above while disabling changing the `flake.lock` file:

```
nix build --override-input libtexpdf-src "github:sile-typesetter/libtexpdf/my_feature_branch" --no-write-lock-file
```

