### PR TITLE
Fix linter to be stricter 5.1

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-std = "max"
+std = "min"
 include_files = {
   "**/*.lua",
   "sile.in",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,6 +21,7 @@ files["**/*_spec.lua"] = {
   std = "+busted"
 }
 globals = {
+  package = { fields = { "searchpath" } },
   "SILE",
   "SU",
   "luautf8",

--- a/core/cli.lua
+++ b/core/cli.lua
@@ -108,7 +108,7 @@ cli.parseArguments = function ()
   -- http://lua-users.org/wiki/VarargTheSecondClassCitizen
   local summary = function (...)
     local contentloc = SILE.traceStack:locationHead()
-    local codeloc = table.unpack({...}, 1, select('#', ...))
+    local codeloc = pl.utils.unpack({...}, 1, select('#', ...))
     return ("Processing at: %s\n\tUsing code at: %s"):format(contentloc, codeloc)
   end
   local unexpected = function ()

--- a/core/deprecations.lua
+++ b/core/deprecations.lua
@@ -30,7 +30,7 @@ SILE.fluent = setmetatable({}, {
   __call = function (_, ...)
     fluentglobal()
     SILE.fluent = fluent
-    return fluent(table.unpack({...}, 1, select("#", ...)))
+    return fluent(pl.utils.unpack({...}, 1, select("#", ...)))
   end,
   __index = function (_, key)
     fluentglobal()

--- a/core/packagemanager.lua
+++ b/core/packagemanager.lua
@@ -30,6 +30,7 @@ end
 
 local function loadInSandbox(untrusted_code)
   _deprecated()
+  -- luacheck: ignore _ENV
   if _ENV then -- simple Lua 5.2 version check
     local env = {}
     local untrusted_function, message = load(untrusted_code, nil, 't', env)

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -6,6 +6,7 @@ SILE.features = require("core.features")
 
 -- Initialize Lua environment and global utilities
 SILE.lua_version = _VERSION:sub(-3)
+-- luacheck: ignore jit
 SILE.lua_isjit = type(jit) == "table"
 SILE.full_version = string.format("SILE %s (%s)", SILE.version, SILE.lua_isjit and jit.version or _VERSION)
 

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -115,7 +115,7 @@ end
 utilities.debug = function (category, ...)
   if SILE.quiet then return end
   if utilities.debugging(category) then
-    local inputs = table.pack(...)
+    local inputs = pl.utils.pack(...)
     for i, input in ipairs(inputs) do
       if type(input) == "function" then
         local status, output = pcall(input)
@@ -261,7 +261,7 @@ end
 
 utilities.compress = function (items)
   local rv = {}
-  local max = math.max(table.unpack(pl.tablex.keys(items)))
+  local max = math.max(pl.utils.unpack(pl.tablex.keys(items)))
   for i = 1, max do if items[i] then rv[#rv+1] = items[i] end end
   return rv
 end

--- a/outputters/debug.lua
+++ b/outputters/debug.lua
@@ -44,7 +44,7 @@ end
 
 function outputter:_writeline (...)
   self:_ensureInit()
-  local args = table.pack(...)
+  local args = pl.utils.pack(...)
   for i = 1, #args do
     outfile:write(args[i])
     if i < #args then outfile:write("\t") end

--- a/outputters/text.lua
+++ b/outputters/text.lua
@@ -23,7 +23,7 @@ end
 
 function outputter:_writeline (...)
   self:_ensureInit()
-  local args = table.pack(...)
+  local args = pl.utils.pack(...)
   for i=1, #args do
     outfile:write(args[i])
   end

--- a/packages/base.lua
+++ b/packages/base.lua
@@ -81,7 +81,7 @@ function package:deprecatedExport (name, func, noclass, notable)
       SU.deprecated(("class.%s"):format(name),
                     ("class.packages.%s:%s"):format(self._name, name),
                     "0.14.0", "0.16.0", _deprecate_class_funcs)
-      return func(table.unpack(inputs, 1, select("#", ...) + 1))
+      return func(pl.utils.unpack(inputs, 1, select("#", ...) + 1))
     end
   end
 
@@ -94,7 +94,7 @@ function package:deprecatedExport (name, func, noclass, notable)
       SU.deprecated(("require('packages.%s').exports.%s"):format(self._name, name),
                     ("class.packages.%s:%s"):format(self._name, name),
                     "0.14.0", "0.16.0", _deprecate_exports_table)
-      return func(table.unpack(inputs, 1, select("#", ...) + 1))
+      return func(pl.utils.unpack(inputs, 1, select("#", ...) + 1))
     end
   end
 

--- a/packages/bibtex/bibliography.lua
+++ b/packages/bibtex/bibliography.lua
@@ -1,4 +1,5 @@
 -- luacheck: globals setfenv getfenv
+-- luacheck: ignore _ENV
 
 -- The following functions borrowed from Norman Ramsey's nbibtex,
 -- with permission.

--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -1112,7 +1112,7 @@ function elements.table:_init (children, options)
   self.children = children
   self.options = options
   self.nrows = #self.children
-  self.ncols = math.max(table.unpack(mapList(function(_, row)
+  self.ncols = math.max(pl.utils.unpack(mapList(function(_, row)
     return #row.children end, self.children)))
   SU.debug("math", "self.ncols =", self.ncols)
   self.rowspacing = self.options.rowspacing and SILE.length(self.options.rowspacing)

--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -83,7 +83,7 @@ local mathGrammar = function (_ENV)
         -- Remove the last mathlist if empty. This way,
         -- `inner1 \\ inner2 \\` is the same as `inner1 \\ inner2`.
         if not t[#t][1] or not t[#t][1][1] then table.remove(t) end
-        return table.unpack(t)
+        return pl.utils.unpack(t)
       end
 
   START "texlike_math"


### PR DESCRIPTION
We don't technically have to be this strict since compat53 shims a lot of things for us, but this will keep us out of trouble better. For example `table.unpack()` is shimmed, but the shim is not nil safe so better to use `pl.utils.unpack` anyway.