### PR TITLE
Avoid stack overflow in Harfbuzz module

### DIFF
--- a/src/justenoughharfbuzz.c
+++ b/src/justenoughharfbuzz.c
@@ -185,7 +185,7 @@ int shape (lua_State *L) {
     }
     glyph_info   = hb_buffer_get_glyph_infos(buf, &glyph_count);
     glyph_pos    = hb_buffer_get_glyph_positions(buf, &glyph_count);
-    lua_checkstack(L, glyph_count);
+    lua_checkstack(L, glyph_count*10);
     for (j = 0; j < glyph_count; ++j) {
       char namebuf[255];
       hb_glyph_extents_t extents = {0,0,0,0};


### PR DESCRIPTION
This bug has been around forever. We've been allocating 1 space on the stack then pushing 8-10 items to it. LuaJIT automatically adjusts. PUC Lua has been using undefined behaviour and just dealing with the stack overflow as long as it didn't get clobbered by anything else. However compiling Lua in debug mode reveals the stack overflow. I ran into this while wrapping SILE in the Rust CLI with embeded mlua interpreter, but it affects all builds so this fix deserves to go in earlier rather than later.

With special thanks to @khvzak for the help debugging.