### PR TITLE
Fix spelling mistakes in simpletable package documentation

### DIFF
--- a/packages/simpletable/init.lua
+++ b/packages/simpletable/init.lua
@@ -101,10 +101,10 @@ This implements (badly) a very simple table formatting class.
 It should be called as so:
 
 \begin[type=autodoc:codeblock]{raw}
-myclass:loadpackage("simpletable", {
- tabletag = "a",
- trtag = "b",
- tdtag = "c"
+myclass:loadPackage("simpletable", {
+ tableTag = "a",
+ trTag = "b",
+ tdTag = "c"
 })
 \end{raw}
 


### PR DESCRIPTION
This PR fixes the `simpletable` package documentation.

But I would also ask your opinion on the following: today this package must be called from a class, and calling it from a document raises an error. I think that this behavior is not intentional, given the tests present in line 15:
`   if type(options) ~= "table" or pl.tablex.size(options) <= 3 then`
When `simpletable` is called from a document, it receives a table as `options`, and its size is 12. Thus, the check in line 15 fails.
What do you think, to change the second test to
`   if type(options) ~= "table" or pl.tablex.size(options) ~= 3 then`
?