### PR TITLE
A few simple CSL fixes

### DIFF
--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -451,7 +451,17 @@ function CslEngine:_text (options, content, entry)
    local link
    if options.macro then
       if self.macros[options.macro] then
+         -- This is not explicit in the CSL 1.0.2 specification, which mention conditional
+         -- rendering for groups only. However, macro should behave as it own group, and
+         -- be suppressed on the same conditions. This is used in a variety of styles, for
+         -- instance UFES-ABNT, UNEAL-ABNT or ABNT-IPEA have definitions like:
+         --    <macro name="translator">
+         --      <text value="Traducao "/>
+         --      <names variable="translator" delimiter=", ">(...) </names>
+         --    </macro>
+         self:_enterGroup()
          t = self:_render_children(self.macros[options.macro], entry)
+         t = self:_leaveGroup(t)
       else
          SU.error("CSL macro " .. options.macro .. " not found")
       end

--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -472,8 +472,8 @@ function CslEngine:_text (options, content, entry)
       t = entry[variable]
       self:_addGroupVariable(variable, t)
       if variable == "locator" then
+         variable = t and t.label
          t = t and t.value
-         variable = entry.locator.label
       end
       if variable == "page" and t then
          -- Replace any dash in page ranges
@@ -732,6 +732,7 @@ function CslEngine:_number (options, content, entry)
    local value = entry[variable]
    self:_addGroupVariable(variable, value)
    if variable == "locator" then -- special case
+      variable = value and value.label
       value = value and value.value
    end
    if value then


### PR DESCRIPTION
So as to make review easier, here are several fixes before I tackle with enhancements.[^1]

 - fix(packages): Empty CSL macros must be suppressed = Mentioned in passing in https://github.com/sile-typesetter/sile/issues/2202#issuecomment-2566791681
   > Some macros are interpreted as present while they should apparently be considered as absent. An example is the "translator" macro, which generates a "Tradução " even in the absence of translator(s) afterwards. Re-reading the CSL 1.0.2 specification, however, the only place where content suppression is clearly mentioned is on `cs:group` (acting as implicit conditional), but there's no such element here... It's still unclear to me where the intended behavior is defined...

   The same entries have the macro suppressed by citeproc-js, and it sounds logical (though poorly documented).

- fix(packages): Invalid link on CSL DOI, PMID, PMCID with affixes = Also mentioned in the above-mentioned discussion:

  >  There's an interesting problem with links (with URL, DOI, etc.) and here again the CSL specification is somewhat obscure and I'd even say rather inconsistent (conflating usage for affixes...)

- fix(packages): Error handling the locator on some CSL styles = Not reported before, but MLA for instance was affected (and likely a bunch of others, we were just lucky Chicago styles have an explicit condition). Just some bad code ;)

- fix(packages): Correctly honor affixes on multiple CSL citations = Not reported before, but preparing the way to support citing multiple keys in our package, I realized the logic was wrong. The CSL specs are so unclear at places.

[^1]: Note to @jodros:  The two first fixes correspond to issues I saw after fixing an (unrelated) issue of yours. This being said, there are still some weird things with UFES-ABNT, UNEAL-ABNT or ABNT-IPEA, notably places where there is either repeated punctuations (e.g. `Lorem. . Something`) or missing spacing (e.g. `(Some editors, EDS.)Some collection title`). However, I see the same issues on these entries with that JavaScript-based [online BiBTeX Converter](https://asouqi.github.io/bibtex-converter/), so I am unsure it's really our fault.