### PR TITLE
Optimize typesetter mode handling

### DIFF
--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -931,6 +931,7 @@ function typesetter:outputLinesToPage (lines)
 end
 
 function typesetter:leaveHmode (independent)
+   if self:vmode() then return end
    if self.state.hmodeOnly then
       SU.error([[Paragraphs are forbidden in restricted horizontal mode.]])
    end


### PR DESCRIPTION
This is awkward. I was working on something else and thought I spotted an easy way to optimize the typesetter look and save quite a bit of time. I threw it in and kept working on my other thing intenting to come back and benchmark it later.

It turns out this broke the world. Some tests started generating infinite pages and building the manual started hanging completely.

This means that `typesetter:leaveHmode()` is doing work even when already in vertical mode. I would have expected all the node queue processing to be a noop.

This is almost certainly intertwined with other `typesetter:pushBack()` issues that have surfaced, but perhaps the fact that this function is doing work outside of its labeled scope is a clue where the algorythm is breaking down.
