### PR TITLE
Add three missing syllables of Brazilian Portuguese

### DIFF
--- a/languages/pt.lua
+++ b/languages/pt.lua
@@ -4,6 +4,7 @@ SILE.nodeMakers.pt = pl.class(SILE.nodeMakers.unicode)
 SILE.nodeMakers.pt.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
 SILE.nodeMakers.pt.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
 
+-- further patterns "1nô", "1tô" and "1cô" were added for Brazilian Portuguese
 SILE.hyphenator.languages["pt"] = {}
 SILE.hyphenator.languages["pt"].patterns = {
    "1b2l",
@@ -32,6 +33,7 @@ SILE.hyphenator.languages["pt"].patterns = {
    "1cu",
    "1cá",
    "1câ",
+   "1cô",
    "1cã",
    "1cé",
    "1cí",
@@ -172,6 +174,7 @@ SILE.hyphenator.languages["pt"].patterns = {
    "1nu",
    "1ná",
    "1nâ",
+   "1nô",
    "1nã",
    "1né",
    "1ní",
@@ -236,6 +239,7 @@ SILE.hyphenator.languages["pt"].patterns = {
    "1tu",
    "1tá",
    "1tâ",
+   "1tô",
    "1tã",
    "1té",
    "1tí",


### PR DESCRIPTION
This PR follows the problem in #2001... And yes, only three syllables, that's all when it comes to the pairs like ó/ô for PT-PT and PT-BR, respectively. Regarding to further differences between these two branches of Portuguese, they aren't related to anything this file has to do... And since the 1990 we have this Agreement among all the Lusophone countries, according to which:

> As for divergent spellings such as *anónimo* and *anônimo*, facto and fato, both will be considered legitimate, according to the dialect of the author or person being transcribed.[^*]

[^*]: (https://en.wikipedia.org/wiki/Portuguese_Language_Orthographic_Agreement_of_1990)