### PR TITLE
fix(math): Script 'math' is needed for the ssty feature to work properly

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -214,6 +214,11 @@ function elements.mbox:_init ()
       size = SILE.settings:get("math.font.size"),
       style = SILE.settings:get("math.font.style"),
       weight = SILE.settings:get("math.font.weight"),
+      -- https://learn.microsoft.com/en-us/typography/opentype/spec/math#opentype-layout-tags-used-with-the-math-table
+      --   "Script tag to be used for features in math layout.
+      --   The only language system supported with this tag is the default language system."
+      -- Thus, needed for the ssty feature in superscript/subscript to work properly.
+      script = "math",
    }
    local filename = SILE.settings:get("math.font.filename")
    if filename and filename ~= "" then

--- a/packages/math/init.lua
+++ b/packages/math/init.lua
@@ -145,8 +145,8 @@ If required, you can set the font style and weight via \autodoc:setting{math.fon
 The font size can be set via \autodoc:setting{math.font.size}.
 The \autodoc:setting{math.font.script.feature} setting can be used to specify OpenType features for the math font, which are applied to the smaller script styles.
 It defaults to \code{ssty} (script style alternates), notably to ensure that some symbols such as the prime, double prime, etc. are displayed correctly.
-The default setting applies to Libertinus Math and well-designed math fonts, but some fonts may require different features.
-(The STIX Two Math font has a stylitic set \code{ss04} from primes only, but also supports, according to its documentation, \code{ssty}, which provides other optical adjustments.)
+The default setting applies to Libertinus Math, STIX Two Math, TeX Gyre Termes Math, and all well-designed math fonts, but some fonts may require different features.
+(The STIX Two Math font has a stylitic set \code{ss04} from primes only, but also supports \code{ssty} with additional optical adjustments.)
 
 \paragraph{MathML}
 The first way to typeset math formulas is to enter them in the MathML format.


### PR DESCRIPTION
So that primes etc. use the correct glyphs.
Libertinus Math v7.051 does not require it, but STIX Two Math 2.13 b171 and TeX Gyre Termes Math v1.543 do, for instance.

---

Closes #2223 

Yay!

I long wanted to test TeX Gyre Termes Math, so gave it shot. I had the same problem as STIX Two Math, with ssty having no effect. Both were indeed fixed by enforcing the script to "math".
We could wonder why Libertinus Math respected ssty without the "math" script while other didn't, but heh. It doesn't complain either if the script is set, so I am gonna pass on that one.