### PR TITLE
Balancing in command makecolums set as an option

### DIFF
--- a/packages/frametricks/init.lua
+++ b/packages/frametricks/init.lua
@@ -42,6 +42,7 @@ end
 local makecolumns = function (options)
   local cFrame = SILE.typesetter.frame
   local cols = options.columns
+  local balanced = SU.boolean(options.balanced, true)
   local gutterWidth = options.gutter or "3%pw"
   local right = cFrame:right()
   local origId = cFrame.id
@@ -58,8 +59,8 @@ local makecolumns = function (options)
       bottom = cFrame:bottom(),
       id = origId .. "_col"..i
     })
-    newFrame.balanced = true
-    cFrame.balanced = true
+    newFrame.balanced = balanced
+    cFrame.balanced = balanced
     gutter:constrain("right", "left("..newFrame.id..")")
     newFrame:constrain("left", "right("..gutter.id..")")
     -- In the future we may way to allow for unequal columns


### PR DESCRIPTION
The user should have the option of disabling the balancing when calling `makecolumns`. For example, this just happened to me right now, using the default `makecolumns`:

![image](https://github.com/sile-typesetter/sile/assets/15092760/91b08624-74bb-473c-93f1-6812e544b312)

But I wanted their bottom to be the same as the original frame, which I got after setting balancing to false:

![image](https://github.com/sile-typesetter/sile/assets/15092760/82c121f2-0d1f-434a-bbdd-3f2f8e6f661f)