### PR TITLE
Keep working on ABNF and fix actual SIL parser to match

### DIFF
--- a/core/parserbits.lua
+++ b/core/parserbits.lua
@@ -61,15 +61,16 @@ local shrink = bits.ws * P"minus" * bits.ws * Cg(amount, "shrink")
 bits.length = Ct(length * stretch^-1 * shrink^-1)
 bits.utf8char = utf8char
 
-local pairsep = S",;" * bits.ws
+local pairsep = S",;"
 local quote = P'"'
 local escaped_quote = B(P"\\") * quote
 local unescapeQuote = function (str) local a = str:gsub('\\"', '"'); return a end
-local quotedString = quote * C((1 - quote + escaped_quote)^1 / unescapeQuote) * quote
-local value = quotedString + (1-S",;]")^1
+local quotedValueString = quote * C((1 - quote + escaped_quote)^0 / unescapeQuote) * quote
+local valueString = (1-pairsep-quote-S"]")^0 / pl.stringx.strip
+local value = quotedValueString + valueString + P""
 local ID = C(bits.letter * (bits.letter + bits.digit)^0)
 bits.silidentifier = (ID + S":-")^1
-local pair = Cg(C(bits.silidentifier) * bits.ws * "=" * bits.ws * C(value)) * pairsep^-1 / unwrapper
+local pair = Cg(bits.ws * C(bits.silidentifier) * bits.ws * "=" * bits.ws * C(value) * bits.ws) * pairsep^-1 / unwrapper
 bits.parameters = Cf(Ct"" * pair^0, rawset)
 
 local wrapper = function (a) return type(a)=="table" and a or {} end

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -170,7 +170,7 @@ local function suggest_luarocks (module)
         SILE.lua_version,
         guessed_module_name,
         SILE.lua_version,
-        pl.stringx.join(" ", _G.arg)
+        pl.stringx.join(" ", _G.arg or {})
         )
 end
 

--- a/inputters/sil-epnf.lua
+++ b/inputters/sil-epnf.lua
@@ -1,4 +1,5 @@
-local bits = SILE.parserBits
+local epnf = require("epnf")
+local bits = require("core.parserbits")
 
 local passthroughCommands = {
   ftl = true,
@@ -25,7 +26,7 @@ end
 
 -- luacheck: push ignore
 ---@diagnostic disable: undefined-global, unused-local, lowercase-global
-local function grammar (_ENV)
+local function builder (_ENV)
   local _ = WS^0
   local eol = S"\r\n"
   local specials = S"\\{}%"
@@ -92,4 +93,10 @@ local function grammar (_ENV)
     )
 end
 
-return grammar
+local grammar = epnf.define(builder)
+
+local function parser (string)
+  return epnf.parsestring(grammar, string)
+end
+
+return parser

--- a/inputters/sil_spec.lua
+++ b/inputters/sil_spec.lua
@@ -44,6 +44,12 @@ describe("#SIL #inputter", function ()
       assert.is.equal("bar", t[1][1])
     end)
 
