### PR TITLE
Sync Flake with nix derivation changes for easier extension of available Lua modules

### DIFF
--- a/build-aux/ax_lua_require.m4
+++ b/build-aux/ax_lua_require.m4
@@ -54,7 +54,7 @@ AC_DEFUN([AX_LUA_REQUIRE],[
         ACTION_IF_FOUND
     ], [
         AC_MSG_RESULT([unable to load])
-        m4_ifset([ACTION_IF_NOT_FOUND][ACTION_IF_NOT_FOUND],
+        m4_ifset([ACTION_IF_NOT_FOUND],[ACTION_IF_NOT_FOUND],
             [AC_MSG_FAILURE([cannot find Lua module MODULE])])
     ])
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732238832,
-        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
+        "lastModified": 1732971106,
+        "narHash": "sha256-pHO+NWd8wJGDuVJjyyxdgtcmiGhNNKbIIXLMLBPxJTI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
+        "rev": "f40efe1ce90f9cd692c8d56d9305fa6b9c07f211",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Hey @doronbehar, my attempt to port the upstream packaging changes to the sile derivation to the flake here did not go quite as planned. It builds and runs, but it doesn't *work* as it should as evidenced by the fact that I can delete stuff in the `luaPackages` array and the build doesn't fail the configure stage where it should be detecting dependencies. That tells me the upstream package one is being used, not the locally defined one. I couldn't figue our the Nix language incantation to override the array in the passthru table and use it in the luaEnv at the same time.
