### PR TITLE
feat(math): Support MathML bevelled fractions

### DIFF
--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -147,7 +147,9 @@ function ConvertMathML (_, content)
       if #children ~= 2 then
          SU.error("Wrong number of children in mfrac: " .. #children)
       end
-      return b.fraction(content.options, children[1], children[2])
+      return SU.boolean(content.options.bevelled, false)
+            and b.bevelledFraction(content.options, children[1], children[2])
+         or b.fraction(content.options, children[1], children[2])
    elseif content.command == "msqrt" then
       local children = convertChildren(content)
       -- "The <msqrt> element generates an anonymous <mrow> box called the msqrt base


### PR DESCRIPTION
Bevelled fractions (also known as skewed or diagonal fractions) are displayed with a slanted line (slash) instead of a horizontal bar.

Although this feature is still included in MathML4, it has been [excluded from the MathML Core](https://github.com/w3c/mathml/issues/29#issuecomment-2276354003) specifications.
As a result, most browsers are unlikely to support bevelled fractions...
But SILE is not a browser -- so it has the freedom to implement a broader standard! :cake: 

As stated in the in-code comments, though, MathML4 does not exactly specify how to compute the layout, and the related OpenType math parameters are, at best, unclear[^1] -- and not pleasant looking; moreover there's no clear distinction for display / cramped / text modes... :cactus: 

So I went for my own interpretation, also looking at various TeX packages (nicefrac, xfrac) for references. I do like the result:[^2]

![image](https://github.com/user-attachments/assets/c2e16ff0-fbe0-4139-bb0f-a0015db95d9e)

Oh, as a final note -- I'm going to enter the debate on the ~~insane~~ glyph assembly logic once again... _So yes,_ the proposed code draws a line. A mere line, of appropriate thickness (incl. the linethickness attribute when specified) :lollipop: 

[^1]: After writing this, I found a ConTeXt manual (Hans Hagen & Mikael P. Sundqvist, _Mathematics in ConTEXt,_  August 7, 2024 edition):  SkewedFractionHorizontalGap and SkewedFractionVerticalGap "do not make sense (for us) so we do not use them." -- It's an interesting reading, by the way.

[^2]: I don't think lowering the fraction with respect to the baseline is the _right_ thing to do. But see previous note: the mentioned ConTeXt book does it. Well, with plenty of other options etc. -- Likely beyond our own scope for now.