+    it("commands with space around args and values", function()
+      local t = inputter:parse([[\foo[ baz = qiz qiz ]{bar}]])[1][1][1]
+      assert.is.equal("foo", t.command)
+      assert.is.equal("qiz qiz", t.options.baz)
+    end)
+
     it("commands with multiple quoted args", function()
       local t = inputter:parse([[\foo[baz="qiz, qiz",qiz="baz, baz"]{bar}]])[1][1][1]
       assert.is.equal("foo", t.command)

--- a/sil.abnf
+++ b/sil.abnf
@@ -55,7 +55,7 @@ braced-passthrough-text = utf8-text
 
 ; Building blocks
 options = "[" parameter *( "," parameter ) "]"
-parameter = sil-identifier "=" ( value / quoted-value )
+parameter = *WSP sil-identifier *WSP "=" *WSP ( value / quoted-value ) *WSP
 value = utf8-text
 quoted-value = DQUOTE utf8-text DQUOTE
 

--- a/sil.abnf
+++ b/sil.abnf
@@ -32,11 +32,11 @@ environment =/ %s"\begin" [ options ] "{" command-id "}"
 
 ; Passthrough (raw) environments can have any valid UTF-8 except the closing
 ; delimiter matching the opening, per the environment rule.
-env-passthrough-text = utf8-text
+env-passthrough-text = *utf8-char
 
 ; Nothing to see here.
 ; But potentially important because it eats newlines!
-comment = "%" utf8-text CRLF
+comment = "%" *utf8-char CRLF
 
 ; Input strings that are not special
 text = *text-char
@@ -51,14 +51,27 @@ command =  "\" passthrough-command-id [ options ] [ braced-passthrough-text ]
 command =/ "\" command-id [ options ] [ braced-content ]
 
 ; Passthrough (raw) command text can have any valid UTF-8 except an unbalanced closing delimiter
-braced-passthrough-text = utf8-text
+braced-passthrough-text = "{" *( *braced-passthrough-char / braced-passthrough-text ) "}"
 
-; Building blocks
+braced-passthrough-char =  %x00-7A ; omit {
+braced-passthrough-char =/ %x7C    ; omit }
+braced-passthrough-char =/ %x7E-7F ; end of utf8-1
+braced-passthrough-char =/ utf8-2
+braced-passthrough-char =/ utf8-3
+braced-passthrough-char =/ utf8-4
+
 options = "[" parameter *( "," parameter ) "]"
-parameter = *WSP sil-identifier *WSP "=" *WSP ( quoted-value / value ) *WSP
-quoted-value = DQUOTE *quoted-value-char DQUOTE
-value = *value-char
+parameter = *WSP identifier *WSP "=" *WSP ( quoted-value / value ) *WSP
 
+quoted-value = DQUOTE *quoted-value-char DQUOTE
+quoted-value-char = "\" %x22
+quoted-value-char =/ %x00-21 ; omit "
+quoted-value-char =/ %x23-7F ; end of utf8-1
+quoted-value-char =/ utf8-2
+quoted-value-char =/ utf8-3
+quoted-value-char =/ utf8-4
+
+value = *value-char
 value-char =/ %x00-21 ; omit "
 value-char =/ %x23-2B ; omit ,
 value-char =/ %x2D-3A ; omit ;
@@ -67,13 +80,6 @@ value-char =/ %x3E-7F ; end of utf8-1
 value-char =/ utf8-2
 value-char =/ utf8-3
 value-char =/ utf8-4
-
-quoted-value-char = "\" %x22
-quoted-value-char =/ %x00-21 ; omit "
-quoted-value-char =/ %x23-7F ; end of utf8-1
-quoted-value-char =/ utf8-2
-quoted-value-char =/ utf8-3
-quoted-value-char =/ utf8-4
 
 text-char =  "\" ( %x5C / %x25 / %x7B / %x7D )
 text-char =/ %x00-24 ; omit %
@@ -87,14 +93,13 @@ text-char =/ utf8-4
 
 letter = ALPHA / "_" / ":"
 identifier = letter *( letter / DIGIT / "-" / "." )
-command-id = identifier ; - ( %s"begin" / %s"end" / passthrough-command-id )
 passthrough-command-id = %s"ftl" / %s"lua" / %s"math" / %s"raw" / %s"script" / %s"sil" / %s"use" / %s"xml"
+command-id = identifier
 
 ; ASCII isn't good enough for us.
-utf8-text = *utf8-char
-utf8-char   = utf8-1 / utf8-2 / utf8-3 / utf8-4
-utf8-1      = %x00-7F
-utf8-2      = %xC2-DF utf8-tail
-utf8-3      = %xE0 %xA0-BF utf8-tail / %xE1-EC 2utf8-tail / %xED %x80-9F utf8-tail / %xEE-EF 2utf8-tail
-utf8-4      = %xF0 %x90-BF 2utf8-tail / %xF1-F3 3utf8-tail / %xF4 %x80-8F 2utf8-tail
-utf8-tail   = %x80-BF
+utf8-char = utf8-1 / utf8-2 / utf8-3 / utf8-4
+utf8-1    = %x00-7F
+utf8-2    = %xC2-DF utf8-tail
+utf8-3    = %xE0 %xA0-BF utf8-tail / %xE1-EC 2utf8-tail / %xED %x80-9F utf8-tail / %xEE-EF 2utf8-tail
+utf8-4    = %xF0 %x90-BF 2utf8-tail / %xF1-F3 3utf8-tail / %xF4 %x80-8F 2utf8-tail
+utf8-tail = %x80-BF

--- a/sil.abnf
+++ b/sil.abnf
@@ -39,7 +39,7 @@ env-passthrough-text = utf8-text
 comment = "%" utf8-text CRLF
 
 ; Input strings that are not special
-text = *( text-char / escaped-specials )
+text = *text-char
 
 ; Input content wrapped in braces can be attatched to a command or used to
 ; manually isolate chunks of content (e.g. to hinder ligatures).
@@ -55,15 +55,28 @@ braced-passthrough-text = utf8-text
 
 ; Building blocks
 options = "[" parameter *( "," parameter ) "]"
-parameter = *WSP sil-identifier *WSP "=" *WSP ( value / quoted-value ) *WSP
-value = utf8-text
-quoted-value = DQUOTE utf8-text DQUOTE
+parameter = *WSP sil-identifier *WSP "=" *WSP ( quoted-value / value ) *WSP
+quoted-value = DQUOTE *quoted-value-char DQUOTE
+value = *value-char
 
-specials = "\" / "%" / "{" / "}"
-escaped-specials = "\" specials
+value-char =/ %x00-21 ; omit "
+value-char =/ %x23-2B ; omit ,
+value-char =/ %x2D-3A ; omit ;
+value-char =/ %x3C-5C ; omit ]
+value-char =/ %x3E-7F ; end of utf8-1
+value-char =/ utf8-2
+value-char =/ utf8-3
+value-char =/ utf8-4
 
-; non-ascii-char = %x80-D7FF / %xE000-10FFFF
-text-char =  %x0-24  ; omit %
+quoted-value-char = "\" %x22
+quoted-value-char =/ %x00-21 ; omit "
+quoted-value-char =/ %x23-7F ; end of utf8-1
+quoted-value-char =/ utf8-2
+quoted-value-char =/ utf8-3
+quoted-value-char =/ utf8-4
+
+text-char =  "\" ( %x5C / %x25 / %x7B / %x7D )
+text-char =/ %x00-24 ; omit %
 text-char =/ %x26-5B ; omit \
 text-char =/ %x5D-7A ; omit {
 text-char =/ %x7C    ; omit }


### PR DESCRIPTION
I've been trying to use the ABNF to automatically generate SIL parsers in other languages and this has turned up a few issues with it. In fixing those I checked the actual SIL parser as a reference and discovered some bugs there too. For example values not being trimmed and quite unexpectedly allowing unescaped quotes if they are not balanced and more. This is ongoing work on both the ABNF spec and the LPEG grammar.