### PR TITLE
Fix use of legacy \script function with non-modules

### DIFF
--- a/classes/base.lua
+++ b/classes/base.lua
@@ -479,7 +479,7 @@ function class:registerCommands ()
          local module = options.src:gsub("%/", ".")
          local original = (("\\script[src=%s]"):format(options.src))
          local result = SILE.require(options.src)
-         local suggested = (result._name and "\\use[module=%s]" or "\\lua[require=%s]"):format(module)
+         local suggested = (type(result) == "table" and result._name and "\\use[module=%s]" or "\\lua[require=%s]"):format(module)
          _deprecated(original, suggested)
          return result
       else


### PR DESCRIPTION
The current implementation assumes that a table is returned. I checks to see if that table is a proper SILE module, but it doesn't stop to think what happens if just a function, string, or other data is returned.