### PR TITLE
Display math numbering

### DIFF
--- a/packages/math/init.lua
+++ b/packages/math/init.lua
@@ -16,6 +16,7 @@ function package:_init ()
       return value * SILE.settings:get("math.font.size") / 18
     end
   })
+  self:loadPackage("counters")
 end
 
 function package.declareSettings (_)
@@ -62,23 +63,30 @@ end
 function package:registerCommands ()
 
   self:registerCommand("mathml", function (options, content)
-    local mode = (options and options.mode) and options.mode or 'text'
     local mbox
     xpcall(function()
       mbox = self:ConvertMathML(content)
     end, function(err) print(err); print(debug.traceback()) end)
-    self:handleMath(mbox, mode)
+    self:handleMath(mbox, options)
   end)
 
   self:registerCommand("math", function (options, content)
-    local mode = (options and options.mode) and options.mode or "text"
     local mbox
     xpcall(function()
       mbox = self:ConvertMathML(self:compileToMathML({}, self:convertTexlike(content)))
     end, function(err) print(err); print(debug.traceback()) end)
-    self:handleMath(mbox, mode)
+    self:handleMath(mbox, options)
   end)
 
+  self:registerCommand("math:numberingstyle", function (options, _)
+    SILE.typesetter:typeset("(")
+    if options.counter then
+      SILE.call("show-counter", { id = options.counter })
+    elseif options.number then
+      SILE.typesetter:typeset(options.number)
+    end
+    SILE.typesetter:typeset(")")
+  end)
 end
 
 package.documentation = [[
@@ -343,6 +351,19 @@ Finally, here is a little secret. This notation:
 \end{raw}
 
 \noindent In other words, the notation using \code{&} and \code{\\\\} is only a syntactic sugar for a two-dimensional array constructed with braces.
+
+\paragraph{Numbered equations}
+Equations can be numbered in display mode.
+
+When \autodoc:parameter{numbered=true}, equations are numbered using a default “equation” counter:
+\math[mode=display, numbered=true]{e^{i\pi} = -1}
+
+A different counter can be set by using the option \autodoc:parameter{counter=<id>}, and this setting will also enable numbering.
+
+It is also possible to impose direct numbering using the \autodoc:parameter{number=<value>} option.
+
+The default numbering format is \autodoc:example{(n)}, but this style may be overridden by defining a custom \autodoc:command{\math:numberingstyle} command.
+The \code{counter} or the direct value \code{number} is passed as a parameter to this hook, as well as any other options.
 
 \paragraph{Missing features}
 This package still lacks support for some mathematical constructs, but hopefully we’ll get there.

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -126,7 +126,11 @@ function ConvertMathML (_, content)
   end
 end
 
-local function handleMath (_, mbox, mode)
+local function handleMath (_, mbox, options)
+  local mode = options and options.mode or 'text'
+  local counter = SU.boolean(options.numbered, false) and "equation"
+  counter = options.counter or counter  -- overrides the default "equation" counter
+
   if mode == 'display' then
     mbox.mode = b.mathMode.display
   elseif mode == 'text' then
@@ -144,10 +148,28 @@ local function handleMath (_, mbox, mode)
   if mode == "display" then
     SILE.typesetter:endline()
     SILE.typesetter:pushExplicitVglue(SILE.settings:get("math.displayskip"))
-    SILE.call("center", {}, function()
+    SILE.settings:temporarily(function ()
+      -- Center the equation in the space available up to the counter (if any),
+      -- respecting the fixed part of the left and right skips.
+      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
+      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
+      SILE.settings:set("document.parindent", SILE.types.node.glue())
+      SILE.settings:set("current.parindent", SILE.types.node.glue())
+      SILE.settings:set("document.lskip", SILE.types.node.hfillglue(lskip.width.length))
+      SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width.length))
+      SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
+      SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
       SILE.typesetter:pushHorizontal(mbox)
+      SILE.typesetter:pushExplicitGlue(SILE.nodefactory.hfillglue())
+      if counter then
+        options.counter = counter
+        SILE.call("increment-counter", { id = counter })
+        SILE.call("math:numberingstyle", options)
+      elseif options.number then
+        SILE.call("math:numberingstyle", options)
+      end
+      SILE.typesetter:endline()
     end)
-    SILE.typesetter:endline()
     SILE.typesetter:pushExplicitVglue(SILE.settings:get("math.displayskip"))
   else
     SILE.typesetter:pushHorizontal(mbox)

--- a/tests/feat-math-display-numbered.expected
+++ b/tests/feat-math-display-numbered.expected
@@ -1,0 +1,262 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	14.8819
+My 	29.3016
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	37 72 74 76 81 w=25.5449	(Begin)
+Mx 	42.8738
+T	77 88 86 87 76 737 72 71 w=36.8940	(justified)
+Mx 	125.8695
+My 	52.4918
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	129.6795
+My 	48.7418
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	131.5115
+T	874 w=4.5280	(nil)
+Mx 	139.2472
+My 	52.4918
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	148.5050
+T	2061 w=6.4800	(nil)
+Mx 	154.9850
+T	18 w=4.6500	(nil)
+Mx 	270.6226
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	11 w=3.4858	(()
+Mx 	274.1084
+T	20 w=5.1616	(1)
+Mx 	279.2701
+T	12 w=3.4858	())
+Mx 	14.8819
+My 	75.6820
+T	40 81 71 w=17.2466	(End)
+Mx 	34.5761
+T	77 88 86 87 76 737 72 71 w=36.8940	(justified)
+Mx 	71.4702
+T	17 w=2.5190	(.)
+Mx 	114.8440
+My 	88.8820
+T	37 72 74 76 81 w=25.5449	(Begin)
+Mx 	142.8113
+T	70 72 81 87 72 85 72 71 w=39.9824	(centered)
+Mx 	125.8695
+My 	112.0723
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	129.6795
+My 	108.3223
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	131.5115
+T	874 w=4.5280	(nil)
+Mx 	139.2472
+My 	112.0723
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	148.5050
+T	2061 w=6.4800	(nil)
+Mx 	154.9850
+T	18 w=4.6500	(nil)
+Mx 	270.6226
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	11 w=3.4858	(()
+Mx 	274.1084
+T	21 w=5.1616	(2)
+Mx 	279.2701
+T	12 w=3.4858	())
+Mx 	118.9932
+My 	135.2625
+T	40 81 71 w=17.2466	(End)
+Mx 	138.6622
+T	70 72 81 87 72 85 72 71 w=39.9824	(centered)
+Mx 	14.8819
+My 	148.4625
+T	37 72 74 76 81 w=25.5449	(Begin)
+Mx 	42.8492
+T	79 72 73 87 w=15.2700	(left)
+Mx 	58.1192
+T	16 w=3.7061	(-)
+Mx 	61.8252
+T	68 79 76 74 81 72 71 w=33.2471	(aligned)
+Mx 	125.8695
+My 	171.6527
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	129.6795
+My 	167.9027
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	131.5115
+T	874 w=4.5280	(nil)
+Mx 	139.2472
+My 	171.6527
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	148.5050
+T	2061 w=6.4800	(nil)
+Mx 	154.9850
+T	18 w=4.6500	(nil)
+Mx 	270.6226
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	11 w=3.4858	(()
+Mx 	274.1084
+T	22 w=5.1616	(3)
+Mx 	279.2701
+T	12 w=3.4858	())
+Mx 	14.8819
+My 	194.8430
+T	40 81 71 w=17.2466	(End)
+Mx 	34.5508
+T	79 72 73 87 w=15.2700	(left)
+Mx 	49.8209
+T	16 w=3.7061	(-)
+Mx 	53.5269
+T	68 79 76 74 81 72 71 w=33.2471	(aligned)
+Mx 	86.7740
+T	17 w=2.5190	(.)
+Mx 	195.2769
+My 	208.0430
+T	37 72 74 76 81 w=25.5449	(Begin)
+Mx 	223.2442
+T	85 76 74 75 87 w=22.5586	(right)
+Mx 	245.8028
+T	16 w=3.7061	(-)
+Mx 	249.5088
+T	68 79 76 74 81 72 71 w=33.2471	(aligned)
+Mx 	125.8695
+My 	231.2332
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	129.6795
+My 	227.4832
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	131.5115
+T	874 w=4.5280	(nil)
+Mx 	139.2472
+My 	231.2332
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	148.5050
+T	2061 w=6.4800	(nil)
+Mx 	154.9850
+T	18 w=4.6500	(nil)
+Mx 	270.6226
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	11 w=3.4858	(()
+Mx 	274.1084
+T	23 w=5.1616	(4)
+Mx 	279.2701
+T	12 w=3.4858	())
+Mx 	203.5752
+My 	254.4234
+T	40 81 71 w=17.2466	(End)
+Mx 	223.2442
+T	85 76 74 75 87 w=22.5586	(right)
+Mx 	245.8028
+T	16 w=3.7061	(-)
+Mx 	249.5088
+T	68 79 76 74 81 72 71 w=33.2471	(aligned)
+Mx 	14.8819
+My 	267.6234
+T	38 88 86 87 82 80 w=34.1279	(Custom)
+Mx 	51.4559
+T	70 82 88 81 87 72 85 w=35.4600	(counter)
+Mx 	96.6255
+My 	293.4798
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+Mx 	2.9400
+T	3796 a=4.0500	(nil)
+Mx 	100.6883
+My 	285.3548
+T	2732 w=4.9200	(nil)
+Mx 	105.2483
+My 	287.4548
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	17 w=3.7200	(nil)
+Mx 	115.3983
+My 	285.3548
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	127.8783
+T	2689 w=6.2100	(nil)
+Mx 	100.6755
+My 	300.8048
+T	2732 w=4.9200	(nil)
+Mx 	105.2355
+My 	302.9048
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2725 w=3.7328	(nil)
+Mx 	115.3983
+My 	300.8048
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	127.8783
+T	2729 w=3.8000	(nil)
+Mx 	133.9005
+T	151 w=5.1000	(nil)
+Mx 	141.2228
+T	2732 w=4.9200	(nil)
+Mx 	145.7828
+My 	302.9048
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2725 w=3.7328	(nil)
+Mx 	149.5156
+T	2061 w=5.1840	(nil)
+Mx 	154.6996
+T	18 w=3.7200	(nil)
+Mx 	158.8496
+My 	300.8048
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	13 w=2.2000	(nil)
+Mx 	162.7162
+T	2043 w=4.8800	(nil)
+Mx 	167.5962
+T	2725 w=4.7100	(nil)
+Mx 	175.0840
+T	2589 w=6.4800	(nil)
+Mx 	184.3418
+T	18 w=4.6500	(nil)
+Mx 	270.7354
+My 	293.4798
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	11 w=3.4858	(()
+Mx 	274.2212
+T	68 w=5.0488	(a)
+Mx 	279.2701
+T	12 w=3.4858	())
+Mx 	14.8819
+My 	322.3002
+T	39 76 85 72 70 87 w=27.5322	(Direct)
+Mx 	44.8592
+T	81 88 80 69 72 85 76 81 74 w=50.1714	(numbering)
+Mx 	122.9207
+My 	345.4905
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	18 w=4.6500	(nil)
+Mx 	130.3485
+T	30 w=6.4800	(nil)
+Mx 	139.6063
+T	2061 w=6.4800	(nil)
+Mx 	146.0863
+T	2717 w=3.8100	(nil)
+Mx 	149.8963
+My 	341.7405
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	151.7283
+T	874 w=4.5280	(nil)
+Mx 	264.7251
+My 	345.4905
+Set font 	Gentium Plus;11;400;;normal;;;LTR
+T	11 w=3.4858	(()
+Mx 	268.2110
+T	24 38 w=11.0591	(5C)
+Mx 	279.2701
+T	12 w=3.4858	())
+End page
+Finish

--- a/tests/feat-math-display-numbered.sil
+++ b/tests/feat-math-display-numbered.sil
@@ -1,0 +1,45 @@
+\begin[papersize=a6]{document}
+\nofolios
+\neverindent
+\use[module=packages.lorem]
+\use[module=packages.math]
+\font[size=11pt]
+% Test numbered display math for all options
+% and in all alignments
+
+Begin justified
+\math[mode=display, numbered=true]{e^{i\pi} = -1}
+End justified.
+
+\begin{center}
+Begin centered
+\math[mode=display, numbered=true]{e^{i\pi} = -1}
+End centered
+\end{center}
+
+\begin{raggedright}
+Begin left-aligned
+\math[mode=display, numbered=true]{e^{i\pi} = -1}
+End left-aligned.
+\end{raggedright}
+
+\begin{raggedleft}
+Begin right-aligned
+\math[mode=display, numbered=true]{e^{i\pi} = -1}
+End right-aligned
+\end{raggedleft}
+
+Custom counter
+\set-counter[id=my-counter, display=alpha]
+\begin[mode=display, counter=my-counter]{math}
+    \{
+    \table[columnalign=right center left]{
+        u_0 &=& C \\
+        u_n &=& r \times u_{n−1}, \forall n ⩾ 1 \\
+    }
+\end{math}
+
+Direct numbering
+\math[mode=display, number=5C]{1 = -e^{i\pi}}
+
+\end{document}

--- a/tests/feat-math-display-unnumbered.expected
+++ b/tests/feat-math-display-unnumbered.expected
@@ -1,0 +1,141 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	36.8819
+My 	28.8853
+Set font 	Gentium Plus;10.45;400;;normal;;;LTR
+T	37 72 74 76 81 w=24.2677	(Begin)
+Mx 	63.4695
+T	77 88 86 87 76 737 72 71 w=35.0493	(justified)
+Mx 	131.9361
+My 	51.4155
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	135.7461
+My 	47.6655
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	137.5781
+T	874 w=4.5280	(nil)
+Mx 	145.3139
+My 	51.4155
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	154.5717
+T	2061 w=6.4800	(nil)
+Mx 	161.0517
+T	18 w=4.6500	(nil)
+Mx 	36.8819
+My 	73.9458
+Set font 	Gentium Plus;10.45;400;;normal;;;LTR
+T	40 81 71 w=16.3843	(End)
+Mx 	55.5867
+T	77 88 86 87 76 737 72 71 w=35.0493	(justified)
+Mx 	90.6360
+T	17 w=2.3931	(.)
+Mx 	116.5428
+My 	86.4858
+T	37 72 74 76 81 w=24.2677	(Begin)
+Mx 	143.1117
+T	70 72 81 87 72 85 72 71 w=37.9833	(centered)
+Mx 	131.9361
+My 	109.0160
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	135.7461
+My 	105.2660
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	137.5781
+T	874 w=4.5280	(nil)
+Mx 	145.3139
+My 	109.0160
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	154.5717
+T	2061 w=6.4800	(nil)
+Mx 	161.0517
+T	18 w=4.6500	(nil)
+Mx 	120.4845
+My 	131.5463
+Set font 	Gentium Plus;10.45;400;;normal;;;LTR
+T	40 81 71 w=16.3843	(End)
+Mx 	139.1700
+T	70 72 81 87 72 85 72 71 w=37.9833	(centered)
+Mx 	36.8819
+My 	144.0863
+T	37 72 74 76 81 w=24.2677	(Begin)
+Mx 	63.4508
+T	79 72 73 87 w=14.5065	(left)
+Mx 	77.9573
+T	16 w=3.5208	(-)
+Mx 	81.4781
+T	68 79 76 74 81 72 71 w=31.5847	(aligned)
+Mx 	131.9361
+My 	166.6165
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	135.7461
+My 	162.8665
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	137.5781
+T	874 w=4.5280	(nil)
+Mx 	145.3139
+My 	166.6165
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	154.5717
+T	2061 w=6.4800	(nil)
+Mx 	161.0517
+T	18 w=4.6500	(nil)
+Mx 	36.8819
+My 	189.1467
+Set font 	Gentium Plus;10.45;400;;normal;;;LTR
+T	40 81 71 w=16.3843	(End)
+Mx 	55.5674
+T	79 72 73 87 w=14.5065	(left)
+Mx 	70.0739
+T	16 w=3.5208	(-)
+Mx 	73.5947
+T	68 79 76 74 81 72 71 w=31.5847	(aligned)
+Mx 	105.1794
+T	17 w=2.3931	(.)
+Mx 	177.6509
+My 	201.6867
+T	37 72 74 76 81 w=24.2677	(Begin)
+Mx 	204.2198
+T	85 76 74 75 87 w=21.4307	(right)
+Mx 	225.6504
+T	16 w=3.5208	(-)
+Mx 	229.1712
+T	68 79 76 74 81 72 71 w=31.5847	(aligned)
+Mx 	131.9361
+My 	224.2170
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2717 w=3.8100	(nil)
+Mx 	135.7461
+My 	220.4670
+Set font 	Libertinus Math;8;400;Regular;normal;;;LTR
+T	2720 w=1.8320	(nil)
+Mx 	137.5781
+T	874 w=4.5280	(nil)
+Mx 	145.3139
+My 	224.2170
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	154.5717
+T	2061 w=6.4800	(nil)
+Mx 	161.0517
+T	18 w=4.6500	(nil)
+Mx 	185.5343
+My 	246.7472
+Set font 	Gentium Plus;10.45;400;;normal;;;LTR
+T	40 81 71 w=16.3843	(End)
+Mx 	204.2198
+T	85 76 74 75 87 w=21.4307	(right)
+Mx 	225.6504
+T	16 w=3.5208	(-)
+Mx 	229.1712
+T	68 79 76 74 81 72 71 w=31.5847	(aligned)
+End page
+Finish

--- a/tests/feat-math-display-unnumbered.sil
+++ b/tests/feat-math-display-unnumbered.sil
@@ -1,0 +1,35 @@
+\begin[papersize=a6]{document}
+\nofolios
+\neverindent
+\use[module=packages.lorem]
+\use[module=packages.math]
+\font[size=11pt]
+% Test default (unnumbered) display math
+% within a blockquote (to check it honors margin skips)
+% and in all alignments
+
+\begin{blockquote}
+Begin justified
+\math[mode=display]{e^{i\pi} = -1}
+End justified.
+
+\begin{center}
+Begin centered
+\math[mode=display]{e^{i\pi} = -1}
+End centered
+\end{center}
+
+\begin{raggedright}
+Begin left-aligned
+\math[mode=display]{e^{i\pi} = -1}
+End left-aligned.
+\end{raggedright}
+
+\begin{raggedleft}
+Begin right-aligned
+\math[mode=display]{e^{i\pi} = -1}
+End right-aligned
+\end{raggedleft}
+\end{blockquote}
+
+\end{document}


### PR DESCRIPTION
Something is better than nothing -- This is a curated re-implementation of @leorosa 's #1821 taking into account all comments there.

 - `\math[mode=display]{...}` works as before
 - `\math[mode=display, numbered=true]{...}` uses counter "equation" for numbering
 - `\math[mode=display, counter=id]{...}` uses counter `id` for numbering
 - `\math[mode=display, number=xxx]{...}` uses direct value `xxx` as number, would the use want any unusual equation "naming" which can't be achieved by a regular counter

Two test files are also included.
(While the package code does not depend on it, tests uses the blockquote environment for checking margin stkips are honored, hence the 0.15 milestone label).

STILL TO DO: Generate the text expectations (my fresh install of SILE using the nix flake for the "develop" branch doesn't have the appropriate font versions, and I don't want to alter the host's fonts)