### PR TITLE
Properly format errors, avoid erroring after already triggering an error

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -27,8 +27,6 @@ globals = {
    "luautf8",
    "pl",
    "fluent",
-   "executablePath",
-   "extendSilePath",
 }
 max_line_length = false
 ignore = {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "mlua",
  "rust-embed",
  "semver",
+ "snafu",
  "vergen-gix",
 ]
 
@@ -1782,6 +1783,27 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ version = "0.15.7"
 [dependencies.anyhow]
 version = "1.0"
 
+[dependencies.snafu]
+version = "0.8"
+
 [dependencies.clap]
 version = "4.4"
 optional = true

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -181,10 +181,10 @@ local function runEvals (evals, arg)
    for _, snippet in ipairs(evals) do
       local pId = SILE.traceStack:pushText(snippet)
       local status, func = pcall(load, snippet)
-      if status then
+      if status and type(func) == "function" then
          func()
       else
-         SU.error(("Error parsing code provided in --%s snippet: %s"):format(arg, func))
+         SU.error(("Error parsing code provided in --%s snippet: %s"):format(arg, snippet))
       end
       SILE.traceStack:pop(pId)
    end

--- a/core/utilities/init.lua
+++ b/core/utilities/init.lua
@@ -332,7 +332,7 @@ function utilities.error (message, isbug)
    utilities.warn(message, isbug)
    _skip_traceback_levels = 2
    io.stderr:flush()
-   SILE.outputter:finish() -- Only really useful from the REPL but no harm in trying
+   SILE.outputter:finish()
    SILE.scratch.caughterror = true
    error("", 2)
 end

--- a/outputters/libtexpdf.lua
+++ b/outputters/libtexpdf.lua
@@ -68,12 +68,13 @@ end
 function outputter._endHook (_) end
 
 function outputter:finish ()
-   self:_ensureInit()
-   pdf.endpage()
-   self:runHooks("prefinish")
-   pdf.finish()
-   started = false
-   lastkey = nil
+   if started then
+      pdf.endpage()
+      self:runHooks("prefinish")
+      pdf.finish()
+      started = false
+      lastkey = nil
+   end
 end
 
 function outputter.getCursor (_)

--- a/rusile.rockspec.in
+++ b/rusile.rockspec.in
@@ -29,4 +29,3 @@ build = {
       "ru@PACKAGE_NAME@",
    },
 }
-

--- a/src/bin/sile.rs
+++ b/src/bin/sile.rs
@@ -1,18 +1,42 @@
+use sile::cli::Cli;
+
+use snafu::prelude::*;
+
 use clap::{CommandFactory, FromArgMatches};
 
-use sile::cli::Cli;
-use sile::Result;
+#[derive(Snafu)]
+enum Error {
+    #[snafu(display("{}", source))]
+    Args { source: clap::error::Error },
+
+    #[snafu(display("{}", source))]
+    Runtime { source: anyhow::Error },
+
+    #[snafu(display("{}", source))]
+    Version { source: anyhow::Error },
+}
+
+// Deeper error types are reported using the Debug trait, but we handle them via Snafu and the Display trait.
+// So we delegate. c.f. https://github.com/shepmaster/snafu/issues/110
+impl std::fmt::Debug for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, fmt)
+    }
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 fn main() -> Result<()> {
     let version = option_env!("VERGEN_GIT_DESCRIBE").unwrap_or_else(|| env!("CARGO_PKG_VERSION"));
     let version = version.replacen('-', ".r", 1);
-    let long_version = sile::version()?
+    let long_version = sile::version()
+        .context(VersionSnafu)?
         .strip_prefix("SILE ")
         .unwrap_or("")
         .to_string();
     let app = Cli::command().version(version).long_version(long_version);
     let matches = app.get_matches();
-    let args = Cli::from_arg_matches(&matches).expect("Unable to parse arguments");
+    let args = Cli::from_arg_matches(&matches).context(ArgsSnafu)?;
     sile::run(
         args.input,
         args.backend,
@@ -29,6 +53,7 @@ fn main() -> Result<()> {
         args.r#use,
         args.quiet,
         args.traceback,
-    )?;
+    )
+    .context(RuntimeSnafu)?;
     Ok(())
 }

--- a/src/embed.rs.in
+++ b/src/embed.rs.in
@@ -56,7 +56,7 @@ extern "C-unwind" {
 /// Register a Lua function in the loaders/searchers table to return C modules linked into the CLI
 /// binary and another to return embedded Lua resources as Lua modules. See discussion in mlua:
 /// https://github.com/khvzak/mlua/discussions/322
-pub fn inject_embedded_loaders(lua: &Lua) {
+pub fn inject_embedded_loaders(lua: Lua) -> crate::Result<Lua> {
     let package: LuaTable = lua.globals().get("package").unwrap();
     let loaders: LuaTable = match package.get("loaders").unwrap() {
         LuaValue::Table(loaders) => loaders,
@@ -164,4 +164,5 @@ pub fn inject_embedded_loaders(lua: &Lua) {
         })
         .unwrap();
     loaders.push(embedded_ftl_loader).unwrap();
+    Ok(lua)
 }


### PR DESCRIPTION
- **chore(deps): Depend on snafu for more robust error handling**
- **feat(cli): Output runtime errors pretty-printed for readability**
- **refactor(cli): Bubble-up more error conditions**
- **fix(outputters): Don't attempt to create output if we error before processing even starts**
- **fix(core): Avoid internal error when also erroring due to user provided content errors**
- **chore(tooling): Drop now obsolete lint exception for non-standard globals**
- **style(tooling): Restyle Lua code with stylua**
