### PR TITLE
fix(packages): Converters package no longer worked after 0.13.0

### DIFF
--- a/packages/converters/init.lua
+++ b/packages/converters/init.lua
@@ -59,11 +59,12 @@ function package.register (_, sourceExt, targetExt, command)
 end
 
 function package.checkConverters (_, source)
+  local resolvedSrc = SILE.resolveFile(source) or SU.error("Couldn't find file " .. source)
   for _, converter in ipairs(SILE.scratch.converters) do
     local extLen = string.len(converter.sourceExt)
-    if ((string.len(source) > extLen) and
-        (string.sub(source, -extLen) == converter.sourceExt)) then
-      return applyConverter(source, converter)
+    if ((string.len(resolvedSrc) > extLen) and
+        (string.sub(resolvedSrc, -extLen) == converter.sourceExt)) then
+      return applyConverter(resolvedSrc, converter)
     end
   end
   return source -- No conversion needed.
@@ -75,17 +76,23 @@ function package:_init ()
     SILE.scratch.converters = {}
   end
   extendCommand("include", function (options, content, original)
-    local result = self:checkConverters(options.src)
-    if not result then
+    local source = SU.required(options, "src", "include (converters)")
+    local result = self:checkConverters(source)
+    if result then
       options["src"] = result
       original(options, content)
+    else
+      SU.error("Conversion failure for include '" .. source ..'"')
     end
   end)
   extendCommand("img", function (options, content, original)
-    local result = self:checkConverters(options.src)
-    if not result then
+    local source = SU.required(options, "src", "img (converters)")
+    local result = self:checkConverters(source)
+    if result then
       options["src"] = result
       original(options, content)
+    else
+      SU.error("Conversion failure for image '" .. source ..'"')
     end
   end)
   self:deprecatedExport("register", self.register)


### PR DESCRIPTION
Closes #1795

Due an inadvertently inverted check.
Also if wasn't resolving the source file name so could not work with relative paths that would have been acceptable for a resource not needing conversion.

The hardest thing was testing that package... and refraining rewriting it wholly :rofl: 
