### PR TITLE
Fix --makedeps to play along without explicit --output

### DIFF
--- a/core/makedeps.lua
+++ b/core/makedeps.lua
@@ -29,7 +29,7 @@ local makeDeps = {
     end
     local depfile, err = io.open(self.filename, "w")
     if not depfile then return SU.error(err) end
-    depfile:write(SILE.outputFilename .. ": " .. tostring(self._deps) .. "\n")
+    depfile:write(SILE.outputter:getOutputFilename() .. ": " .. tostring(self._deps) .. "\n")
     depfile:close()
   end
 }

--- a/outputters/base.lua
+++ b/outputters/base.lua
@@ -34,10 +34,20 @@ function outputter.debugFrame (_, _, _) end
 
 function outputter.debugHbox (_, _, _) end
 
-function outputter.getOutputFilename (_, ext)
-  if SILE.outputFilename then return SILE.outputFilename end
-  if SILE.masterFilename then return SILE.masterFilename .. "." .. ext end
-  SU.error("Cannot guess output filename without an input name")
+function outputter:getOutputFilename ()
+  local fname
+  if SILE.outputFilename then
+    fname = SILE.outputFilename
+  elseif SILE.masterFilename then
+    fname = SILE.masterFilename
+    if self.extension then
+      fname = fname .. "." .. self.extension
+    end
+  end
+  if not fname then
+    SU.error("Cannot guess output filename without an input name")
+  end
+  return fname
 end
 
 return outputter

--- a/outputters/cairo.lua
+++ b/outputters/cairo.lua
@@ -19,9 +19,10 @@ local sgs
 
 local outputter = pl.class(base)
 outputter._name = "cairo"
+outputter.extension = "pdf"
 
 function outputter:_init ()
-  local fname = self:getOutputFilename("pdf")
+  local fname = self:getOutputFilename()
   local surface = cairolgi.PdfSurface.create(fname == "-" and "/dev/stdout" or fname, SILE.documentState.paperSize[1], SILE.documentState.paperSize[2])
   cr = cairolgi.Context.create(surface)
   move = cr.move_to

--- a/outputters/debug.lua
+++ b/outputters/debug.lua
@@ -24,6 +24,7 @@ end
 
 local outputter = pl.class(base)
 outputter._name = "debug"
+outputter.extension = "debug"
 
 -- The outputter init can't actually initialize output (as logical as it might
 -- have seemed) because that requires a page size which we don't know yet.
@@ -32,7 +33,7 @@ outputter._name = "debug"
 function outputter:_ensureInit ()
   if not started then
     started = true -- keep this before self:_writeline or it will be a race condition!
-    local fname = self:getOutputFilename("debug")
+    local fname = self:getOutputFilename()
     outfile = fname == "-" and io.stdout or io.open(fname, "w+")
     if SILE.documentState.paperSize then
       self:_writeline("Set paper size ", SILE.documentState.paperSize[1], SILE.documentState.paperSize[2])

--- a/outputters/dummy.lua
+++ b/outputters/dummy.lua
@@ -2,12 +2,6 @@ local base = require("outputters.base")
 
 local outputter = pl.class(base)
 outputter._name = "dummy"
-
--- Most of the base outputter functions are just empty prototypes, but for the
--- few that actually do something override them...
-
-local _dummy = function () end
-
-outputter.getOutputFilename = _dummy
+outputter.extension = "dummy"
 
 return outputter

--- a/outputters/libtexpdf.lua
+++ b/outputters/libtexpdf.lua
@@ -20,6 +20,7 @@ local _font
 
 local outputter = pl.class(base)
 outputter._name = "libtexpdf"
+outputter.extension = "pdf"
 
 -- The outputter init can't actually initialize output (as logical as it might
 -- have seemed) because that requires a page size which we don't know yet.
@@ -28,7 +29,7 @@ outputter._name = "libtexpdf"
 function outputter:_ensureInit ()
   if not started then
     local w, h = SILE.documentState.paperSize[1], SILE.documentState.paperSize[2]
-    local fname = self:getOutputFilename("pdf")
+    local fname = self:getOutputFilename()
     pdf.init(fname == "-" and "/dev/stdout" or fname, w, h, SILE.full_version)
     pdf.beginpage()
     started = true

--- a/outputters/podofo.lua
+++ b/outputters/podofo.lua
@@ -17,10 +17,10 @@ local lastkey
 
 local podofoFaces = {}
 
-local outputer = pl.class(base)
-outputer._name = "podofo"
+local outputter = pl.class(base)
+outputter._name = "podofo"
 
