### PR TITLE
Math overset/underset and munder/mover spacing

### DIFF
--- a/tests/math-underset-overset.expected
+++ b/tests/math-underset-overset.expected
@@ -1,0 +1,111 @@
+Set paper size 	297.6377985	419.5275636
+Begin page
+Mx 	135.0361
+My 	27.5564
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2720 w=7.0300	(nil)
+Mx 	144.8439
+T	1960 w=9.1200	(nil)
+Mx 	156.7417
+T	2721 w=5.8600	(nil)
+Mx 	135.0361
+My 	57.7204
+T	2720 w=7.0300	(nil)
+Mx 	144.8439
+T	1960 w=9.1200	(nil)
+Mx 	147.1823
+My 	64.0844
+Set font 	Libertinus Math;8;400;Regular;normal;+ssty=1;;LTR
+T	2751 w=4.4432	(nil)
+Mx 	156.7417
+My 	57.7204
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2721 w=5.8600	(nil)
+Mx 	135.0361
+My 	98.6205
+T	2720 w=7.0300	(nil)
+Mx 	147.1823
+My 	90.7365
+Set font 	Libertinus Math;8;400;Regular;normal;+ssty=1;;LTR
+T	2751 w=4.4432	(nil)
+Mx 	144.8439
+My 	98.6205
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	1960 w=9.1200	(nil)
+Mx 	156.7417
+T	2721 w=5.8600	(nil)
+Mx 	132.4961
+My 	128.7846
+T	2720 w=7.0300	(nil)
+Mx 	142.3039
+T	2577 w=14.2000	(nil)
+Mx 	159.2817
+T	2721 w=5.8600	(nil)
+Mx 	132.4961
+My 	160.5326
+T	2720 w=7.0300	(nil)
+Mx 	144.1455
+My 	153.5526
+Set font 	Libertinus Math;8;400;Regular;normal;+ssty=1;;LTR
+T	69 70 71 w=10.5168	(nil)
+Mx 	142.3039
+My 	160.5326
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2577 w=14.2000	(nil)
+Mx 	159.2817
+T	2721 w=5.8600	(nil)
+Mx 	128.7121
+My 	190.6967
+T	2720 w=7.0300	(nil)
+Mx 	142.3039
+T	2577 w=14.2000	(nil)
+Mx 	138.5199
+My 	197.0607
+Set font 	Libertinus Math;8;400;Regular;normal;+ssty=1;;LTR
+T	66 77 78 80 84 85 w=21.7680	(nil)
+Mx 	163.0657
+My 	190.6967
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2721 w=5.8600	(nil)
+Mx 	136.3561
+My 	222.8848
+T	2720 w=7.0300	(nil)
+Mx 	146.1639
+T	30 w=6.4800	(nil)
+Mx 	155.4217
+T	2721 w=5.8600	(nil)
+Mx 	136.3561
+My 	253.6348
+T	2720 w=7.0300	(nil)
+Mx 	147.0559
+My 	247.2848
+Set font 	Libertinus Math;8;400;Regular;normal;+ssty=1;;LTR
+T	51 w=4.6960	(nil)
+Mx 	146.1639
+My 	253.6348
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	30 w=6.4800	(nil)
+Mx 	155.4217
+T	2721 w=5.8600	(nil)
+Mx 	136.5017
+My 	283.7989
+T	2720 w=7.0300	(nil)
+Mx 	145.7539
+T	2219 w=7.3000	(nil)
+Mx 	155.2761
+T	2721 w=5.8600	(nil)
+Mx 	136.5017
+My 	313.9629
+T	2720 w=7.0300	(nil)
+Mx 	145.7539
+T	2219 w=7.3000	(nil)
+Mx 	146.4839
+My 	321.1889
+Set font 	Libertinus Math;8;400;Regular;normal;+ssty=1;;LTR
+T	41 w=5.8400	(nil)
+Mx 	155.2761
+My 	313.9629
+Set font 	Libertinus Math;10;400;Regular;normal;;;LTR
+T	2721 w=5.8600	(nil)
+End page
+Finish

--- a/tests/math-underset-overset.sil
+++ b/tests/math-underset-overset.sil
@@ -1,0 +1,25 @@
+\begin[papersize=a6]{document}
+\neverindent
+\nofolios
+\use[module=packages.math]
+% Test for TeX-like operator stacking (overset/underset)
+
+% Arrows have a rel atom type.
+\math[mode=display]{A \rightarrow B}% For comparison
+\math[mode=display]{A \underset{f}{\rightarrow} B}
+\math[mode=display]{A \overset{f}{\rightarrow} B}
+% Longer overset text.
+\math[mode=display]{A \implies B}% For comparison
+\math[mode=display]{A \overset{\text{def}}{\implies} B}
+% Even long underset text (bigger than the operator)
+\math[mode=display]{A \underset{\text{almost}}{\implies} B}
+
+% The = has a rel atom type too
+\math[mode=display]{A = B}% For comparison
+\math[mode=display]{A \overset{\mathrm{R}}{=} B}
+
+% \otimes has a bin atom type
+\math[mode=display]{A \otimes B}% For comparison
+\math[mode=display]{A \underset{\mathrm{H}}{\otimes} B}
+
+\end{document}


### PR DESCRIPTION
Closes #2133

Did I say that my remaining math tasks would be slightly controversial? 
Well, this one isn't really, provides a good TeX-like feature and fixes a spacing weirdness, along with a nice test.

_Yet,_ the code has some smell. Not really what I added, the smell was just here unrevealed, and now we are all eyes on it.
I've spent literally hours to try finding the root cause, with no result, so I went for the most minimal things I could do to make it work without breaking something else (esp. MathML tables)... I cannot spent more efforts here on such a "small" topic, while "accents" are still awaiting and the last big missing block in our math experience...

Still, I'd advocate for the PR to be accepted, it does it's job supporting a missing feature nicely, and maybe one day someone more clever will pinpoint the underlying design issue. Advice is welcome...