### PR TITLE
Manual: Bump url and rules to high status

### DIFF
--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -117,7 +117,7 @@ This section covers a range of different topics from initial capitals to text tr
 \package-documentation{unichar}
 
 \subsection{url}
-\status:medium
+\status:high
 \package-documentation{url}
 
 \subsection{gutenberg}
@@ -146,7 +146,7 @@ Line-filling patterns or rules, rectangular blobs of inks... What else to say?
 \package-documentation{leaders}
 
 \subsection{rules}
-\status:medium
+\status:high
 \package-documentation{rules}
 
 \section{Boxes & Effects}


### PR DESCRIPTION
A.k.a. "Good maturity"
The main concern here is that some constructs previously used an hbox, and could not span multiples lines.
They now use "liners" supporting this use case.
Other refactors also made the code much better.

That is, features currently on develop --> for 0.15.0 as well.

Note: The same would be true for the **pdf** packages, but the latter has other concerns too (naming, scope, outputter interfacing) which in my opinion mandate it being left as "medium" (a.k.a. "Usable with limitations")