### PR TITLE
Use OpenType +ruby feature for ruby, toggle with setting

### DIFF
--- a/Makefile-fonts
+++ b/Makefile-fonts
@@ -34,6 +34,7 @@ TESTFONTFILES  = $(DOCSFONTFILES)
 TESTFONTFILES += Amiri-Regular.ttf
 TESTFONTFILES += AmiriQuran.ttf
 TESTFONTFILES += AwamiNastaliq-Regular.ttf
+TESTFONTFILES += FRBTaiwaneseKana.otf
 TESTFONTFILES += LibertinusSans-Bold.otf
 TESTFONTFILES += NotoNaskhArabic-Regular.ttf
 TESTFONTFILES += NotoSansKannada-Regular.ttf
@@ -72,6 +73,10 @@ notobase = $(shell echo $(notdir $1) | sed -e 's/-.*//')
 
 .fonts/TwemojiMozilla.ttf: | .fonts
 	$(CURL) -fsSL https://github.com/mozilla/twemoji-colr/releases/download/v0.5.1/$(notdir $@) -o $@
+
+.fonts/FRBTaiwaneseKana.otf: | .fonts
+	: $(CURL) -fsSL https://github.com/ctrlcctrlv/FRBTaiwaneseKana/releases/download/v1.1/$(notdir $@) -o $@
+	$(CURL) -fsSL https://raw.githubusercontent.com/ctrlcctrlv/FRBTaiwaneseKana/5c367e9ee5aefd54b5c9c9e996705f0561fe3d15/$(notdir $@) -o $@
 
 # Tell  make how to download font file bundles (when not downloadable individually)
 

--- a/packages/ruby/init.lua
+++ b/packages/ruby/init.lua
@@ -51,12 +51,23 @@ function package.declareSettings (_)
     help = "Glue added between consecutive Latin ruby"
   })
 
