### PR TITLE
More CSL features: multiple citations and paragraph format

### DIFF
--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -449,7 +449,9 @@ function CslEngine:_layout (options, content, entries)
    -- quite logically as we force a paragraph break between entries.
    for _, entry in ipairs(entries) do
       self:_prerender()
-      local elem = self:_render_children(content, entry)
+      local elem = self:_render_children(content, entry, {
+         secondFieldAlign = self.inheritable.bibliography["second-field-align"] and true or false,
+      })
       elem = self:_render_affixes(elem, options)
       elem = self:_render_formatting(elem, options)
       elem = self:_postrender(elem)
@@ -1458,6 +1460,16 @@ function CslEngine:_render_children (ast, entry, context)
       else
          SU.error("CSL unexpected content") -- Should not happen
       end
+   end
+   if context.secondFieldAlign then
+      -- CSL 1.0.2 says that "subsequent lines of bibliographic entries are aligned
+      -- along the second field" with the first field either flushed "with the margin"
+      -- or "put in the margin".
+      -- This is a dubious wording, probably bad typography, with no amount of spacing
+      -- even described.
+      -- We choose to "box" the first field, and the default implementation will take
+      -- care of doing sound typography.
+      ret[1] = "<bibBoxForIndent>" .. ret[1] .. "</bibBoxForIndent>"
    end
    return #ret > 0 and self:_render_delimiter(ret, context.delimiter) or nil
 end

--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -482,7 +482,7 @@ function CslEngine:_text (options, content, entry)
          SU.error("CSL macro " .. options.macro .. " not found")
       end
    elseif options.term then
-      t = self:_render_term(options.term, options.form, options.plural)
+      t = self:_render_term(options.term, options.form, SU.boolean(options.plural, false))
    elseif options.variable then
       variable = options.variable
       t = entry[variable]

--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -347,7 +347,7 @@ function CslEngine:_render_formatting (t, options)
       t = "<underline>" .. t .. "</underline>"
    end
    if options["vertical-align"] == "sup" then
-      t = "<textsuperscript>" .. t .. "</textsuperscript>"
+      t = "<bibSuperScript>" .. t .. "</bibSuperScript>"
    end
    if options["vertical-align"] == "sub" then
       t = "<textsubscript>" .. t .. "</textsubscript>"
@@ -434,7 +434,7 @@ function CslEngine:_layout (options, content, entries)
       -- citations, affixes and formatting apply on the whole layout.
       -- Affixes are arround the delimited list, e.g. "(Smith, 2000; Jones, 2001)"
       -- Rendering is done after, so vertical-align, etc. apply to the whole list,
-      -- e.g. <textsuperscript>1,2</textsuperscript>
+      -- e.g. <bibSuperScript>1, 2</bibSuperScript>
       local cites = self:_render_delimiter(output, options.delimiter or "; ")
       cites = self:_render_affixes(cites, options)
       cites = self:_render_formatting(cites, options)

--- a/packages/bibtex/csl/style.lua
+++ b/packages/bibtex/csl/style.lua
@@ -46,9 +46,9 @@ function CslStyle:_preprocess (tree)
          end
          self.macros[name] = SU.ast.subContent(content)
       elseif content.command == "cs:locale" then
-         local lang = content.options and content.options["xml:lang"]
+         local lang = content.options and content.options["xml:lang"] or self.globalOptions["default-locale"]
          if not lang then
-            SU.error("CSL locale without xml:lang")
+            SU.error("CSL locale without xml:lang and no default locale")
          end
          if self.locales[lang] then
             SU.warn("CSL locale " .. lang .. " has multiple definitions, using the last one")

--- a/packages/bibtex/csl/utils/superfolding.lua
+++ b/packages/bibtex/csl/utils/superfolding.lua
@@ -140,7 +140,7 @@ local function superfolding (str)
       local replaced = luautf8.gsub(group, ".", function (char)
          return supersyms[char]
       end)
-      return "<textsuperscript>" .. replaced .. "</textsuperscript>"
+      return "<bibSuperScript>" .. replaced .. "</bibSuperScript>"
    end)
 end
 

