### PR TITLE
Remove code soon to be inaccessable because of deprecations

### DIFF
--- a/core/cli.lua
+++ b/core/cli.lua
@@ -119,9 +119,8 @@ cli.parseArguments = function ()
   for _, path in ipairs(opts.postamble) do
     table.insert(SILE.input.postambles, path)
   end
-  for _, path in ipairs(opts.include) do
+  if opts.include then
     SU.deprecated("-I/--include", "-u/--use or -p/--preamble", "0.14.0", "0.15.0")
-    table.insert(SILE.input.includes, path)
   end
   -- http://lua-users.org/wiki/VarargTheSecondClassCitizen
   local summary = function (...)

--- a/core/deprecations.lua
+++ b/core/deprecations.lua
@@ -49,9 +49,8 @@ SILE.baseClass = setmetatable({}, {
     __index = nobaseclass
   })
 
-SILE.defaultTypesetter = function (frame)
+SILE.defaultTypesetter = function ()
   SU.deprecated("SILE.defaultTypesetter", "SILE.typesetters.base", "0.14.6", "0.15.0")
-  return SILE.typesetters.base(frame)
 end
 
 SILE.toPoints = function (_, _)

--- a/core/pagebuilder.lua
+++ b/core/pagebuilder.lua
@@ -1,3 +1,1 @@
 SU.deprecated("core.pagebuilder", "pagebuilder.base", "0.14.6", "0.15.0")
-
-return require("pagebuilders.base")

--- a/core/settings.lua
+++ b/core/settings.lua
@@ -1,6 +1,5 @@
 local deprecator = function ()
   SU.deprecated("SILE.settings.*", "SILE.settings:*", "0.13.0", "0.15.0")
-  return SILE.settings
 end
 
 local settings = pl.class()
@@ -96,18 +95,18 @@ function settings:_init()
 end
 
 function settings:pushState ()
-  if not self then self = deprecator() end
+  if not self then return deprecator() end
   table.insert(self.stateQueue, self.state)
   self.state = pl.tablex.copy(self.state)
 end
 
 function settings:popState ()
-  if not self then self = deprecator() end
+  if not self then return deprecator() end
   self.state = table.remove(self.stateQueue)
 end
 
 function settings:declare (spec)
-  if not spec then self, spec = deprecator(), self end
+  if not spec then return deprecator() end
   if spec.name then
     SU.deprecated("'name' argument of SILE.settings:declare", "'parameter' argument of SILE.settings:declare", "0.10.10", "0.11.0")
   end
@@ -121,7 +120,7 @@ end
 
 --- Reset all settings to their default value.
 function settings:reset ()
-  if not self then self = deprecator() end
+  if not self then return deprecator() end
   for k,_ in pairs(self.state) do
     self:set(k, self.defaults[k])
   end
@@ -131,7 +130,7 @@ end
 -- that is at the head of the settings stack (normally the document
 -- level).
 function settings:toplevelState ()
-  if not self then self = deprecator() end
+  if not self then return deprecator() end
   if #self.stateQueue ~= 0 then
     for parameter, _ in pairs(self.state) do
       -- Bypass self:set() as the latter performs some tests and a cast,
@@ -148,7 +147,7 @@ function settings:get (parameter)
   if parameter == "current.parindent" then
     return SILE.typesetter and SILE.typesetter.state.parindent
   end
-  if not parameter then self, parameter = deprecator(), self end
+  if not parameter then return deprecator() end
   if not self.declarations[parameter] then
     SU.error("Undefined setting '"..parameter.."'")
   end
@@ -184,7 +183,7 @@ function settings:set (parameter, value, makedefault, reset)
     end
     return
   end
-  if type(self) ~= "table" then self, parameter, value, makedefault, reset = deprecator(), self, parameter, value, makedefault end
+  if type(self) ~= "table" then return deprecator() end
   if not self.declarations[parameter] then
     SU.error("Undefined setting '"..parameter.."'")
   end
@@ -203,14 +202,14 @@ function settings:set (parameter, value, makedefault, reset)
 end
 
 function settings:temporarily (func)
-  if not func then self, func = deprecator(), self end
+  if not func then return deprecator() end
   self:pushState()
   func()
   self:popState()
 end
 
 function settings:wrap () -- Returns a closure which applies the current state, later
