### PR TITLE
Support MathML mroot

### DIFF
--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -134,6 +134,9 @@ function ConvertMathML (_, content)
       local children = convertChildren(content)
       -- "The <msqrt> element generates an anonymous <mrow> box called the msqrt base
       return b.sqrt(b.stackbox("H", children))
+   elseif content.command == "mroot" then
+      local children = convertChildren(content)
+      return b.sqrt(children[1], children[2])
    elseif content.command == "mtable" or content.command == "table" then
       local children = convertChildren(content)
       return b.table(children, content.options)

--- a/shapers/base.lua
+++ b/shapers/base.lua
@@ -68,7 +68,7 @@ function shaper:measureChar (char)
    options.tracking = SILE.settings:get("shaper.tracking")
    local items = self:shapeToken(char, options)
    if #items > 0 then
-      return { height = items[1].height, width = items[1].width }
+      return { height = items[1].height, width = items[1].width, depth = items[1].depth }
    else
       SU.error("Unable to measure character", char)
    end


### PR DESCRIPTION
Ticks a box in #2120 

![image](https://github.com/user-attachments/assets/5ef1afb5-e4a5-4038-af2b-6dc011306ee8)

Also slightly improved the look of the "fake" radical sign (both mroot and msqrt use the same common implementation node)
