### PR TITLE
fix(math): Erroneous capital H and I in fraktur variant

### DIFF
--- a/packages/math/unicode-mathvariants.lua
+++ b/packages/math/unicode-mathvariants.lua
@@ -77,8 +77,8 @@ local mathScriptConversionTable = {
       [scriptType.fraktur] = function (codepoint)
          -- MathML Core "fraktur" (annex C.5)
          return codepoint == 0x43 and 0x212D -- C
-            or codepoint == 0x48 and 0x210B -- H
-            or codepoint == 0x49 and 0x2110 -- I
+            or codepoint == 0x48 and 0x210C -- H
+            or codepoint == 0x49 and 0x2111 -- I
             or codepoint == 0x52 and 0x211C -- R
             or codepoint == 0x5A and 0x2128 -- Z
             or codepoint + 0x1D504 - 0x41


### PR DESCRIPTION
Despite having built a table to check all these, I overlooked those two where I had a mere copy & paste issue from the wrong mapping table.