### PR TITLE
Replace '~' to ' ' as a non-breaking space in bibliography.lua

### DIFF
--- a/packages/bibtex/bibliography.lua
+++ b/packages/bibtex/bibliography.lua
@@ -69,7 +69,7 @@ local function namesplit(str)
 end
 
 local sep_and_not_tie = '%-'
-local sep_chars = sep_and_not_tie .. '%~'
+local sep_chars = sep_and_not_tie .. '% '
 
 local parse_name
 do
@@ -238,10 +238,10 @@ do
             -- <possibly adjust [[sep]] and [[ssep]] according to token position and size>=
             if not string.find(sep, sep_char) then
               if i == lim-1 then
-                sep, ssep = '~', '~'
+                sep, ssep = ' ', ' '
               elseif i == start + 1 then
-                sep  = string.len(shortname)  < 3 and '~' or ' '
-                ssep = string.len(longname) < 3 and '~' or ' '
+                sep  = string.len(shortname)  < 3 and ' ' or ' '
+                ssep = string.len(longname) < 3 and ' ' or ' '
               else
                 sep, ssep = ' ', ' '
               end


### PR DESCRIPTION
The `bibtex` package, specifically the `bibliography.lua` file, has functions "borrowed from nbibtex". Along it, the '\~' character (which is used is used to insert a non-breaking space in latex) is used to separate author's names. However, in sile '\~' is an ordinary character and, therefore, the `\reference` command may produce undesired '~' symbols in the generated document.
This PR changes one occurrence of '\~' to ' ' (0x00A0) character, which (hack or not) works just fine in sile.
I was tempted to also replace '\~' in lines 241, 243 and 244, but since I could not trigger them in my documents, I left these lines unchanged.
