### PR TITLE
Use en-US instead of en-GB spelling for math types

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -1594,12 +1594,12 @@ end
 
 function elements.padded.output (_, _, _, _) end
 
--- Bevelled fractions are not part of MathML Core, and MathML4 does not
+-- Beveled fractions are not part of MathML Core, and MathML4 does not
 -- exactly specify how to compute the layout.
-elements.bevelledFraction = pl.class(elements.fraction) -- Inherit from fraction
-elements.fraction._type = "BevelledFraction"
+elements.beveledFraction = pl.class(elements.fraction) -- Inherit from fraction
+elements.fraction._type = "BeveledFraction"
 
-function elements.bevelledFraction:shape ()
+function elements.beveledFraction:shape ()
    local constants = self:getMathMetrics().constants
    local scaleDown = self:getScaleDown()
    local hSkew = constants.skewedFractionHorizontalGap * scaleDown
@@ -1628,7 +1628,7 @@ function elements.bevelledFraction:shape ()
    self.barX = self.numerator.relX + self.numerator.width
 end
 
-function elements.bevelledFraction:output (x, y, line)
+function elements.beveledFraction:output (x, y, line)
    local h = self.height:tonumber()
    local d = self.depth:tonumber()
    local barwidth = scaleWidth(self.barWidth, line):tonumber()

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -147,8 +147,8 @@ function ConvertMathML (_, content)
       if #children ~= 2 then
          SU.error("Wrong number of children in mfrac: " .. #children)
       end
-      return SU.boolean(content.options.bevelled, false)
-            and b.bevelledFraction(content.options, children[1], children[2])
+      return SU.boolean(content.options.beveled, false)
+            and b.beveledFraction(content.options, children[1], children[2])
          or b.fraction(content.options, children[1], children[2])
    elseif content.command == "msqrt" then
       local children = convertChildren(content)
@@ -214,7 +214,7 @@ local function handleMath (_, mbox, options)
 
    if mode == "display" then
       -- See https://github.com/sile-typesetter/sile/issues/2160
-      --    We are not excactly doing the right things here with respect to
+      --    We are not exactly doing the right things here with respect to
       --    paragraphing expectations.
       -- The vertical penalty will flush the previous paragraph, if any.
       SILE.call("penalty", { penalty = SILE.settings:get("math.predisplaypenalty"), vertical = true })


### PR DESCRIPTION
I missed this in reviewing #2165, but we've been using en-US spelling though most of the code base. Two Ls in bevelled appears to be an en-GB thing.

Is there any particular reason *not* to stick with US spellings in math? Obviously this has some impact on people using this feature, so if there is any precident in the science and math publishing world for one over the other I'd be happy to follow it.
