### PR TITLE
Escape Unicode so over-zealous code linters don't flip out

### DIFF
--- a/outputters/text.lua
+++ b/outputters/text.lua
@@ -57,13 +57,13 @@ function outputter:setCursor (x, y, relative)
          if newy - cursorY > bs then
             outfile:write("\n")
          else
-            outfile:write("‫")
+            outfile:write("\u{202b}")
          end
       elseif newx > cursorX then
          if newx:tonumber() - cursorX:tonumber() > spc then
             outfile:write(" ")
          else
-            outfile:write("‫")
+            outfile:write("\u{202b}")
          end
       end
    end


### PR DESCRIPTION
Pun intended.

Looking at you Fedora, GitHub, and browser based editors.

c.f. https://artifacts.dev.testing-farm.io/0eb6559c-43aa-43fd-a0f7-b653dfd5013e/
c.f. https://bugzilla.redhat.com/show_bug.cgi?id=2149698#c37
