### PR TITLE
feat(typesetters): Discourage page breaks after hyphenated lines

### DIFF
--- a/packages/retrograde/init.lua
+++ b/packages/retrograde/init.lua
@@ -12,6 +12,9 @@ end
 
 -- Default settings that have gone out of fashion
 package.default_settings = {
+   ["0.15.10"] = {
+      ["typesetter.brokenpenalty"] = 0,
+   },
    ["0.15.0"] = {
       ["shaper.spaceenlargementfactor"] = 1.2,
       ["document.parindent"] = "20pt",

--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -89,6 +89,13 @@ function typesetter.declareSettings (_)
    })
 
    SILE.settings:declare({
+      parameter = "typesetter.brokenpenalty",
+      type = "integer",
+      default = 100,
+      help = "Penalty to be applied to broken (hyphenated) lines",
+   })
+
+   SILE.settings:declare({
       parameter = "typesetter.orphanpenalty",
       type = "integer",
       default = 3000,
@@ -647,6 +654,8 @@ function typesetter:boxUpNodes ()
          pageBreakPenalty = SILE.settings:get("typesetter.widowpenalty")
       elseif #lines > 1 and index == (#lines - 1) then
          pageBreakPenalty = SILE.settings:get("typesetter.orphanpenalty")
+      elseif line.is_broken then
+         pageBreakPenalty = SILE.settings:get("typesetter.brokenpenalty")
       end
       vboxes[#vboxes + 1] = self:leadingFor(vbox, self.state.previousVbox)
       vboxes[#vboxes + 1] = vbox
@@ -1255,12 +1264,16 @@ function typesetter:breakpointsToLines (breakpoints)
             SU.debug("typesetter", "Skipping a line containing only discardable nodes")
             linestart = point.position + 1
          else
+            local is_broken = false
             if slice[#slice].is_discretionary then
                -- The line ends, with a discretionary:
                -- repeat it on the next line, so as to account for a potential postbreak.
                linestart = point.position
                -- And mark it as used as prebreak for now.
                slice[#slice]:markAsPrebreak()
+               -- We'll want a "brokenpenalty" eventually (if not an orphan or widow)
+               -- to discourage page breaking after this line.
+               is_broken = true
             else
                linestart = point.position + 1
             end
@@ -1282,7 +1295,7 @@ function typesetter:breakpointsToLines (breakpoints)
                slice = self:_reboxLiners(slice)
             end
 
-            local thisLine = { ratio = ratio, nodes = slice }
+            local thisLine = { ratio = ratio, nodes = slice, is_broken = is_broken }
             lines[#lines + 1] = thisLine
          end
       end


### PR DESCRIPTION
When typesetting a real book, sooner or later, the following occurs:

![image](https://github.com/user-attachments/assets/21b9704f-21ad-4c73-ad09-6e754057d416)

Most typographers would frown upon hyphenated words at the end of a page (even so more if the page ends being a right page).

Is this a bug? Well yes if SILE reportedly pretends being as good as TeX already.
Otherwise it's a "feature", implementing the missing TeX "brokenpenalty".

So here it is...

**Simplified MWE**

```
\begin[papersize=a7]{document}
\neverindent
\nofolios
\font[family=Libertinus Serif, size=12pt]
\language[main=en]

Check page break.

% Ad hoc skip to trigger the issue, with some flexibility to allow for lines to
% move around.
% Some lines of text, our sentence with a long word ("desintructionalizations")
% that we expect to be hyphenated, and some more text.
% The game is for our word to be broken, but not conflict with orphan/widow lines.
\skip[height=6.5cm plus 1cm minus 1cm]

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec nunc ultricies ultricies.
Desintructionalizations may lead to revolutions in the future.

\end{document}
```

**Observed**

![image](https://github.com/user-attachments/assets/d2d8f4e2-6772-4f97-8aad-019ebb748b24)

**Expected (fixed)**

![image](https://github.com/user-attachments/assets/e9675de1-8877-4692-a07c-600d6db12f23)

It should be a good thing to start with.[^1]

[^1]: To be honest, there's more to be discussed on the topic...
          - Esp. with footnotes, where this could be more "acceptable" (say some) (so what value should be active with footnotes is a question for the footnote logic)
          - And... Er... on the main text content with footnotes again, due to the way they can be split or not, etc. and how the current pagebuilder computes penalties and badness.

