### PR TITLE
refactor(packages): Remove unused typesetter-scoped cursor tracking

### DIFF
--- a/packages/raiselower/init.lua
+++ b/packages/raiselower/init.lua
@@ -12,9 +12,6 @@ local function raise (height, content)
   SILE.process(content)
   SILE.typesetter:pushHbox({
     outputYourself = function (_, typesetter, _)
-      if (type(typesetter.state.cursorY)) == "table" then
-        typesetter.state.cursorY = typesetter.state.cursorY.length
-      end
       typesetter.frame:advancePageDirection(height)
     end
   })


### PR DESCRIPTION
This was present since the very first commit of the raiselower package, but we do not have any use of such a thing anywhere else in the code base.

I think we can safely remove it...

I noticed it a while back, and remembered it when checking whether this raise/lower commands should use the new liners (the answer that question would be "no", it doesn't seem to me this case meets the criteria).

Another question, then should come its own issue shortly afterwards,.. I can tease it here, though:
Regarding the signature of `ouputYourself` methods, why do we still need the typesetter at output time? It's job ought to be finished then! All we seem to need is... the frame. (I'm still checking the code to check if there is any counter-argument).