--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -84,6 +84,7 @@ function package:_init ()
    if not self:loadOptPackage("textsubsuper") then
       self:loadPackage("raiselower")
       self:registerCommand("textsuperscript", function (_, content)
+         -- Fake more or less ad hoc superscripting
          SILE.call("raise", { height = "0.7ex" }, function ()
             SILE.call("font", { size = "1.5ex" }, content)
          end)
@@ -230,6 +231,16 @@ function package:registerCommands ()
    self:registerCommand("bibSmallCaps", function (_, content)
       -- To avoid attributes in the CSL-processed content
       SILE.call("font", { features = "+smcp" }, content)
+   end)
+
+   self:registerCommand("bibSuperScript", function (_, content)
+      -- Superscripted content from CSL may contain characters that are not
+      -- available in the font even with +sups.
+      -- E.g. ACS style uses superscripted numbers for references, but also
+      -- comma-separated lists of numbers, or ranges with an en-dash.
+      -- We want to be consistent between all these cases, so we always
+      -- use fake superscripts.
+      SILE.call("textsuperscript", { fake = true}, content)
    end)
 
    -- CSL 1.0.2 appendix VI

--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -95,7 +95,7 @@ function package.declareSettings (_)
    SILE.settings:declare({
       parameter = "bibtex.style",
       type = "string",
-      default = "chicago",
+      default = "csl",
       help = "BibTeX style",
    })
 
@@ -153,13 +153,13 @@ function package.getLocator (_, options)
    for k, v in pairs(options) do
       if k ~= "key" then
          if not locators[k] then
-            SU.warn("Unknown option '" .. k .. "' in \\csl:cite")
+            SU.warn("Unknown option '" .. k .. "' in \\cite")
          else
             if not locator then
                local label = locators[k]
                locator = { label = label, value = v }
             else
-               SU.warn("Multiple locators in \\csl:cite, using the first one")
+               SU.warn("Multiple locators in \\cite, using the first one")
             end
          end
       end
@@ -457,32 +457,11 @@ You can load multiple files, and the entries will be merged into a single biblio
 
 \smallskip
 \noindent
-\em{Producing citations and references (legacy commands)}
-\novbreak
-
-\indent
-The “legacy” implementation is based on a custom rendering system.
-The plan is to eventually deprecate it in favor of the CSL implementation.
-
-To produce an inline citation, call \autodoc:command{\cite{<key>}}, which will typeset something like “Jones 1982”.
-If you want to cite a particular page number, use \autodoc:command{\cite[page=22]{<key>}}.
-
-To produce a bibliographic reference, use \autodoc:command{\reference{<key>}}.
-
-The \autodoc:setting[check=false]{bibtex.style} setting controls the style of the bibliography.
-It currently defaults to \code{chicago}, the only style supported out of the box.
-It can however be set to \code{csl} to enforce the use of the CSL implementation on the above commands.
-
-This implementation doesn’t currently produce full bibliography listings.
-(Actually, you can use the \autodoc:command{\printbibliography} introduced below, but then it always uses the CSL implementation for rendering the bibliography, differing from the output of the \autodoc:command{\reference} command.)
-
-\smallskip
-\noindent
 \em{Producing citations and references (CSL implementation)}
 \novbreak
 
 \indent
-While an experimental work-in-progress, the CSL (Citation Style Language) implementation is more powerful and flexible than the legacy commands.
+The CSL (Citation Style Language) implementation is more powerful and flexible than the former legacy solution available in earlier versions of this package (see below).
 
 You should first invoke \autodoc:command{\bibliographystyle[style=<style>, lang=<lang>]}, where \autodoc:parameter{style} is the name of the CSL style file (without the \code{.csl} extension), and \autodoc:parameter{lang} is the language code of the CSL locale to use (e.g., \code{en-US}).
 
@@ -498,14 +477,14 @@ The locale and styles files are searched in the \code{csl/locales} and \code{csl
 For convenience and testing, SILE bundles the \code{chicago-author-date} and \code{chicago-author-date-fr} styles, and the \code{en-US} and \code{fr-FR} locales.
 If you don’t specify a style or locale, the author-date style and the \code{en-US} locale will be used.
 
-To produce an inline citation, call \autodoc:command{\csl:cite{<key>}}, which will typeset something like “(Jones 1982)”.
-If you want to cite a particular page number, use \autodoc:command{\csl:cite[page=22]{<key>}}. Other “locator”  options are available (article, chapter, column, line, note, paragraph, section, volume, etc.) – see the CSL documentation for details.
+To produce an inline citation, call \autodoc:command{\cite{<key>}}, which will typeset something like “(Jones 1982)”.
+If you want to cite a particular page number, use \autodoc:command{\cite[page=22]{<key>}}. Other “locator”  options are available (article, chapter, column, line, note, paragraph, section, volume, etc.) – see the CSL documentation for details.
 Some frequent abbreviations are also supported (art, chap, col, fig…)
 
 To mark an entry as cited without actually producing a citation, use \autodoc:command{\nocite{<key>}}.
 This is useful when you want to include an entry in the bibliography without citing it in the text.
 
-To generate multiple citations grouped correctly, use \autodoc:command{\cites{\cite{<key1>}, \cite{<key2>}, …}}.
+To generate multiple citations grouped correctly, use \autodoc:command{\cites{\cite{<key1>} \cite{<key2>}, …}}.
 This wrapper command only accepts \autodoc:command{\cite} elements following their standard syntax.
 Any other element triggers an error, and any text content is silently ignored.
 
@@ -513,9 +492,30 @@ To produce a bibliography of cited references, use \autodoc:command{\printbiblio
 After printing the bibliography, the list of cited entries will be cleared. This allows you to start fresh for subsequent uses (e.g., in a different chapter).
 If you want to include all entries in the bibliography, not just those that have been cited, set the option \autodoc:parameter{cited} to false.
 
-To produce a bibliographic reference, use \autodoc:command{\csl:reference{<key>}}.
+To produce a bibliographic reference, use \autodoc:command{\reference{<key>}}.
 Note that this command is not intended for actual use, but for testing purposes.
 It may be removed in the future.
+
+\smallskip
+\noindent
+\em{Producing citations and references (legacy commands)}
+\novbreak
+
+\indent
+The “legacy” implementation is based on a custom rendering system.
+The plan is to eventually deprecate and remove it, as the CSL implementation covers more use cases and is more powerful.
+
+The \autodoc:setting[check=false]{bibtex.style} setting controls the style of the bibliography.
+It may be set, for instance, to \code{chicago}, the only style supported out of the box.
+(By default, it is set to \code{csl} to enforce the use of the CSL implementation.)
+
+To produce an inline citation, call \autodoc:command{\cite{<key>}}, which will typeset something like “Jones 1982”.
+If you want to cite a particular page number, use \autodoc:command{\cite[page=22]{<key>}}.
+
+To produce a bibliographic reference, use \autodoc:command{\reference{<key>}}.
+
+This implementation doesn’t currently produce full bibliography listings.
+(Actually, you can use the \autodoc:command{\printbibliography} introduced above, but then it always uses the CSL implementation for rendering the bibliography, differing from the output of the \autodoc:command{\reference} command.)
 
 \smallskip
 \noindent

--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -398,6 +398,10 @@ function package:registerCommands ()
       parseBibtex(file, SILE.scratch.bibtex.bib)
    end)
 
+   self:registerCommand("nocite", function (options, content)
+      self:getEntryForCite(options, content, false)
+   end, "Mark an entry as cited without actually producing a citation.")
+
    -- LEGACY COMMANDS
 
    self:registerCommand("bibstyle", function (_, _)
@@ -420,7 +424,7 @@ function package:registerCommands ()
          local cite = Bibliography.produceCitation(options, SILE.scratch.bibtex.bib, bibstyle)
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
       end
-   end)
+   end, "Produce a single citation.")
 
    self:registerCommand("reference", function (options, content)
       local style = SILE.settings:get("bibtex.style")
@@ -442,7 +446,7 @@ function package:registerCommands ()
          end
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
       end
-   end)
+   end, "Produce a single bibliographic reference.")
 
    -- CSL IMPLEMENTATION COMMANDS
 