-  if not self then self = deprecator() end
+  if not self then return deprecator() end
   local clSettings = pl.tablex.copy(self.state)
   return function(content)
     table.insert(self.stateQueue, self.state)

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -65,7 +65,6 @@ SILE.input = {
   filenames = {},
   evaluates = {},
   evaluateAfters = {},
-  includes = {},
   uses = {},
   options = {},
   preambles = {},

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -1,3 +1,1 @@
 SU.deprecated("core.typesetter", "typesetters.base", "0.14.0", "0.15.0")
-
-return require("typesetters.base")

--- a/packages/balanced-frames/init.lua
+++ b/packages/balanced-frames/init.lua
@@ -55,7 +55,7 @@ local function buildPage (typesetter, independent)
   end
   typesetter.state.lastPenalty = 0
   local oldPageBuilder = SILE.pagebuilder
-  SILE.pagebuilder = require("core.pagebuilder")()
+  SILE.pagebuilder = SILE.pagebuilders.base()
   while typesetter.frame and typesetter.frame.balanced do
     unbalanced_buildPage(typesetter, true)
     if typesetter.frame.next and SILE.getFrame(typesetter.frame.next).balanced == true then

--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -81,12 +81,6 @@ function package:registerCommands ()
 
   self:registerCommand("bibstyle", function (_, content)
     SU.deprecated("\\bibstyle", '\\set[parameter=bibtex.style]', "0.13.2", "0.14.0")
-    if type(content) == "table" then
-      content = content[1]
-    end
-    if type(content) == "string" then
-      SILE.settings:set("bibtex.style", content)
-    end
   end)
 
   self:registerCommand("cite", function (options, content)

--- a/packages/counters/init.lua
+++ b/packages/counters/init.lua
@@ -3,14 +3,12 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "counters"
 
-SILE.formatCounter = function (counter)
+SILE.formatCounter = function ()
   SU.deprecated("SILE.formatCounter", "class:formatCounter", "0.13.0", "0.15.0")
-  return package.formatCounter(nil, counter)
 end
 
-SILE.formatMultilevelCounter = function (counter, options)
+SILE.formatMultilevelCounter = function ()
   SU.deprecated("SILE.formatMultilevelCounter", "class:formatMultilevelCounter", "0.13.0", "0.15.0")
-  return package.formatMultilevelCounter(nil, counter, options)
 end
 
 local function getCounter (_, id)

--- a/packages/infonode/init.lua
+++ b/packages/infonode/init.lua
@@ -43,9 +43,8 @@ function package:_init ()
     SILE.scratch.info = { thispage = {} }
   end
   self.class:registerHook("newpage", newPageInfo)
-  self:deprecatedExport("newPageInfo", function (class)
+  self:deprecatedExport("newPageInfo", function ()
     SU.deprecated("class:newPageInfo", nil, "0.13.0", "0.15.0", _deprecate)
-    return class:newPageInfo()
   end)
 end
 

--- a/packages/masters/init.lua
+++ b/packages/masters/init.lua
@@ -37,9 +37,8 @@ local function doswitch (frames)
   end
 end
 
-local function switchMasterOnePage (class, id)
+local function switchMasterOnePage (_, id)
   if not id then
-    id = class
     SU.deprecated("class.switchMasterOnePage", "class:switchMasterOnePage", "0.13.0", "0.15.0")
   end
   if not SILE.scratch.masters[id] then
@@ -53,7 +52,6 @@ end
 
 local function switchMaster (class, id)
   if not id then
-    id, class = class, SILE.documentState.documentClass
     SU.deprecated("class.switchMaster", "class:switchMaster", "0.13.0", "0.15.0")
   end
   _currentMaster = id

--- a/packages/rules/init.lua
+++ b/packages/rules/init.lua
@@ -107,38 +107,15 @@ function package:registerCommands ()
     local thickness = SU.cast("measurement", options.thickness or "0.2pt")
     local raise = SU.cast("measurement", options.raise or "0.5em")
 
-    -- BEGIN DEPRECATION COMPATIBILITY
     if options.height then
       SU.deprecated("\\fullrule[…, height=…]", "\\fullrule[…, thickness=…]", "0.13.1", "0.15.0")
-      thickness = SU.cast("measurement", options.height)
     end
     if not SILE.typesetter:vmode() then
       SU.deprecated("\\fullrule in horizontal mode", "\\hrule or \\hrulefill", "0.13.1", "0.15.0")
-      if options.width then
-        SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1", "0.15.0")
-        SILE.call("raise", { height = raise }, function ()
-          SILE.call("hrule", {
-            height = thickness,
-            width = options.width
-          })
-        end)
-      else
-        -- This was very broken anyway, as it was overflowing the line.
-        -- At least we try better...
-        SILE.call("hrulefill", { raise = raise, thickness = thickness })
-      end
-     return
     end
     if options.width then
       SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1 ", "0.15.0")
-      SILE.call("raise", { height = raise }, function ()
-        SILE.call("hrule", {
-          height = thickness,
-          width = options.width
-        })
-      end)
     end
-    -- END DEPRECATION COMPATIBILITY
 
     SILE.typesetter:leaveHmode()
     SILE.call("noindent")

--- a/packages/twoside/init.lua
+++ b/packages/twoside/init.lua
@@ -57,9 +57,8 @@ function package:_init (options)
   end
   self:export("oddPage", self.oddPage)
   self:export("mirrorMaster", mirrorMaster)
-  self:export("switchPage", function (class)
+  self:export("switchPage", function ()
     SU.deprecated("class:switchPage", nil, "0.13.0", "0.15.0", _deprecate)
-    return class:switchPage()
   end)
   self.class.oddPageMaster = options.oddPageMaster
   self.class.evenPageMaster = options.evenPageMaster


### PR DESCRIPTION
Since the version isn't set to v0.15.0 yet it wasn't apparent we were still using deprecated APIs internally.