### PR TITLE
Support MathML mphantom and TeX-like phantom, hphantom, vphantom

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -533,6 +533,43 @@ end
 
 function elements.stackbox.output (_, _, _, _) end
 
+elements.phantom = pl.class(elements.stackbox) -- inherit from stackbox
+elements.phantom._type = "Phantom"
+
+function elements.phantom:_init (children, special)
+   -- MathML core 3.3.7:
+   -- "Its layout algorithm is the same as the mrow element".
+   -- Also not the MathML states that <mphantom> is sort of legacy, "implemented
+   -- for compatibility with full MathML. Authors whose only target is MathML
+   -- Core are encouraged to use CSS for styling."
+   -- The thing is that we don't have CSS in SILE, so supporting <mphantom> is
+   -- a must.
+   elements.stackbox._init(self, "H", children)
+   self.special = special
+end
+
+function elements.phantom:shape ()
+   elements.stackbox.shape(self)
+   -- From https://latexref.xyz:
+   -- "The \vphantom variant produces an invisible box with the same vertical size
+   -- as subformula, the same height and depth, but having zero width.
+   -- And \hphantom makes a box with the same width as subformula but
+   -- with zero height and depth."
+   if self.special == "v" then
+      self.width = SILE.types.length()
+   elseif self.special == "h" then
+      self.height = SILE.types.length()
+      self.depth = SILE.types.length()
+   end
+end
+
+function elements.phantom:output (_, _, _)
+   -- Note the trick here: when the tree is rendered, the node's output
+   -- function is invoked, then all its children's output functions.
+   -- So we just cancel the list of children here, before it's rendered.
+   self.children = {}
+end
+
 elements.subscript = pl.class(elements.mbox)
 elements.subscript._type = "Subscript"
 

--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -499,6 +499,11 @@ compileToMathML(
   % Modulus operator forms
   \def{bmod}{\mo{mod}}
   \def{pmod}{\quad(\mo{mod} #1)}
+
+  % Phantom commands from TeX/LaTeX
+  \def{phantom}{\mphantom{#1}}
+  \def{hphantom}{\mphantom[special=h]{#1}}
+  \def{vphantom}{\mphantom[special=v]{#1}}
 ]==],
    })
 )

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -41,6 +41,11 @@ function ConvertMathML (_, content)
       return b.stackbox("V", convertChildren(content))
    elseif content.command == "mrow" then
       return b.stackbox("H", convertChildren(content))
+   elseif content.command == "mphantom" then
+      -- MathML's standard mphantom corresponds to TeX's \phantom only.
+      -- Let's support a special attribute "h" or "v" for TeX-like \hphantom or \vphantom.
+      local special = content.options.special
+      return b.phantom(convertChildren(content), special)
    elseif content.command == "mi" then
       local script = content.options.mathvariant and b.mathVariantToScriptType(content.options.mathvariant)
       local text = content[1]


### PR DESCRIPTION
On the quest to tick another box in #2138

 - MathML `<mphantom>`: MathML Core encourages the use of CSS for styling, but of course we don't have that. It's still a valid "full MathML" construct though.
   References:
    - https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom
    - https://www.w3.org/TR/mathml4/#presm_mphantom

 - TeX/LaTeX `\phantom`, `\hphantom` and `vphantom` are no-brain implementations, with a small special extra attribute to MathML (`<mphantom>` only corresponds to `\phantom`).
   References:
    - https://latexref.xyz/_005cphantom-_0026-_005cvphantom-_0026-_005chphantom.html

**Note**: MathML has some extra considerations such as the "form" of operators in a phantom formula (e.g. `<mo form="infix">+</mo> ...`  - This is not addressed here, and would require a more general handling of attributes, which is another point in #2138...