+  SILE.settings:declare({
+    parameter = "ruby.opentype",
+    type = "boolean",
+    default = true,
+    help = "Use OpenType tate feature instead of of a bold weight"
+  })
+
 end
 
 function package:registerCommands ()
 
   self:registerCommand("ruby:font", function (_, _)
-    SILE.call("font", { size = "0.6zw", weight = 800 })
+    if SILE.settings:get("ruby.opentype") then
+      SILE.call("font", { size = "0.6zw", features = "+ruby" })
+    else
+      SILE.call("font", { size = "0.6zw", weight = 700 })
+    end
   end)
 
   self:registerCommand("ruby", function (options, content)

--- a/tests/bug-1047.expected
+++ b/tests/bug-1047.expected
@@ -1,0 +1,17 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	24.7039
+My 	42.3452
+Set font 	FRB Taiwanese Kana;24;400;;normal;+ruby;;LTR
+T	172 w=24.0000	(タ)
+Mx 	48.7039
+T	145 w=24.0000	(イ)
+Mx 	72.7039
+T	122 w=12.0000	(𚿳)
+Mx 	24.7039
+My 	82.3452
+Mx 	34.7039
+Set font 	Noto Serif CJK TC;40;400;;normal;;;LTR
+T	34119 w=40.0000	(臺)
+End page
+Finish

--- a/tests/bug-1047.sil
+++ b/tests/bug-1047.sil
@@ -1,0 +1,10 @@
+\begin[class=jplain,papersize=a6]{document}
+\nofolios
+\neverindent
+\language[main=zh]
+\use[module=packages.ruby]
+\font:remove-fallback
+\font:add-fallback[family=Noto Serif CJK TC]
+\font[family=FRB Taiwanese Kana,size=40pt]
+\ruby[reading=タイ𚿳]{臺}
+\end{document}

--- a/tests/bug-524.expected
+++ b/tests/bug-524.expected
@@ -1605,7 +1605,7 @@ Mx 	59.5278
 T	1506 w=10.0000	(は)
 Mx 	51.7739
 My 	129.9592
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	56 w=5.2680	(W)
 Mx 	49.4079
 My 	139.9592

--- a/tests/bug-524.sil
+++ b/tests/bug-524.sil
@@ -3,6 +3,7 @@
 \neverindent
 \show-hanmen
 \use[module=packages.ruby]
+\set[parameter=ruby.opentype,value=false]
 私は
 
 {}私は

--- a/tests/bug-525.expected
+++ b/tests/bug-525.expected
@@ -2,7 +2,7 @@ Set paper size 	297.6377985	419.5275636
 Begin page
 Mx 	24.7039
 My 	46.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	20220 w=6.0000	(日)
 Mx 	30.8207
 T	20758 w=6.0000	(本)
@@ -15,7 +15,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	42.9375
 My 	46.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	45 w=3.2580	(L)
 Mx 	46.3123
 Mx 	3.2940
@@ -33,7 +33,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	24.7039
 My 	63.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	45 w=3.2580	(L)
 Mx 	28.0787
 Mx 	3.2940
@@ -51,7 +51,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	39.3011
 My 	63.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	20220 w=6.0000	(日)
 Mx 	45.4179
 T	20758 w=6.0000	(本)
@@ -64,7 +64,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	24.7039
 My 	80.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	45 w=3.2580	(L)
 Mx 	28.0790
 Mx 	3.2940
@@ -82,7 +82,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	41.8022
 My 	80.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	45 w=3.2580	(L)
 Mx 	45.1773
 Mx 	3.2940

--- a/tests/bug-525.sil
+++ b/tests/bug-525.sil
@@ -2,6 +2,7 @@
 \nofolios
 \neverindent
 \use[module=packages.ruby]
+\set[parameter=ruby.opentype,value=false]
 \ruby[reading=日本語]{私}\ruby[reading=Latin]{私}
 
 \ruby[reading=Latin]{私}\ruby[reading=日本語]{私}

--- a/tests/bug-926.expected
+++ b/tests/bug-926.expected
@@ -2,7 +2,7 @@ Set paper size 	297.6377985	419.5275636
 Begin page
 Mx 	24.7039
 My 	46.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	20220 w=6.0000	(日)
 Mx 	30.7039
 T	20758 w=6.0000	(本)
@@ -15,7 +15,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	42.7039
 My 	46.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 Mx 	3.2580
 Mx 	3.2940
 Mx 	2.2620
@@ -29,7 +29,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	24.7039
 My 	63.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 Mx 	3.2580
 Mx 	3.2940
 Mx 	2.2620
@@ -43,7 +43,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	38.8339
 My 	63.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 T	20220 w=6.0000	(日)
 Mx 	44.8339
 T	20758 w=6.0000	(本)
@@ -56,7 +56,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	24.7039
 My 	80.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 Mx 	3.2580
 Mx 	3.2940
 Mx 	2.2620
@@ -70,7 +70,7 @@ Set font 	Noto Sans CJK JP;10;400;;normal;;;LTR
 T	29078 w=10.0000	(私)
 Mx 	41.3339
 My 	80.9652
-Set font 	Noto Sans CJK JP;6;800;;normal;;;LTR
+Set font 	Noto Sans CJK JP;6;700;;normal;;;LTR
 Mx 	3.2580
 Mx 	3.2940
 Mx 	2.2620

--- a/tests/bug-926.sil
+++ b/tests/bug-926.sil
@@ -3,6 +3,7 @@
 \neverindent
 \language[main=en]
 \use[module=packages.ruby]
+\set[parameter=ruby.opentype,value=false]
 \ruby[reading=日本語]{私}\ruby[reading=Latin]{私}
 
 \ruby[reading=Latin]{私}\ruby[reading=日本語]{私}


### PR DESCRIPTION
Closes #1047

I wasn't sure if the font size was something we still needed to set to a smaller size relative to the base font or if the +tate feature should also produce approriately sized glyphs.