### PR TITLE
TeX-math limits and other commands behaving as big ops

### DIFF
--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -493,6 +493,11 @@ compileToMathML(
 
   % From amsmath:
   \def{to}{\mo[atom=bin]{→}}
+  \def{gcd}{\mo[atom=big]{gcd}}
+  \def{sup}{\mo[atom=big]{sup}}
+  \def{inf}{\mo[atom=big]{inf}}
+  \def{max}{\mo[atom=big]{max}}
+  \def{min}{\mo[atom=big]{min}}
   % Those use U+202F NARROW NO-BREAK SPACE in their names
   \def{limsup}{\mo[atom=big]{lim sup}}
   \def{liminf}{\mo[atom=big]{lim inf}}


### PR DESCRIPTION
Movin' forward...

One needs [incentives](https://en.wikipedia.org/wiki/Laplace%27s_method#Formal_statement_and_proof), so the target should be:[^1]

![image](https://github.com/user-attachments/assets/344162f4-7618-4503-b3a8-d2cbb375b320)

Closes #2131 

Closes #2130 

(The latter being... a side effect ;)

[^1]: This target also requires `\text` support... #2140 
