### PR TITLE
Make masterFilename what it says on the tin

### DIFF
--- a/classes/base.lua
+++ b/classes/base.lua
@@ -575,9 +575,9 @@ function class:finish ()
   end
   SILE.typesetter:runHooks("pageend") -- normally run by the typesetter
   self:endPage()
-    if SILE.typesetter then
-      assert(SILE.typesetter:isQueueEmpty(), "queues not empty")
-    end
+  if SILE.typesetter then
+    assert(SILE.typesetter:isQueueEmpty(), "queues not empty")
+  end
   SILE.outputter:finish()
   self:runHooks("finish")
 end

--- a/core/makedeps.lua
+++ b/core/makedeps.lua
@@ -25,7 +25,7 @@ local makeDeps = {
   write = function (self)
     self:add_modules()
     if type(self.filename) ~= "string" then
-      self.filename = pl.path.splitext(SILE.masterFilename) .. ".d"
+      self.filename = pl.path.splitext(SILE.input.filenames[1]) .. ".d"
     end
     local depfile, err = io.open(self.filename, "w")
     if not depfile then return SU.error(err) end

--- a/core/makedeps.lua
+++ b/core/makedeps.lua
@@ -25,7 +25,7 @@ local makeDeps = {
   write = function (self)
     self:add_modules()
     if type(self.filename) ~= "string" then
-      self.filename = SILE.masterFilename .. ".d"
+      self.filename = pl.path.splitext(SILE.masterFilename) .. ".d"
     end
     local depfile, err = io.open(self.filename, "w")
     if not depfile then return SU.error(err) end

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -291,7 +291,7 @@ function SILE.processString (doc, format, filename, options)
   -- a specific inputter to use, use it at the exclusion of all content type
   -- detection
   local inputter
-  if filename and pl.path.normcase(pl.path.normpath(filename)) == pl.path.normcase(SILE.masterFilename) and SILE.inputter then
+  if filename and pl.path.normcase(pl.path.normpath(filename)) == pl.path.normcase(SILE.input.filenames[1]) and SILE.inputter then
     inputter = SILE.inputter
   else
     format = format or detectFormat(doc, filename)
@@ -301,7 +301,7 @@ function SILE.processString (doc, format, filename, options)
     inputter = SILE.inputters[format](options)
     -- If we did content detection *and* this is the master file, save the
     -- inputter for posterity and postambles
-    if filename and pl.path.normcase(filename) == SILE.masterFilename then
+    if filename and pl.path.normcase(filename) == pl.path.normcase(SILE.input.filenames[1]) then
       SILE.inputter = inputter
     end
   end
@@ -315,16 +315,15 @@ function SILE.processFile (filename, format, options)
   local doc
   if filename == "-" then
     filename = "STDIN"
-    SILE.masterFilename = "STDIN"
     doc = io.stdin:read("*a")
   else
     -- Turn slashes around in the event we get passed a path from a Windows shell
     filename = filename:gsub("\\", "/")
     if not SILE.masterFilename then
-      SILE.masterFilename = pl.path.normpath(filename)
+      SILE.masterFilename = pl.path.splitext(pl.path.normpath(filename))
     end
-    if SILE.masterFilename and not SILE.masterDir then
-      SILE.masterDir = pl.path.dirname(SILE.masterFilename)
+    if SILE.input.filenames[1] and not SILE.masterDir then
+      SILE.masterDir = pl.path.dirname(SILE.input.filenames[1])
     end
     if SILE.masterDir and SILE.masterDir:len() >= 1 then
       _G.extendSilePath(SILE.masterDir)
@@ -462,7 +461,7 @@ function SILE.finish ()
   end
   if SU.debugging("profile") then
     ProFi:stop()
-    ProFi:writeReport(pl.path.splitext(SILE.masterFilename) .. '.profile.txt')
+    ProFi:writeReport(pl.path.splitext(SILE.input.filenames[1]) .. '.profile.txt')
   end
   if SU.debugging("versions") then
     SILE.shaper:debugVersions()

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -291,7 +291,7 @@ function SILE.processString (doc, format, filename, options)
   -- a specific inputter to use, use it at the exclusion of all content type
   -- detection
   local inputter
-  if filename and pl.path.splitext(pl.path.normcase(filename)) == SILE.masterFilename and SILE.inputter then
+  if filename and pl.path.normcase(pl.path.normpath(filename)) == pl.path.normcase(SILE.masterFilename) and SILE.inputter then
     inputter = SILE.inputter
   else
     format = format or detectFormat(doc, filename)
@@ -301,7 +301,7 @@ function SILE.processString (doc, format, filename, options)
     inputter = SILE.inputters[format](options)
     -- If we did content detection *and* this is the master file, save the
     -- inputter for posterity and postambles
-    if filename and pl.path.splitext(pl.path.normcase(filename)) == SILE.masterFilename then
+    if filename and pl.path.normcase(filename) == SILE.masterFilename then
       SILE.inputter = inputter
     end
   end
@@ -321,11 +321,10 @@ function SILE.processFile (filename, format, options)
     -- Turn slashes around in the event we get passed a path from a Windows shell
     filename = filename:gsub("\\", "/")
     if not SILE.masterFilename then
-      -- Strip extension
-      SILE.masterFilename = string.match(filename, "(.+)%..-$") or filename
+      SILE.masterFilename = pl.path.normpath(filename)
     end
     if SILE.masterFilename and not SILE.masterDir then
-      SILE.masterDir = SILE.masterFilename:match("(.-)[^%/]+$")
+      SILE.masterDir = pl.path.dirname(SILE.masterFilename)
     end
     if SILE.masterDir and SILE.masterDir:len() >= 1 then
       _G.extendSilePath(SILE.masterDir)
@@ -463,7 +462,7 @@ function SILE.finish ()
   end
   if SU.debugging("profile") then
     ProFi:stop()
-    ProFi:writeReport(SILE.masterFilename..'.profile.txt')
+    ProFi:writeReport(pl.path.splitext(SILE.masterFilename) .. '.profile.txt')
   end
   if SU.debugging("versions") then
     SILE.shaper:debugVersions()

--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -496,7 +496,7 @@ Here is a function to be called by the \code{finish} output routine:
 function package.writeToc (_)
   -- (Simplified from the actual implementation.)
   local tocdata = pl.pretty.write(SILE.scratch.tableofcontents)
-  local tocfile, err = io.open(SILE.masterFilename .. '.toc', "w")
+  local tocfile, err = io.open(pl.path.splitext(SILE.masterFilename) .. '.toc', "w")
   if not tocfile then return SU.error(err) end
   tocfile:write("return " .. tocdata)
   tocfile:close()

--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -496,7 +496,7 @@ Here is a function to be called by the \code{finish} output routine:
 function package.writeToc (_)
   -- (Simplified from the actual implementation.)
   local tocdata = pl.pretty.write(SILE.scratch.tableofcontents)
-  local tocfile, err = io.open(pl.path.splitext(SILE.masterFilename) .. '.toc', "w")
+  local tocfile, err = io.open(pl.path.splitext(SILE.input.filenames[1]) .. '.toc', "w")
   if not tocfile then return SU.error(err) end
   tocfile:write("return " .. tocdata)
   tocfile:close()

--- a/outputters/base.lua
+++ b/outputters/base.lua
@@ -38,8 +38,8 @@ function outputter:getOutputFilename ()
   local fname
   if SILE.outputFilename then
     fname = SILE.outputFilename
-  elseif SILE.masterFilename then
-    fname = pl.path.splitext(SILE.masterFilename)
+  elseif SILE.input.filenames[1] then
+    fname = pl.path.splitext(SILE.input.filenames[1])
     if self.extension then
       fname = fname .. "." .. self.extension
     end

--- a/outputters/base.lua
+++ b/outputters/base.lua
@@ -39,7 +39,7 @@ function outputter:getOutputFilename ()
   if SILE.outputFilename then
     fname = SILE.outputFilename
   elseif SILE.masterFilename then
-    fname = SILE.masterFilename
+    fname = pl.path.splitext(SILE.masterFilename)
     if self.extension then
       fname = fname .. "." .. self.extension
     end

--- a/packages/cropmarks/init.lua
+++ b/packages/cropmarks/init.lua
@@ -64,7 +64,7 @@ end
 function package:registerCommands ()
 
   self:registerCommand("crop:header", function (_, _)
-    local info = SILE.masterFilename .. " - " .. self.class:date("%x %X") .. " -  " .. outcounter
+    local info = SILE.input.filenames[1] .. " - " .. self.class:date("%x %X") .. " -  " .. outcounter
     SILE.typesetter:typeset(info)
   end)
 

--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -19,7 +19,7 @@ end
 
 function package.writeToc (_)
   local tocdata = pl.pretty.write(SILE.scratch.tableofcontents)
-  local tocfile, err = io.open(pl.path.splitext(SILE.masterFilename) .. '.toc', "w")
+  local tocfile, err = io.open(pl.path.splitext(SILE.input.filenames[1]) .. '.toc', "w")
   if not tocfile then return SU.error(err) end
   tocfile:write("return " .. tocdata)
   tocfile:close()
@@ -34,7 +34,7 @@ function package.readToc (_)
     -- already loaded
     return SILE.scratch._tableofcontents
   end
-  local tocfile, _ = io.open(pl.path.splitext(SILE.masterFilename) .. '.toc')
+  local tocfile, _ = io.open(pl.path.splitext(SILE.input.filenames[1]) .. '.toc')
   if not tocfile then
     return false -- No TOC yet
   end

--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -19,7 +19,7 @@ end
 
 function package.writeToc (_)
   local tocdata = pl.pretty.write(SILE.scratch.tableofcontents)
-  local tocfile, err = io.open(SILE.masterFilename .. '.toc', "w")
+  local tocfile, err = io.open(pl.path.splitext(SILE.masterFilename) .. '.toc', "w")
   if not tocfile then return SU.error(err) end
   tocfile:write("return " .. tocdata)
   tocfile:close()
@@ -34,7 +34,7 @@ function package.readToc (_)
     -- already loaded
     return SILE.scratch._tableofcontents
   end
-  local tocfile, _ = io.open(SILE.masterFilename .. '.toc')
+  local tocfile, _ = io.open(pl.path.splitext(SILE.masterFilename) .. '.toc')
   if not tocfile then
     return false -- No TOC yet
   end


### PR DESCRIPTION
Closes #1833.

As far as SILE itself is concerned this shouldn't be noticed, but that's not to say documents or other project code that generates files and assumes that `masterFilename` is a basename not a file name won't be affected. I had in mind to put this in the next breaking release just to be safe, but given the current situation I'm not sure adding more hacks to work around this silly problem in the short term knowing we want to fix it properly anyway makes sense either.

This will break CaSILE but I'll fix that. I don't know if any other 3rd party extensions will be affected.

@Omikhleia does this change make sense to you?
