### PR TITLE
Backport a couple things from develop to master

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,14 @@ AC_SUBST([LUAROCKSARGS])
 
 AX_SUBST_TRANSFORMED_PACKAGE_NAME
 
-adl_RECURSIVE_EVAL(["${datadir}/${TRANSFORMED_PACKAGE_NAME}"], [SILE_PATH])
+# Avoid need for `--datarootdir=$(cd ..; pwd)` hack to run locally for
+# tests/manual build when developer mode is enabled
+AM_COND_IF([DEVELOPER], [
+    adl_RECURSIVE_EVAL(["$(pwd)"], [SILE_PATH])
+    datarootdir="$(cd ..; pwd)"
+],[
+    adl_RECURSIVE_EVAL(["${datadir}/${TRANSFORMED_PACKAGE_NAME}"], [SILE_PATH])
+])
 AC_DEFINE_UNQUOTED([SILE_PATH],["${SILE_PATH}"],[Path for SILE packages and classes])
 AC_SUBST([SILE_PATH])
 

--- a/sile.in
+++ b/sile.in
@@ -6,7 +6,11 @@ SHARED_LIB_EXT = "@SHARED_LIB_EXT@"
 
 -- At this point at run time we may or may not have anything useful in package.path,
 -- so require() isn't something we can rely on.
-local status = pcall(dofile, "@SILE_PATH@/core/pathsetup.lua")
+local status
+for path in string.gmatch("@SILE_PATH@", "[^;]+") do
+  status = pcall(dofile, path .. "/core/pathsetup.lua")
+  if status then break end
+end
 if not status then
   dofile("./core/pathsetup.lua")
 end


### PR DESCRIPTION
This should fix CaSILE so it can be released again depending on the current SILE version instead of only working with the development branch. It now sets multiple SILE_PATH segments: for itself, for the project, for any other toolkit packages being added, etc.. That made it dependent on the unrleased SILE development branch, which prohibits it being released. As that is the only change it was dependent on, the change is not breaking, and it is easy to backport I figured why not…