### PR TITLE
feat(math): Support MathML mtext and ms elements

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -908,8 +908,8 @@ end
 
 function elements.text:_init (kind, attributes, script, text)
    elements.terminal._init(self)
-   if not (kind == "number" or kind == "identifier" or kind == "operator") then
-      SU.error("Unknown text node kind '" .. kind .. "'; should be one of: number, identifier, operator")
+   if not (kind == "number" or kind == "identifier" or kind == "operator" or kind == "string") then
+      SU.error("Unknown text node kind '" .. kind .. "'; should be one of: number, identifier, operator, string")
    end
    self.kind = kind
    self.script = script

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -45,7 +45,7 @@ function ConvertMathML (_, content)
       local script = content.options.mathvariant and b.mathVariantToScriptType(content.options.mathvariant)
       local text = content[1]
       if type(text) ~= "string" then
-         SU.error("mi command contains " .. text .. ", which is not text")
+         SU.error("mi command contains content which is not text")
       end
       script = script or (luautf8.len(text) == 1 and b.scriptType.italic or b.scriptType.upright)
       return b.text("identifier", {}, script, text)
@@ -67,7 +67,7 @@ function ConvertMathML (_, content)
          end
       end
       if type(text) ~= "string" then
-         SU.error("mo command contains " .. text .. ", which is not text")
+         SU.error("mo command contains content which is not text")
       end
       return b.text("operator", attributes, script, text)
    elseif content.command == "mn" then
@@ -75,7 +75,7 @@ function ConvertMathML (_, content)
          or b.scriptType.upright
       local text = content[1]
       if type(text) ~= "string" then
-         SU.error("mn command contains " .. text .. ", which is not text")
+         SU.error("mn command contains content which is not text")
       end
       if string.sub(text, 1, 1) == "-" then
          text = "−" .. string.sub(text, 2)
@@ -136,6 +136,19 @@ function ConvertMathML (_, content)
       return b.mtr(convertChildren(content))
    elseif content.command == "mtd" then
       return b.stackbox("H", convertChildren(content))
+   elseif content.command == "mtext" or content.command == "ms" then
+      if #content > 1 then
+         SU.error("Wrong number of children in " .. content.command .. ": " .. #content)
+      end
+      local text = content[1] or "" -- empty mtext is allowed, and found in examples...
+      if type(text) ~= "string" then
+         SU.error(content.command .. " command contains content which is not text")
+      end
+      -- MathML Core 3.2.1.1 Layout of <mtext> has some wording about forced line breaks
+      -- and soft wrap opportunities: ignored here.
+      -- There's also some explanations about CSS, italic correction etc. which we ignore too.
+      text = text:gsub("[\n\r]", " ")
+      return b.text("string", {}, b.scriptType.upright, text:gsub("%s+", " "))
    else
       SU.error("Unknown math command " .. content.command)
    end


### PR DESCRIPTION
Ticking one box in #2138 

I am on a quest, sort of...

So let's derive the [Quadratic Formula](https://developer.mozilla.org/en-US/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula).

![image](https://github.com/user-attachments/assets/cc2c51e4-abdf-4425-a17b-5ca6e7199bfe)
