### PR TITLE
Overhaul indexer

### DIFF
--- a/packages/indexer/init.lua
+++ b/packages/indexer/init.lua
@@ -3,9 +3,9 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "indexer"
 
-function package:buildIndex ()
+function package.buildIndex (class) -- Called from the class, not as a package method
    local nodes = SILE.scratch.info.thispage.index
-   local thisPage = self.class.packages.counters:formatCounter(SILE.scratch.counters.folio)
+   local thisPage = class.packages.counters:formatCounter(SILE.scratch.counters.folio)
    if not nodes then
       return
    end
@@ -22,21 +22,14 @@ function package:buildIndex ()
       end
    end
 end
--- if content then
---   for i = 1, #content do
---     if not SILE.scratch.index.commands[content[i].label] then
---       SILE.scratch.index.commands[content[i].label] = {}
---     end
---     SILE.scratch.index.commands[content[i].label][class:formatCounter(SILE.scratch.counters.folio)] = 1
---   end
--- end
 
 function package:_init ()
    base._init(self)
+   self:loadPackage("infonode")
+   self.class:registerHook("endpage", self.buildIndex)
    if not SILE.scratch.index then
       SILE.scratch.index = {}
    end
-   self:deprecatedExport("buildIndex", self.buildIndex)
 end
 
 function package:registerCommands ()
@@ -60,7 +53,6 @@ function package:registerCommands ()
    end)
 
    self:registerCommand("printindex", function (options, _)
-      self:buildIndex()
       if not options.index then
          options.index = "main"
       end
@@ -99,7 +91,6 @@ The entry can be styled using the \autodoc:command{\index:item} command.
 
 Multiple indexes are available and an index can be selected by passing the \autodoc:parameter{index=<name>} parameter to \autodoc:command{\indexentry} and \autodoc:command{\printindex}.
 
-Classes using the indexer will need to call its exported function \code{buildIndex} as part of the end page routine.
 \end{document}
 ]]
 

--- a/packages/indexer/init.lua
+++ b/packages/indexer/init.lua
@@ -61,7 +61,7 @@ function package:registerCommands ()
       for n in pairs(index) do
          table.insert(sortedIndex, n)
       end
-      table.sort(sortedIndex)
+      SU.collatedSort(sortedIndex)
       SILE.call("bigskip")
       for _, k in ipairs(sortedIndex) do
          local pageno = table.concat(index[k], ", ")

