### PR TITLE
docs(readme): Remove unreachable closed japanese google group

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,6 @@ There's also an [FAQ][faq] available.
 Please report bugs and send patches and pull requests at the [github repository][github].
 For questions and discussion, please join the [mailing list][list-en].
 
-日本語利用者は[メーリングリスト][list-ja]に参加してください。
-
 ## License Terms
 
 SILE is distributed under the [MIT licence][license].
@@ -361,7 +359,6 @@ SILE is distributed under the [MIT licence][license].
   [brew]: http://brew.sh
   [brewfonts]: https://github.com/Homebrew/homebrew-cask-fonts
   [list-en]: https://groups.google.com/d/forum/sile-users
-  [list-ja]: https://groups.google.com/d/forum/sile-users-ja
   [nix]: https://nixos.org/nix
   [nix-flakes]: https://nixos.wiki/wiki/Flakes#Installing_flakes
   [ports]: http://ports.su/print/sile


### PR DESCRIPTION
Closes #717

Remove the japanese google group from the README
- No one from the SILE organization has access to it
- It's not an "open" group and we can't tell if it stopped being active, but there's no known way to register to it...

In #717 @alerque notes:
> Just FYI at one point there was even a complete SILE manual translated to Japanese (when it was 80-90 pages if I recall). I don't know if there is still lots of active use in an isolated subculture there, but at one time at least there was. Until we poll somebody from that group I don't think we should impose time limits on erasing notes about their existence.

The japanese manual is here: https://github.com/shirat74/SILE-doc_ja
- No change for 6+ years
- Thus still in version 0.9.5
- Author never answered https://github.com/shirat74/SILE-doc_ja/issues/1 from 2019
- Author seems inactive on GitHub for years

This is dead and outside our reach.

All in all, rather than having a broken link in the README (or rather, a link that potentially interested users **cannot use**, and we can do nothing about it), we should remove it.

If someone from the Japanese community of SILE users takes on reviving the effort, a new link would be welcome.

