### PR TITLE
Fix empty output regression

### DIFF
--- a/core/utilities/init.lua
+++ b/core/utilities/init.lua
@@ -332,7 +332,7 @@ function utilities.error (message, isbug)
    utilities.warn(message, isbug)
    _skip_traceback_levels = 2
    io.stderr:flush()
-   SILE.outputter:finish() -- Only really useful from the REPL but no harm in trying
+   SILE.outputter:abort()
    SILE.scratch.caughterror = true
    error("", 2)
 end

--- a/core/utilities/init.lua
+++ b/core/utilities/init.lua
@@ -332,7 +332,7 @@ function utilities.error (message, isbug)
    utilities.warn(message, isbug)
    _skip_traceback_levels = 2
    io.stderr:flush()
-   SILE.outputter:finish()
+   SILE.outputter:finish() -- Only really useful from the REPL but no harm in trying
    SILE.scratch.caughterror = true
    error("", 2)
 end

--- a/outputters/base.lua
+++ b/outputters/base.lua
@@ -29,6 +29,10 @@ end
 
 function outputter.newPage () end
 
+function outputter:abort ()
+   return self:finish() -- unless otherwise defined
+end
+
 function outputter:finish ()
    self:runHooks("prefinish")
 end

--- a/outputters/debug.lua
+++ b/outputters/debug.lua
@@ -46,6 +46,14 @@ function outputter:newPage ()
    self:_writeline("New page")
 end
 
+function outputter:abort ()
+   if started then
+      self:_writeline("Aborted")
+      outfile:close()
+      started = false
+   end
+end
+
 function outputter:finish ()
    if SILE.status.unsupported then
       self:_writeline("UNSUPPORTED")
@@ -54,6 +62,7 @@ function outputter:finish ()
    self:runHooks("prefinish")
    self:_writeline("Finish")
    outfile:close()
+   started = false
 end
 
 function outputter.getCursor (_)

--- a/outputters/libtexpdf.lua
+++ b/outputters/libtexpdf.lua
@@ -68,13 +68,12 @@ end
 function outputter._endHook (_) end
 
 function outputter:finish ()
-   if started then
-      pdf.endpage()
-      self:runHooks("prefinish")
-      pdf.finish()
-      started = false
-      lastkey = nil
-   end
+   self:_ensureInit()
+   pdf.endpage()
+   self:runHooks("prefinish")
+   pdf.finish()
+   started = false
+   lastkey = nil
 end
 
 function outputter.getCursor (_)

--- a/outputters/libtexpdf.lua
+++ b/outputters/libtexpdf.lua
@@ -67,13 +67,23 @@ end
 -- pdf structure package needs a tie in here
 function outputter._endHook (_) end
 
+function outputter.abort ()
+   if started then
+      pdf.endpage()
+      pdf.finish()
+      started = false
+      lastkey = false
+   end
+end
+
 function outputter:finish ()
+   -- allows generation of empty PDFs
    self:_ensureInit()
    pdf.endpage()
    self:runHooks("prefinish")
    pdf.finish()
    started = false
-   lastkey = nil
+   lastkey = false
 end
 
 function outputter.getCursor (_)

--- a/outputters/text.lua
+++ b/outputters/text.lua
@@ -15,7 +15,8 @@ outputter.extension = "txt"
 -- function outputter:_init () end
 
 function outputter:_ensureInit ()
-   if not outfile then
+   if not started then
+      started = true
       local fname = self:getOutputFilename()
       outfile = fname == "-" and io.stdout or io.open(fname, "w+")
    end
@@ -34,10 +35,17 @@ function outputter:newPage ()
    outfile:write("")
 end
 
+function outputter.abort ()
+   if started then
+      outfile:close()
+      started = false
+   end
+end
 function outputter:finish ()
    self:_ensureInit()
    self:runHooks("prefinish")
    outfile:close()
+   started = false
 end
 
 function outputter.getCursor (_)
@@ -79,7 +87,6 @@ function outputter:drawHbox (value, width)
    end
    self:_writeline(value.text)
    if width > 0 then
-      started = true
       cursorX = cursorX + width
    end
 end


### PR DESCRIPTION
In an attempt to not throw errors when closing a PDF we couldn't actually start, I busted the ability to generate empty PDFs. Notably `<sile></sile` would generate but `<sile><nofolios /></sile>` would *not* because there is no output on the page and hence it never gets initialized until it's time to finish. This makes a distinction between needing to possible close open PDF handles and abort after an error and successfully running all processing and outputting a blank canvas if called for.