@@ -542,7 +546,7 @@ function package:registerCommands ()
 
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
       end
-   end)
+   end, "Produce a single citation.")
 
    self:registerCommand("csl:reference", function (options, content)
       local entry, citnum = self:getEntryForCite(options, content, true)
@@ -554,7 +558,7 @@ function package:registerCommands ()
 
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
       end
-   end)
+   end, "Produce a single bibliographic reference.")
 
    self:registerCommand("printbibliography", function (options, _)
       local bib
@@ -598,7 +602,7 @@ function package:registerCommands ()
       SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
 
       SILE.scratch.bibtex.cited = { keys = {}, citnums = {} }
-   end)
+   end, "Produce a bibliography of references.")
 end
 
 package.documentation = [[
@@ -662,6 +666,9 @@ If you don’t specify a style or locale, the author-date style and the \code{en
 To produce an inline citation, call \autodoc:command{\csl:cite{<key>}}, which will typeset something like “(Jones 1982)”.
 If you want to cite a particular page number, use \autodoc:command{\csl:cite[page=22]{<key>}}. Other “locator”  options are available (article, chapter, column, line, note, paragraph, section, volume, etc.) – see the CSL documentation for details.
 Some frequent abbreviations are also supported (art, chap, col, fig…)
+
+To mark an entry as cited without actually producing a citation, use \autodoc:command{\nocite{<key>}}.
+This is useful when you want to include an entry in the bibliography without citing it in the text.
 
 To produce a bibliography of cited references, use \autodoc:command{\printbibliography}.
 After printing the bibliography, the list of cited entries will be cleared. This allows you to start fresh for subsequent uses (e.g., in a different chapter).

--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -8,6 +8,14 @@ local CslLocale = require("packages.bibtex.csl.locale")
 local CslStyle = require("packages.bibtex.csl.style")
 local CslEngine = require("packages.bibtex.csl.engine")
 
+local bibparser = require("packages.bibtex.support.bibparser")
+local parseBibtex, crossrefAndXDataResolve = bibparser.parseBibtex, bibparser.crossrefAndXDataResolve
+
+local bib2csl = require("packages.bibtex.support.bib2csl")
+local locators = require("packages.bibtex.support.locators")
+
+local Bibliography = require("packages.bibtex.bibliography") -- Legacy
+
 local function loadCslLocale (name)
    local filename = SILE.resolveFile("packages/bibtex/csl/locales/locales-" .. name .. ".xml")
       or cslLocaleLoader("packages.bibtex.csl.locales.locales-" .. name)
@@ -38,246 +46,6 @@ end
 local package = pl.class(base)
 package._name = "bibtex"
 
-local epnf = require("epnf")
-local nbibtex = require("packages.bibtex.support.nbibtex")
-local namesplit, parse_name = nbibtex.namesplit, nbibtex.parse_name
-local isodatetime = require("packages.bibtex.support.isodatetime")
-local bib2csl = require("packages.bibtex.support.bib2csl")
-local locators = require("packages.bibtex.support.locators")
-
-local Bibliography
-
-local nbsp = luautf8.char(0x00A0)
-local function sanitize (str)
-   local s = str
-      -- TeX special characters:
-      -- Backslash-escaped tilde is a tilde,
-      -- but standalone tilde is a non-breaking space
-      :gsub(
-         "(.?)~",
-         function (prev)
-            if prev == "\\" then
-               return "~"
-            end
-            return prev .. nbsp
-         end
-      )
-      -- Other backslash-escaped characters are skipped
-      -- TODO FIXME:
-      -- This ok for \", \& etc. which we want to unescape,
-      -- BUT what should we do with other TeX-like commands?
-      :gsub(
-         "\\",
-         ""
-      )
-      -- We will wrap the content in <sile> tags so we need to XML-escape
-      -- the input.
-      :gsub("&", "&amp;")
-      :gsub("<", "&lt;")
-      :gsub(">", "&gt;")
-   return s
-end
-
--- luacheck: push ignore
--- stylua: ignore start
----@diagnostic disable: undefined-global, unused-local, lowercase-global
-local bibtexparser = epnf.define(function (_ENV)
-   local strings = {} -- Local store for @string entries
-
-   local identifier = (SILE.parserBits.identifier + S":-")^1
-   local balanced = C{ "{" * P" "^0 * C(((1 - S"{}") + V(1))^0) * "}" } / function (...) local t={...}; return t[2] end
-   local quoted = C( P'"' * C(((1 - S'"\r\n\f\\') + (P'\\' * 1)) ^ 0) * '"' ) / function (...) local t={...}; return t[2] end
-   local _ = WS^0
-   local sep = S",;" * _
-   local myID = C(identifier)
-   local myStrID = myID / function (t) return strings[t] or t end
-   local myTag = C(identifier) / function (t) return t:lower() end
-   local pieces = balanced + quoted + myStrID
-   local value = Ct(pieces * (WS * P("#") * WS * pieces)^0)
-      / function (t) return table.concat(t) end / sanitize
-   local pair = myTag * _ * "=" * _ * value * _ * sep^-1
-      / function (...) local t= {...}; return t[1], t[#t] end
-   local list = Cf(Ct("") * pair^0, rawset)
-   local skippedType = Cmt(R("az", "AZ")^1, function(_, _, tag)
-      -- ignore both @comment and @preamble
-      local t = tag:lower()
-      return t == "comment" or t == "preamble"
-   end)
-
-   START "document"
-   document = (V"skipped" -- order important: skipped (@comment, @preamble) must be first
-      + V"stringblock" -- order important: @string must be before @entry
-      + V"entry")^1
-      * (-1 + E("Unexpected character at end of input"))
-   skipped  = WS + (V"blockskipped" + (1 - P"@")^1 ) / ""
-   blockskipped = (P("@") * skippedType) + balanced / ""
-   stringblock = Ct( P("@string") * _ * P("{") * pair * _ * P("}") * _ )
-       / function (t)
-          strings[t[1]] = t[2]
-          return t end
-   entry = Ct( P("@") * Cg(myTag, "type") * _ * P("{") * _ * Cg(myID, "label") * _ * sep * list * P("}") * _ )
-end)
--- luacheck: pop
--- stylua: ignore end
----@diagnostic enable: undefined-global, unused-local, lowercase-global
-
-local bibcompat = require("packages.bibtex.support.bibmaps")
-local crossrefmap, fieldmap = bibcompat.crossrefmap, bibcompat.fieldmap
-local months =
-   { jan = 1, feb = 2, mar = 3, apr = 4, may = 5, jun = 6, jul = 7, aug = 8, sep = 9, oct = 10, nov = 11, dec = 12 }
-
-local function consolidateEntry (entry, label)
-   local consolidated = {}
-   -- BibLaTeX aliases for legacy BibTeX fields
-   for field, value in pairs(entry.attributes) do
-      consolidated[field] = value
-      local alias = fieldmap[field]
-      if alias then
-         if entry.attributes[alias] then
-            SU.warn("Duplicate field '" .. field .. "' and alias '" .. alias .. "' in entry '" .. label .. "'")
-         else
-            consolidated[alias] = value
-         end
-      end
-   end
-   -- Names field split and parsed
-   for _, field in ipairs({ "author", "editor", "translator", "shortauthor", "shorteditor", "holder" }) do
-      if consolidated[field] then
-         -- FIXME Check our corporate names behave, we are probably bad currently
-         -- with nested braces !!!
-         -- See biblatex manual v3.20 §2.3.3 Name Lists
-         -- e.g. editor = {{National Aeronautics and Space Administration} and Doe, John}
-         local names = namesplit(consolidated[field])
-         for i = 1, #names do
-            names[i] = parse_name(names[i])
-         end
-         consolidated[field] = names
-      end
-   end
-   -- Month field in either number or string (3-letter code)
-   if consolidated.month then
-      local month = tonumber(consolidated.month) or months[consolidated.month:lower()]
-      if month and (month >= 1 and month <= 12) then
-         consolidated.month = month
-      else
-         SU.warn("Unrecognized month skipped in entry '" .. label .. "'")
-         consolidated.month = nil
-      end
-   end
-   -- Extended date fields
-   for _, field in ipairs({ "date", "origdate", "eventdate", "urldate" }) do
-      if consolidated[field] then
-         local dt = isodatetime(consolidated[field])
-         if dt then
-            consolidated[field] = dt
-         else
-            SU.warn("Invalid '" .. field .. "' skipped in entry '" .. label .. "'")
-            consolidated[field] = nil
-         end
-      end
-   end
-   entry.attributes = consolidated
-   return entry
-end
-
---- Parse a BibTeX file and populate a bibliography table.
--- @tparam string fn Filename
--- @tparam table biblio Table of entries
-local function parseBibtex (fn, biblio)
-   fn = SILE.resolveFile(fn) or SU.error("Unable to resolve Bibtex file " .. fn)
-   local fh, e = io.open(fn)
-   if e then
-      SU.error("Error reading bibliography file: " .. e)
-   end
-   local doc = fh:read("*all")
-   local t = epnf.parsestring(bibtexparser, doc)
-   if not t or not t[1] or t.id ~= "document" then
-      SU.error("Error parsing bibtex")
-   end
-   for i = 1, #t do
-      if t[i].id == "entry" then
-         local ent = t[i][1]
-         local entry = { type = ent.type, label = ent.label, attributes = ent[1] }
-         if biblio[ent.label] then
-            SU.warn("Duplicate entry key '" .. ent.label .. "', picking the last one")
-         end
-         biblio[ent.label] = consolidateEntry(entry, ent.label)
-      end
-   end
-end
-
---- Copy fields from the parent entry to the child entry.
--- BibLaTeX/Biber have a complex inheritance system for fields.
--- This implementation is more naive, but should be sufficient for reasonable
--- use cases.
--- @tparam table parent Parent entry
--- @tparam table entry Child entry
-local function fieldsInherit (parent, entry)
-   local map = crossrefmap[parent.type] and crossrefmap[parent.type][entry.type]
-   if not map then
-      -- @xdata and any other unknown types: inherit all missing fields
-      for field, value in pairs(parent.attributes) do
-         if not entry.attributes[field] then
-            entry.attributes[field] = value
-         end
-      end
-      return -- done
-   end
-   for field, value in pairs(parent.attributes) do
-      if map[field] == nil and not entry.attributes[field] then
-         entry.attributes[field] = value
-      end
-      for childfield, parentfield in pairs(map) do
-         if parentfield and not entry.attributes[parentfield] then
-            entry.attributes[parentfield] = parent.attributes[childfield]
-         end
-      end
-   end
-end
-
---- Resolve the 'crossref' and 'xdata' fields on a bibliography entry.
--- (Supplementing the entry with the attributes of the parent entry.)
--- Once resolved recursively, the crossref and xdata fields are removed
--- from the entry.
--- So this is intended to be called at first use of the entry, and have no
--- effect on subsequent uses: BibTeX does seem to mandate cross references
--- to be defined before the entry that uses it, or even in the same bibliography
--- file.
--- Implementation note:
--- We are not here to check the consistency of the BibTeX file, so there is
--- no check that xdata refers only to @xdata entries
--- Removing the crossref field implies we won't track its use and implicitly
--- cite referenced entries in the bibliography over a certain threshold.
--- @tparam table bib Bibliography
--- @tparam table entry Bibliography entry
-local function crossrefAndXDataResolve (bib, entry)
-   local refs
-   local xdata = entry.attributes.xdata
-   if xdata then
-      refs = xdata and pl.stringx.split(xdata, ",")
-      entry.attributes.xdata = nil
-   end
-   local crossref = entry.attributes.crossref
-   if crossref then
-      refs = refs or {}
-      table.insert(refs, crossref)
-      entry.attributes.crossref = nil
-   end
-
-   if not refs then
-      return
-   end
-   for _, ref in ipairs(refs) do
-      local parent = bib[ref]
-      if parent then
-         crossrefAndXDataResolve(bib, parent)
-         fieldsInherit(parent, entry)
-      else
-         SU.warn("Unknown crossref " .. ref .. " in bibliography entry " .. entry.label)
-      end
-   end
-end
-
 local function resolveEntry (bib, key)
    local entry = bib[key]
    if not entry then
@@ -304,7 +72,6 @@ end
 function package:_init ()
    base._init(self)
    SILE.scratch.bibtex = { bib = {}, cited = { keys = {}, citnums = {} } }
-   Bibliography = require("packages.bibtex.bibliography")
    -- For DOI, PMID, PMCID and URL support.
    self:loadPackage("url")
    -- For underline styling support

--- a/packages/bibtex/support/bibparser.lua
+++ b/packages/bibtex/support/bibparser.lua
@@ -1,0 +1,241 @@
+local epnf = require("epnf")
+local nbibtex = require("packages.bibtex.support.nbibtex")
+local namesplit, parse_name = nbibtex.namesplit, nbibtex.parse_name
+local isodatetime = require("packages.bibtex.support.isodatetime")
+
+local nbsp = luautf8.char(0x00A0)
+local function sanitize (str)
+   local s = str
+      -- TeX special characters:
+      -- Backslash-escaped tilde is a tilde,
+      -- but standalone tilde is a non-breaking space
+      :gsub(
+         "(.?)~",
+         function (prev)
+            if prev == "\\" then
+               return "~"
+            end
+            return prev .. nbsp
+         end
+      )
+      -- Other backslash-escaped characters are skipped
+      -- TODO FIXME:
+      -- This ok for \", \& etc. which we want to unescape,
+      -- BUT what should we do with other TeX-like commands?
+      :gsub(
+         "\\",
+         ""
+      )
+      -- We will wrap the content in <sile> tags so we need to XML-escape
+      -- the input.
+      :gsub("&", "&amp;")
+      :gsub("<", "&lt;")
+      :gsub(">", "&gt;")
+   return s
+end
+
+-- luacheck: push ignore
+-- stylua: ignore start
+---@diagnostic disable: undefined-global, unused-local, lowercase-global
+local bibtexparser = epnf.define(function (_ENV)
+   local strings = {} -- Local store for @string entries
+
+   local identifier = (SILE.parserBits.identifier + S":-")^1
+   local balanced = C{ "{" * P" "^0 * C(((1 - S"{}") + V(1))^0) * "}" } / function (...) local t={...}; return t[2] end
+   local quoted = C( P'"' * C(((1 - S'"\r\n\f\\') + (P'\\' * 1)) ^ 0) * '"' ) / function (...) local t={...}; return t[2] end
+   local _ = WS^0
+   local sep = S",;" * _
+   local myID = C(identifier)
+   local myStrID = myID / function (t) return strings[t] or t end
+   local myTag = C(identifier) / function (t) return t:lower() end
+   local pieces = balanced + quoted + myStrID
+   local value = Ct(pieces * (WS * P("#") * WS * pieces)^0)
+      / function (t) return table.concat(t) end / sanitize
+   local pair = myTag * _ * "=" * _ * value * _ * sep^-1
+      / function (...) local t= {...}; return t[1], t[#t] end
+   local list = Cf(Ct("") * pair^0, rawset)
+   local skippedType = Cmt(R("az", "AZ")^1, function(_, _, tag)
+      -- ignore both @comment and @preamble
+      local t = tag:lower()
+      return t == "comment" or t == "preamble"
+   end)
+
+   START "document"
+   document = (V"skipped" -- order important: skipped (@comment, @preamble) must be first
+      + V"stringblock" -- order important: @string must be before @entry
+      + V"entry")^1
+      * (-1 + E("Unexpected character at end of input"))
+   skipped  = WS + (V"blockskipped" + (1 - P"@")^1 ) / ""
+   blockskipped = (P("@") * skippedType) + balanced / ""
+   stringblock = Ct( P("@string") * _ * P("{") * pair * _ * P("}") * _ )
+       / function (t)
+          strings[t[1]] = t[2]
+          return t end
+   entry = Ct( P("@") * Cg(myTag, "type") * _ * P("{") * _ * Cg(myID, "label") * _ * sep * list * P("}") * _ )
+end)
+-- luacheck: pop
+-- stylua: ignore end
+---@diagnostic enable: undefined-global, unused-local, lowercase-global
+
+
+local bibcompat = require("packages.bibtex.support.bibmaps")
+local crossrefmap, fieldmap = bibcompat.crossrefmap, bibcompat.fieldmap
+local months =
+   { jan = 1, feb = 2, mar = 3, apr = 4, may = 5, jun = 6, jul = 7, aug = 8, sep = 9, oct = 10, nov = 11, dec = 12 }
+
+local function consolidateEntry (entry, label)
+   local consolidated = {}
+   -- BibLaTeX aliases for legacy BibTeX fields
+   for field, value in pairs(entry.attributes) do
+      consolidated[field] = value
+      local alias = fieldmap[field]
+      if alias then
+         if entry.attributes[alias] then
+            SU.warn("Duplicate field '" .. field .. "' and alias '" .. alias .. "' in entry '" .. label .. "'")
+         else
+            consolidated[alias] = value
+         end
+      end
+   end
+   -- Names field split and parsed
+   for _, field in ipairs({ "author", "editor", "translator", "shortauthor", "shorteditor", "holder" }) do
+      if consolidated[field] then
+         -- FIXME Check our corporate names behave, we are probably bad currently
+         -- with nested braces !!!
+         -- See biblatex manual v3.20 §2.3.3 Name Lists
+         -- e.g. editor = {{National Aeronautics and Space Administration} and Doe, John}
+         local names = namesplit(consolidated[field])
+         for i = 1, #names do
+            names[i] = parse_name(names[i])
+         end
+         consolidated[field] = names
+      end
+   end
+   -- Month field in either number or string (3-letter code)
+   if consolidated.month then
+      local month = tonumber(consolidated.month) or months[consolidated.month:lower()]
+      if month and (month >= 1 and month <= 12) then
+         consolidated.month = month
+      else
+         SU.warn("Unrecognized month skipped in entry '" .. label .. "'")
+         consolidated.month = nil
+      end
+   end
+   -- Extended date fields
+   for _, field in ipairs({ "date", "origdate", "eventdate", "urldate" }) do
+      if consolidated[field] then
+         local dt = isodatetime(consolidated[field])
+         if dt then
+            consolidated[field] = dt
+         else
+            SU.warn("Invalid '" .. field .. "' skipped in entry '" .. label .. "'")
+            consolidated[field] = nil
+         end
+      end
+   end
+   entry.attributes = consolidated
+   return entry
+end
+
+--- Parse a BibTeX file and populate a bibliography table.
+-- @tparam string fn Filename
+-- @tparam table biblio Table of entries
+local function parseBibtex (fn, biblio)
+   fn = SILE.resolveFile(fn) or SU.error("Unable to resolve Bibtex file " .. fn)
+   local fh, e = io.open(fn)
+   if e then
+      SU.error("Error reading bibliography file: " .. e)
+   end
+   local doc = fh:read("*all")
+   local t = epnf.parsestring(bibtexparser, doc)
+   if not t or not t[1] or t.id ~= "document" then
+      SU.error("Error parsing bibtex")
+   end
+   for i = 1, #t do
+      if t[i].id == "entry" then
+         local ent = t[i][1]
+         local entry = { type = ent.type, label = ent.label, attributes = ent[1] }
+         if biblio[ent.label] then
+            SU.warn("Duplicate entry key '" .. ent.label .. "', picking the last one")
+         end
+         biblio[ent.label] = consolidateEntry(entry, ent.label)
+      end
+   end
+end
+
+--- Copy fields from the parent entry to the child entry.
+-- BibLaTeX/Biber have a complex inheritance system for fields.
+-- This implementation is more naive, but should be sufficient for reasonable
+-- use cases.
+-- @tparam table parent Parent entry
+-- @tparam table entry Child entry
+local function fieldsInherit (parent, entry)
+   local map = crossrefmap[parent.type] and crossrefmap[parent.type][entry.type]
+   if not map then
+      -- @xdata and any other unknown types: inherit all missing fields
+      for field, value in pairs(parent.attributes) do
+         if not entry.attributes[field] then
+            entry.attributes[field] = value
+         end
+      end
+      return -- done
+   end
+   for field, value in pairs(parent.attributes) do
+      if map[field] == nil and not entry.attributes[field] then
+         entry.attributes[field] = value
+      end
+      for childfield, parentfield in pairs(map) do
+         if parentfield and not entry.attributes[parentfield] then
+            entry.attributes[parentfield] = parent.attributes[childfield]
+         end
+      end
+   end
+end
+
+--- Resolve the 'crossref' and 'xdata' fields on a bibliography entry.
+-- (Supplementing the entry with the attributes of the parent entry.)
+-- Once resolved recursively, the crossref and xdata fields are removed
+-- from the entry.
+-- So this is intended to be called at first use of the entry, and have no
+-- effect on subsequent uses: BibTeX does seem to mandate cross references
+-- to be defined before the entry that uses it, or even in the same bibliography
+-- file.
+-- Implementation note:
+-- We are not here to check the consistency of the BibTeX file, so there is
+-- no check that xdata refers only to @xdata entries
+-- Removing the crossref field implies we won't track its use and implicitly
+-- cite referenced entries in the bibliography over a certain threshold.
+-- @tparam table bib Bibliography
+-- @tparam table entry Bibliography entry
+local function crossrefAndXDataResolve (bib, entry)
+   local refs
+   local xdata = entry.attributes.xdata
+   if xdata then
+      refs = xdata and pl.stringx.split(xdata, ",")
+      entry.attributes.xdata = nil
+   end
+   local crossref = entry.attributes.crossref
+   if crossref then
+      refs = refs or {}
+      table.insert(refs, crossref)
+      entry.attributes.crossref = nil
+   end
+
+   if not refs then
+      return
+   end
+   for _, ref in ipairs(refs) do
+      local parent = bib[ref]
+      if parent then
+         crossrefAndXDataResolve(bib, parent)
+         fieldsInherit(parent, entry)
+      else
+         SU.warn("Unknown crossref " .. ref .. " in bibliography entry " .. entry.label)
+      end
+   end
+end
+
+return {
+   parseBibtex = parseBibtex,
+   crossrefAndXDataResolve = crossrefAndXDataResolve
+}

--- a/tests/bibtex.sil
+++ b/tests/bibtex.sil
@@ -3,6 +3,7 @@
 \neverindent
 \nofolios
 \use[module=packages.bibtex]
+\set[parameter=bibtex.style, value=chicago]% LEGACY IMPLEMENTATION
 \language[main=en]
 \set[parameter=document.parskip, value=4pt]
 

--- a/tests/bug-2054.sil
+++ b/tests/bug-2054.sil
@@ -3,6 +3,7 @@
 \neverindent
 \language[main=en]
 \use[module=packages.bibtex]
+\set[parameter=bibtex.style, value=chicago]% LEGACY IMPLEMENTATION
 \loadbibliography[file=tests/bug-2054.bib]
 
 \reference{bar}


### PR DESCRIPTION
~~Currently based on #2228 - to rebase accordingly~~ REBASED

**Objectives**

 - [x] Properly grouped multiple citations
 - [x] Handling of the CSL indentation rules (`hanging-indent`, `second-field-align`) in order to support more styles effectively (stretch goal: with IEEE as main target).
 - [x] I think it will then also be the right time to switch to `csl` mode by default, while still keeping the legacy stuff for now.

**Changes**

 - Some code refactors
 - Some fixes and improvements
 - `\nocite` command for marking an entry as cited with out actually citing it (= force its inclusion in the list of cited works, as with LaTeX)
 - `\cites` command for grouped (multiple) citations

**Other notes**

On the way, I tested a few more styles, now guaranteed not to crash :rofl: and produce something at least decent :rabbit: 
 - (EDIT) (obviously still Chicago author-date)
 - IEEE (for the indentation rules) w/ and w/o URL.
 - ISO690 (author-date) and ISO690 (numeric), both English and French styles (I was told this one is often used in French papers, so heh)... And there was a bug in our locale logic (fix: Apply default locale on locale overrides without xml:lang). Doh.
 - APA, as several French styles are APA-derivatves (... and I thought APA was for Psychology-related journals, but apparently is used in many other contexts, incl. Humanities).
 - ACS
 - (EDIT) MLA
 - (EDIT) _Acta philosophica_ (see discussion below, after further fixes)
 - (EDIT) ABNT (see discussion below)
 - (EDIT) Harvard / Cite them right (see discussion below)

Closes #2196 

Closes #2023