-function outputer._init (_)
+function outputter._init (_)
   document = pdf.PdfMemDocument()
   pagesize = pdf.PdfRect()
   pagesize:SetWidth(SILE.documentState.paperSize[1])
@@ -30,33 +30,33 @@ function outputer._init (_)
   painter:SetPage(page)
 end
 
-function outputer.newPage (_)
+function outputter.newPage (_)
   painter:FinishPage()
   page = document:CreatePage(pagesize)
   painter:SetPage(page)
 end
 
-function outputer:finish ()
+function outputter:finish ()
   painter:FinishPage()
   local fname = self:getOutputFilename("pdf")
   document:Write(fname == "-" and "/dev/stdout" or fname)
 end
 
-function outputer.getCursor (_)
+function outputter.getCursor (_)
   return cursorX, cursorY
 end
 
-function outputer.setCursor (_, x, y, relative)
+function outputter.setCursor (_, x, y, relative)
   local offset = relative and { x = cursorX, y = cursorY } or { x = 0, y = 0 }
   cursorX = offset.x + x
   cursorY = offset.y + SILE.documentState.paperSize[2] - y
 end
 
-function outputer.setColor (_, color)
+function outputter.setColor (_, color)
   painter:SetColor(color.r, color.g, color.b)
 end
 
-function outputer:drawHbox (value, _)
+function outputter:drawHbox (value, _)
   local x, y = self:getCursor()
   if not value.glyphNames then return end
   for i = 1, #(value.glyphNames) do
@@ -64,7 +64,7 @@ function outputer:drawHbox (value, _)
   end
 end
 
-function outputer.setFont (_, options)
+function outputter.setFont (_, options)
   if SILE.font._key(options) == lastkey then return end
   lastkey = SILE.font._key(options)
   if not podofoFaces[lastkey] then
@@ -78,7 +78,7 @@ function outputer.setFont (_, options)
   SILE.fontCache[lastkey] = nil
 end
 
-function outputer.getImageSize (_, src)
+function outputter.getImageSize (_, src)
   local box_width, box_height, err = imagesize.imgsize(src)
   if not box_width then
     SU.error(err.." loading image")
@@ -86,13 +86,13 @@ function outputer.getImageSize (_, src)
   return box_width, box_height
 end
 
-function outputer.drawRule (_, x, y, width, depth)
+function outputter.drawRule (_, x, y, width, depth)
   painter:Rectangle(x, SILE.documentState.paperSize[2] - y, width, depth)
   painter:Close()
   painter:Fill()
 end
 
-function outputer:debugHbox (hbox, scaledWidth)
+function outputter:debugHbox (hbox, scaledWidth)
   painter:SetColor(0.9, 0.9, 0.9)
   painter:SetStrokeWidth(0.5)
   local x, y = self:getCursor()
@@ -103,4 +103,4 @@ function outputer:debugHbox (hbox, scaledWidth)
   --cr:move_to(x, y)
 end
 
-return outputer
+return outputter

--- a/outputters/podofo.lua
+++ b/outputters/podofo.lua
@@ -19,6 +19,7 @@ local podofoFaces = {}
 
 local outputter = pl.class(base)
 outputter._name = "podofo"
+outputter.extension = "pdf"
 
 function outputter._init (_)
   document = pdf.PdfMemDocument()
@@ -38,7 +39,7 @@ end
 
 function outputter:finish ()
   painter:FinishPage()
-  local fname = self:getOutputFilename("pdf")
+  local fname = self:getOutputFilename()
   document:Write(fname == "-" and "/dev/stdout" or fname)
 end
 

--- a/outputters/text.lua
+++ b/outputters/text.lua
@@ -8,6 +8,7 @@ local started = false
 
 local outputter = pl.class(base)
 outputter._name = "text"
+outputter.extension = "txt"
 
 -- The outputter init can't actually initialize output (as logical as it might
 -- have seemed) because that requires a page size which we don't know yet.
@@ -15,7 +16,7 @@ outputter._name = "text"
 
 function outputter:_ensureInit ()
   if not outfile then
-    local fname = self:getOutputFilename("text")
+    local fname = self:getOutputFilename()
     outfile = fname == "-" and io.stdout or io.open(fname, "w+")
   end
 end


### PR DESCRIPTION
Both SILE's own regression suite and CaSILE have happily used this broken feature for a long time because it always specifies --output explicitly, but the --makedeps feature has been broken for a long time because it couldn't derive the correct filename and was trying to
concatenate nil.

(Found while porting CLI to Rust).