--- a/packages/indexer/init.lua
+++ b/packages/indexer/init.lua
@@ -215,16 +215,8 @@ end
 function package:registerCommands ()
    self:registerCommand("indexentry", function (options, content)
       if not options.label then
-         -- Reconstruct the text.
-         SILE.typesetter:pushState()
-         SILE.process(content)
-         local text = ""
-         local nl = SILE.typesetter.state.nodes
-         for i = 2, #nl do
-            text = text .. nl[i]:toText()
-         end
-         options.label = text
-         SILE.typesetter:popState()
+         -- Reconstruct the text from the content tree
+         options.label = SILE.typesetter:contentToText(content)
       end
       if not options.index then
          options.index = "main"

--- a/packages/indexer/init.lua
+++ b/packages/indexer/init.lua
@@ -7,10 +7,10 @@ if not SILE.scratch.pdf_destination_counter then
    SILE.scratch.pdf_destination_counter = 1
 end
 
--- Check if page p2 is not the same as previous page p1.
--- @tparam table p1 A page counter value or nil (if no previous page yet).
--- @tparam table p2 A page counter value.
--- @treturn boolean True if p2 is not the same as p1.
+--- Check if page p2 is not the same as previous page p1.
+-- @tparam table p1 A page counter value or nil (if no previous page yet)
+-- @tparam table p2 A page counter value
+-- @treturn boolean True if p2 is not the same as p1
 local function _isNotSamePage (p1, p2)
    if not p1 then
       return true
@@ -18,9 +18,9 @@ local function _isNotSamePage (p1, p2)
    return p1.display ~= p2.display or p1.value ~= p2.value
 end
 
--- Group pages into ranges of consecutive pages.
--- @tparam table pages A list of pages with pageno (counter) and link (internal string) fields.
--- @treturn table A list of ranges, each containing a list of pages.
+--- Group pages into ranges of consecutive pages.
+-- @tparam table pages A list of pages with pageno (counter) and link (internal string) fields
+-- @treturn table A list of ranges, each containing a list of pages
 local function _groupPageRanges(pages)
    local ret = {}
    for _, page in ipairs(pages) do
@@ -36,10 +36,10 @@ local function _groupPageRanges(pages)
    return ret
 end
 
--- Wrap content in a link if a destination is provided.
--- @tparam string dest The destination name.
--- @tparam string page The page number.
--- @treturn table The content AST, possibly wrapped in a link.
+--- Wrap content in a link if a destination is provided.
+-- @tparam string dest The destination name
+-- @tparam string page The page number
+-- @treturn table The content AST, possibly wrapped in a link
 local function _linkWrapper (dest, page)
    if dest and SILE.Commands["pdf:link"] then
       return SU.ast.createCommand("pdf:link", { dest = dest }, page)
@@ -47,10 +47,10 @@ local function _linkWrapper (dest, page)
    return page
 end
 
--- Add a delimiter between elements of a table.
--- @tparam table t A list of elements.
--- @tparam string sep The delimiter.
--- @treturn table A new list with the delimiter inserted between elements.
+--- Add a delimiter between elements of a table.
+-- @tparam table t A list of elements
+-- @tparam string sep The delimiter
+-- @treturn table A new list with the delimiter inserted between elements
 local function _addDelimiter (t, sep)
    local ret = {}
    for i = 1, #t - 1 do
@@ -63,11 +63,11 @@ local function _addDelimiter (t, sep)
    return ret
 end
 
--- Simplify the second number in an Arabic page range.
--- @tparam string p1 The first page number (assumed to be in Arabic format).
--- @tparam string p2 The second page number (assumed to be in Arabic format).
--- @tparam string format The format to use (either 'minimal' or 'minimal-two').
--- @treturn string The simplified second page number.
+--- Simplify the second number in an Arabic page range.
+-- @tparam string p1 The first page number (assumed to be in Arabic format)
+-- @tparam string p2 The second page number (assumed to be in Arabic format)
+-- @tparam string format The format to use (either 'minimal' or 'minimal-two')
+-- @treturn string The simplified second page number
 local function _simplifyArabicInRange (p1, p2, format)
    if #p1 > 1 and #p1 == #p2 then
       local ending = format == 'minimal' and 1 or 2
@@ -83,7 +83,9 @@ end
 
 local _indexer_used = false
 
-function package.writeIndex (_) -- not a package method, called as a hook from the class
+--- Write the index to a file.
+-- This function is called as a hook from the class, not as a method of the package.
+function package.writeIndex ()
    local idxdata = pl.pretty.write(SILE.scratch.index)
    local idxfile, err = io.open(pl.path.splitext(SILE.input.filenames[1]) .. ".idx", "w")
    if not idxfile then
@@ -96,7 +98,9 @@ function package.writeIndex (_) -- not a package method, called as a hook from t
    end
 end
 
-function package.readIndex (_) -- not a package method, called as a hook from the class
+--- Read the index from a file.
+-- This function is called as a hook from the class, not as a method of the package.
+function package.readIndex ()
    if SILE.scratch._index and #SILE.scratch._index > 0 then
       -- already loaded
       return SILE.scratch._index
@@ -112,7 +116,9 @@ function package.readIndex (_) -- not a package method, called as a hook from th
    return SILE.scratch._index
 end
 
-function package.buildIndex () -- not a package method, called as a hook from the class
+--- Collect index entries from the current page.
+-- This function is called as a hook from the class, not as a method of the package.
+function package.buildIndex ()
    local nodes = SILE.scratch.info.thispage.index
    local pageno = pl.tablex.copy(SILE.scratch.counters.folio)
    if not nodes then
@@ -133,6 +139,8 @@ function package.buildIndex () -- not a package method, called as a hook from th
    end
 end
 
+--- Initialize the package.
+-- @tparam table options Configuration options
 function package:_init (options)
    base._init(self)
    self.config = pl.tablex.merge({
@@ -212,6 +220,7 @@ function package:outputIndexEntry (options, entry, pages)
    end)
 end
 
+-- Register the indexer commands.
 function package:registerCommands ()
    self:registerCommand("indexentry", function (options, content)
       if not options.label then
@@ -277,7 +286,9 @@ end
 
 package.documentation = [[
 \begin{document}
-An index is essentially the same thing as a table of contents, but sorted.
+The \autodoc:package{indexer} package provides a way to create indexex of terms in a document.
+An index functions similarly to a table of contents but organizes entries alphabetically by the indexed terms.
+The sorting order is based on the conventions of the current language.
 
 The package accepts several configuration options:
 \begin{itemize}
@@ -299,8 +310,12 @@ Possible values are:
 \end{itemize}}
 \end{itemize}
 
-This package provides the \autodoc:command{\indexentry} command, which can be called as either \autodoc:command{\indexentry[label=<text>]} or \autodoc:command{\indexentry{<text>}} (so that it can be called from a macro).
-Index entries are collated at the end of each page, and the command \autodoc:command{\printindex} will deposit them in a list.
+The package provides the \autodoc:command{\indexentry} command, which can be called as either \autodoc:command{\indexentry[label=<text>]} or \autodoc:command{\indexentry{<text>}}.
+Index entries are gathered and collated at the end of each page, tracking their page numbers.
+
+The \autodoc:command{\printindex} command outputs the collected entries as a formatted list.
+Since page numbers are finalized after rendering, the index appears on the second pass.
+If the index occurs early and affects pagination, a third pass may be needed for accuracy.
 
 Multiple indexes are available and an index can be selected by passing the \autodoc:parameter{index=<name>} parameter to \autodoc:command{\indexentry} and \autodoc:command{\printindex}.
 

--- a/packages/indexer/init.lua
+++ b/packages/indexer/init.lua
@@ -3,9 +3,31 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "indexer"
 
-function package.buildIndex (class) -- Called from the class, not as a package method
+local function isNotSamePage (p1, p2)
+   if not p1 then
+      return true
+   end
+   return p1.display ~= p2.display or p1.value ~= p2.value
+end
+
+local function groupPageRanges(pages)
+   local ret = {}
+   for _, page in ipairs(pages) do
+      if #ret == 0
+         or ret[#ret][#ret[#ret]].display ~= page.display
+         or ret[#ret][#ret[#ret]].value + 1 ~= page.value
+      then
+         table.insert(ret, { page })
+      else
+         table.insert(ret[#ret], page)
+      end
+   end
+   return ret
+end
+
+function package.buildIndex ()
    local nodes = SILE.scratch.info.thispage.index
-   local thisPage = class.packages.counters:formatCounter(SILE.scratch.counters.folio)
+   local pageno = pl.tablex.copy(SILE.scratch.counters.folio)
    if not nodes then
       return
    end
@@ -13,23 +35,54 @@ function package.buildIndex (class) -- Called from the class, not as a package m
       if not SILE.scratch.index[node.index] then
          SILE.scratch.index[node.index] = {}
       end
-      local thisIndex = SILE.scratch.index[node.index]
-      if not thisIndex[node.label] then
-         thisIndex[node.label] = {}
+      local index = SILE.scratch.index[node.index]
+      if not index[node.label] then
+         index[node.label] = {}
       end
-      if not #thisIndex[node.label] or (thisIndex[node.label])[#thisIndex[node.label]] ~= thisPage then
-         table.insert(thisIndex[node.label], thisPage)
+      local pages = index[node.label]
+      if not #pages or isNotSamePage(pages[#pages], pageno) then
+         table.insert(pages, pageno)
       end
    end
 end
 
-function package:_init ()
+function package:_init (options)
    base._init(self)
+   self.config = pl.tablex.merge({
+      ["page-range-format"] = "expanded",
+      ["page-range-delimiter"] = "–",
+      ["page-delimiter"] = ", "
+   }, options, true)
    self:loadPackage("infonode")
    self.class:registerHook("endpage", self.buildIndex)
    if not SILE.scratch.index then
       SILE.scratch.index = {}
    end
+end
+
+function package:formatPageRanges (pages)
+   local ranges = {}
+   for _, range in ipairs(groupPageRanges(pages)) do
+      if #range == 1 then
+         table.insert(ranges, self.class.packages.counters:formatCounter(range[1]))
+      else
+         table.insert(ranges,
+            self.class.packages.counters:formatCounter(range[1])
+               .. self.config['page-range-delimiter']
+               .. self.class.packages.counters:formatCounter(range[#range]))
+      end
+   end
+   return table.concat(ranges, self.config['page-delimiter'])
+end
+
+function package:formatPages (pages)
+   if self.config['page-range-format'] ~= 'none' then
+      return self:formatPageRanges(pages)
+   end
+   local ret = pl.tablex.map(function (page)
+      return self.class.packages.counters:formatCounter(page)
+   end, pages)
+   return table.concat(ret, self.config['page-delimiter'])
 end
 
 function package:registerCommands ()
@@ -64,7 +117,7 @@ function package:registerCommands ()
       SU.collatedSort(sortedIndex)
       SILE.call("bigskip")
       for _, k in ipairs(sortedIndex) do
-         local pageno = table.concat(index[k], ", ")
+         local pageno = self:formatPages(index[k])
          SILE.call("index:item", { pageno = pageno }, { k })
       end
    end)
@@ -85,6 +138,15 @@ end
 package.documentation = [[
 \begin{document}
 An index is essentially the same thing as a table of contents, but sorted.
+
+The package accepts several configuration options:
+\begin{itemize}
+\item{\autodoc:parameter{page-range-format}: The format used to display page ranges.
+Possible values are \autodoc:parameter{expanded} (default), \autodoc:parameter{none}.}
+\item{\autodoc:parameter{page-range-delimiter}: The delimiter between the start and end of a page range.}
+\item{\autodoc:parameter{page-delimiter}: The delimiter between pages.}
+\end{itemize}
+
 This package provides the \autodoc:command{\indexentry} command, which can be called as either \autodoc:command{\indexentry[label=<text>]} or \autodoc:command{\indexentry{<text>}} (so that it can be called from a macro).
 Index entries are collated at the end of each page, and the command \autodoc:command{\printindex} will deposit them in a list.
 The entry can be styled using the \autodoc:command{\index:item} command.

--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -59,45 +59,6 @@ local function _linkWrapper (dest, func)
    end
 end
 
--- Flatten a node list into just its string representation.
--- (Similar to SU.ast.contentToString(), but allows passing typeset
--- objects to functions that need plain strings).
-local function _nodesToText (nodes)
-   -- A real interword space width depends on several settings (depending on variable
-   -- spaces being enabled or not, etc.), and the computation below takes that into
-   -- account.
-   local iwspc = SILE.shaper:measureSpace(SILE.font.loadDefaults({}))
-   local iwspcmin = (iwspc.length - iwspc.shrink):tonumber()
-
-   local string = ""
-   for i = 1, #nodes do
-      local node = nodes[i]
-      if node.is_nnode or node.is_unshaped then
-         string = string .. node:toText()
-      elseif node.is_glue or node.is_kern then
-         -- What we want to avoid is "small" glues or kerns to be expanded as full
-         -- spaces.
-         -- Comparing them to half of the smallest width of a possibly shrinkable
-         -- interword space is fairly fragile and empirical: the content could contain
-         -- font changes, so the comparison is wrong in the general case.
-         -- It's a simplistic approach. We cannot really be sure what a "space" meant
-         -- at the point where the kern or glue got absolutized.
-         if node.width:tonumber() > iwspcmin * 0.5 then
-            string = string .. " "
-         end
-      elseif not (node.is_zerohbox or node.is_migrating) then
-         -- Here, typically, the main case is an hbox.
-         -- Even if extracting its content could be possible in some regular cases
-         -- we cannot take a general decision, as it is a versatile object  and its
-         -- outputYourself() method could moreover have been redefined to do fancy
-         -- things. Better warn and skip.
-         SU.warn("Some content could not be converted to text: " .. node)
-      end
-   end
-   -- Trim leading and trailing spaces, and simplify internal spaces.
-   return pl.stringx.strip(string):gsub("%s%s+", " ")
-end
-
 if not SILE.scratch.pdf_destination_counter then
    SILE.scratch.pdf_destination_counter = 1
 end
@@ -166,10 +127,8 @@ function package:registerCommands ()
       if SILE.Commands["pdf:destination"] then
          dest = "dest" .. tostring(SILE.scratch.pdf_destination_counter)
          SILE.call("pdf:destination", { name = dest })
-         SILE.typesetter:pushState()
-         SILE.process(content)
-         local title = _nodesToText(SILE.typesetter.state.nodes)
-         SILE.typesetter:popState()
+         -- Reconstruct a textual representation of the content tree
+         local title = SILE.typesetter:contentToText(content)
          SILE.call("pdf:bookmark", { title = title, dest = dest, level = options.level })
          SILE.scratch.pdf_destination_counter = SILE.scratch.pdf_destination_counter + 1
       end

--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -1500,4 +1500,58 @@ function typesetter:liner (name, content, outputYourself)
    end
 end
 
+--- Flatten a node list into just its string representation.
+-- @tparam table nodes Typeset nodes
+-- @treturn string Textual Text reconstruction of the nodes
+local function _nodesToText (nodes)
+   -- A real interword space width depends on several settings (depending on variable
+   -- spaces being enabled or not, etc.), and the computation below takes that into
+   -- account.
+   local iwspc = SILE.shaper:measureSpace(SILE.font.loadDefaults({}))
+   local iwspcmin = (iwspc.length - iwspc.shrink):tonumber()
+
+   local string = ""
+   for i = 1, #nodes do
+      local node = nodes[i]
+      if node.is_nnode or node.is_unshaped then
+         string = string .. node:toText()
+      elseif node.is_glue or node.is_kern then
+         -- What we want to avoid is "small" glues or kerns to be expanded as full
+         -- spaces.
+         -- Comparing them to half of the smallest width of a possibly shrinkable
+         -- interword space is fairly fragile and empirical: the content could contain
+         -- font changes, so the comparison is wrong in the general case.
+         -- It's a simplistic approach. We cannot really be sure what a "space" meant
+         -- at the point where the kern or glue got absolutized.
+         if node.width:tonumber() > iwspcmin * 0.5 then
+            string = string .. " "
+         end
+      elseif not (node.is_zerohbox or node.is_migrating) then
+         -- Here, typically, the main case is an hbox.
+         -- Even if extracting its content could be possible in some regular cases
+         -- we cannot take a general decision, as it is a versatile object  and its
+         -- outputYourself() method could moreover have been redefined to do fancy
+         -- things. Better warn and skip.
+         SU.warn("Some content could not be converted to text: " .. node)
+      end
+   end
+   -- Trim leading and trailing spaces, and simplify internal spaces.
+   return pl.stringx.strip(string):gsub("%s%s+", " ")
+end
+
+--- Convert a SILE AST to a textual representation.
+-- This is similar to SU.ast.contentToString(), but it performs a full
+-- typesetting of the content, and then reconstructs the text from the
+-- typeset nodes.
+-- @tparam table content SILE AST to process
+-- @treturn string Textual representation of the content
+function typesetter:contentToText (content)
+   self:pushState()
+   self.state.hmodeOnly = true
+   SILE.process(content)
+   local text = _nodesToText(self.state.nodes)
+   self:popState()
+   return text
+end
+
 return typesetter

--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -1081,7 +1081,7 @@ end
 --- Any unclosed liner is reopened on the current line, so we clone and repeat it.
 -- An assumption is that the inserts are done after the current slice content,
 -- supposed to be just before meaningful (visible) content.
--- @tparam slice slice
+-- @tparam table slice Flat nodes from current line
 -- @treturn boolean Whether a liner was reopened
 function typesetter:_repeatEnterLiners (slice)
    local m = self.state.liners
@@ -1502,7 +1502,7 @@ end
 
 --- Flatten a node list into just its string representation.
 -- @tparam table nodes Typeset nodes
--- @treturn string Textual Text reconstruction of the nodes
+-- @treturn string Text reconstruction of the nodes
 local function _nodesToText (nodes)
    -- A real interword space width depends on several settings (depending on variable
    -- spaces being enabled or not, etc.), and the computation below takes that into


### PR DESCRIPTION
Closes #1339 

 - Automatically register the indexer on endpage class hook = using the 0.14.x way so any document class can use it (vs. the 0.12.x way where classes had to explicitly call a method)
 - Use language-dependent sorting (collation) in indexer = Sorting based on ICU for the current language
 - Support page ranges in indexer = either `none` (all pages are listed without page range collapsing) or `expanded` (consecutive pages are collapsed in full, e.g. 301-305)
 - Support links to pages in the indexer = hyperlinks if the `pdf` package is previously loaded
 - Add indexer options `minimal`/`minimal-two`  for page range collapsing = consecutive pages are collapsed in minimal ranges (e.g. 301-5) or minimal ranges with at least two digits (e.g. 301-05). N.B. the "minimal", "minimal-two" and "expanded" names are loosely derived from those defined in CSL.[^1]
 - Add option for filler between item and page in indexer = `dotfill` (leaders) (default), `fill` (space as before), `comma` (content is not line-flushed). These are the most usual ways of presenting an index, i.e.
    - `item . . . . . 50, 60-63`
    - `item           50, 60-63`
    - or `item, 50, 60-63`
  - Add new styling hooks to the indexer = introduces hooks on entry and pages, (BREAK) removes hard-coded verbatim styling (@davidchisnall see discussion below)
  - Allow indexes to be used anywhere in a document = As for table of contents, use an intermediary file, so the index(es)
may be used (at the cost of a SILE re-run) anywhere, and not only on their own page at the end of a document... (This does fix several items from #1339, notably lost index entries if there's no page break before the `\printindex` and index entries are on that page[^2])
 - refactor(packages): Change `index:item` into an indexer package method = It's no longer callable from SIL/XML, so a package method is certainly better than a command.
 - feat(typesetters): Add content to text utility to the base typesetter = **at last**[^3]
 - refactor(packages): Use typesetter content to text in indexer and tableofcontents
 - docs(packages): Improve indexer package documentation = As it's name says :)

[^1]: For some consistency, although indexes are not related to CSL. Note that some language may prefer a certain format (e.g. French typography rules usually recommend full expanded ranges, while English rules may prefer a minimal variant), but the package leaves that decision to the user.

[^2]: It's also more general towards supporting indexes that are not at the end of document on their own pages. I do have cases for indexes early in the document (as for table of contents, one may want them this way, in some books...). Reading the index from an intermediary files also allows for other packages to use it (e.g. one could implement a fancyindex as as did for the ToC in [fancytoc.sile](https://github.com/Omikhleia/fancytoc.sile), and do their own rendering based on another logic while reusing most of the "common" code)

[^3]: As noted in the commit log, there are good reasons to do that (I always was convinced of it, at least! Doh)... @davidchisnall Just for the notice, I'll need to backport that to resilient's (actually silex's) modified typesetter, if that proposed change is accepted.