### PR TITLE
Hbox fixes for RTL languages

### DIFF
--- a/shapers/base.lua
+++ b/shapers/base.lua
@@ -141,7 +141,7 @@ function shaper:formNnode (contents, token, options)
       nodes = nnodeContents,
       text = token,
       misfit = misfit,
-      options = options,
+      options = pl.tablex.copy(options),
       language = options.language
     })
 end

--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -864,15 +864,6 @@ end
 -- is responsible of doing it, if the hbox is built for anything
 -- else than e.g. measuring it. Likewise, the call has to decide
 -- what to do with the migrating content.
-local _rtl_pre_post = function (box, atypesetter, line)
-  local advance = function () atypesetter.frame:advanceWritingDirection(box:scaledWidth(line)) end
-  if atypesetter.frame:writingDirection() == "RTL" then
-    advance()
-    return function () end
-  else
-    return advance
-  end
-end
 function typesetter:makeHbox (content)
   local recentContribution = {}
   local migratingNodes = {}
@@ -936,7 +927,6 @@ function typesetter:makeHbox (content)
       depth = d,
       value = recentContribution,
       outputYourself = function (box, atypesetter, line)
-        local _post = _rtl_pre_post(box, atypesetter, line)
         local ox = atypesetter.frame.state.cursorX
         local oy = atypesetter.frame.state.cursorY
         SILE.outputter:setCursor(atypesetter.frame.state.cursorX, atypesetter.frame.state.cursorY)
@@ -945,7 +935,7 @@ function typesetter:makeHbox (content)
         end
         atypesetter.frame.state.cursorX = ox
         atypesetter.frame.state.cursorY = oy
-        _post()
+        atypesetter.frame:advanceWritingDirection(box:scaledWidth(line))
         SU.debug("hboxes", function ()
           SILE.outputter:debugHbox(box, box:scaledWidth(line))
           return "Drew debug outline around hbox"


### PR DESCRIPTION
Closes #1796 (for me at least).

I know that `bidi.reorder()` was deprecated, and here I'm trying to export `bidi.splitNodelistIntoBidiRuns()` as well, as I'm not able to find a better way.

Packages that call `typesetter:makeHbox()` and wraps the results somehow are responsible for calling the above two exported functions, as found in the `rules` and `rotate` packages, like so:

```diff
diff --git a/packages/rules/init.lua b/packages/rules/init.lua
index 22f6885..28bb5d1 100644
--- a/packages/rules/init.lua
+++ b/packages/rules/init.lua
@@ -3,6 +3,8 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "rules"
 
+local bidi = require("packages.bidi")
+
 local function getUnderlineParameters ()
   local ot = require("core.opentype-parser")
   local fontoptions = SILE.font.loadDefaults({})
@@ -211,6 +213,8 @@ function package:registerCommands ()
     SU.deprecated("\\boxaround (undocumented)", "\\framebox (package)", "0.12.0")
 
     local hbox, hlist = SILE.typesetter:makeHbox(content)
+    hbox.value = bidi.splitNodelistIntoBidiRuns(hbox.value, SILE.typesetter)
+    hbox.value = bidi.reorder(nil, hbox.value, SILE.typesetter)
     -- Re-wrap the hbox in another hbox responsible for boxing it at output
     -- time, when we will know the line contribution and can compute the scaled width
     -- of the box, taking into account possible stretching and shrinking.
```