### PR TITLE
fix(typesetters): Special punctuation spaces need better italic corre…

### DIFF
--- a/tests/feat-italic-correction.expected
+++ b/tests/feat-italic-correction.expected
@@ -167,28 +167,28 @@ T	12 w=4.7534	())
 Mx 	14.8819
 My 	122.6951
 T	14 w=6.1523	(+)
-Mx 	25.0138
+Mx 	25.0137
 T	169 w=7.2803	(«)
-Mx 	35.4699
+Mx 	35.4698
 Set font 	Gentium Plus;15;400;Italic;normal;;;LTR
 T	739 88 747 w=23.2910	(fluff)
-Mx 	61.9367
+Mx 	61.9366
 Set font 	Gentium Plus;15;400;;normal;;;LTR
 T	170 w=7.2803	(»)
-Mx 	73.1709
+Mx 	73.1963
 Set font 	Gentium Plus;15;400;Italic;normal;;;LTR
 T	73 85 72 81 70 75 w=35.9619	(french)
-Mx 	112.7506
+Mx 	112.7759
 T	83 85 82 82 73 w=29.1431	(proof)
-Mx 	143.8756
+Mx 	144.3722
 Set font 	Gentium Plus;15;400;;normal;;;LTR
 T	4 w=4.0796	(!)
-Mx 	151.9347
+Mx 	152.4313
 T	11 w=4.7534	(()
-Mx 	157.1638
+Mx 	157.6604
 Set font 	Gentium Plus;15;400;Italic;normal;;;LTR
 T	739 88 747 w=23.2910	(fluff)
-Mx 	182.9744
+Mx 	183.4710
 Set font 	Gentium Plus;15;400;;normal;;;LTR
 T	12 w=4.7534	())
 Mx 	14.8819
@@ -221,23 +221,23 @@ Set font 	Gentium Plus;15;400;;normal;;;LTR
 T	739 88 747 w=26.0083	(fluff)
 My 	176.6951
 T	14 w=6.1523	(+)
-Mx 	26.4319
+Mx 	26.6973
 Set font 	Gentium Plus;15;400;Italic;normal;;;LTR
 T	739 88 747 w=23.2910	(fluff)
-Mx 	52.1762
+Mx 	52.4415
 Set font 	Gentium Plus;15;400;;normal;;;LTR
 T	4 w=4.0796	(!)
-Mx 	62.0234
+Mx 	62.2445
 Set font 	Gentium Plus;15;400;Italic;normal;;;LTR
 T	739 88 747 w=23.2910	(fluff)
-Mx 	93.5412
+Mx 	93.7181
 Set font 	Gentium Plus;15;400;;normal;;;LTR
 T	739 88 747 w=26.0083	(fluff)
-Mx 	125.2568
+Mx 	125.3895
 T	68 68 68 68 68 68 68 w=48.1934	(aaaaaaa)
-Mx 	179.1574
+Mx 	179.2459
 T	68 68 68 68 w=27.5391	(aaaa)
-Mx 	212.4037
+Mx 	212.4480
 T	68 68 68 68 68 68 w=41.3086	(aaaaaa)
 Mx 	259.4649
 Set font 	Gentium Plus;15;400;Italic;normal;;;LTR
@@ -473,15 +473,15 @@ T	2404 w=4.6350	())
 Mx 	14.8819
 My 	302.6951
 T	2530 w=5.9700	(+)
-Mx 	25.0820
+Mx 	25.0819
 T	2441 w=6.8400	(«)
-Mx 	35.2970
+Mx 	35.2969
 Set font 	Cormorant Infant;15;400;Italic;normal;;;LTR
 T	718 555 634 816 w=22.2450	(fluff)
-Mx 	60.9170
+Mx 	60.9169
 Set font 	Cormorant Infant;15;400;;normal;;;LTR
 T	2442 w=6.8400	(»)
-Mx 	71.7616
+Mx 	71.9870
 Set font 	Cormorant Infant;15;400;Italic;normal;;;LTR
 Mx 	3.9300
 Mx 	4.8300
@@ -490,22 +490,22 @@ Mx 	7.0650
 Mx 	5.1750
 Mx 	6.6750
 T	517 a=3.9300 607 a=5.1000 498 a=5.1450 567 a=6.9750 486 a=5.1750 527 a=6.6750	(french)
-Mx 	108.8116
+Mx 	109.0370
 Mx 	6.1050
 Mx 	4.8300
 Mx 	5.9700
 Mx 	5.9700
 Mx 	3.9300
 T	604 a=6.1050 607 a=5.1000 577 a=5.9700 577 a=5.9700 517 a=3.9300	(proof)
-Mx 	137.7226
+Mx 	137.9480
 Set font 	Cormorant Infant;15;400;;normal;;;LTR
 T	2371 w=3.7050	(!)
-Mx 	145.6577
+Mx 	145.8830
 T	2403 w=4.6350	(()
-Mx 	150.9750
+Mx 	151.2003
 Set font 	Cormorant Infant;15;400;Italic;normal;;;LTR
 T	718 555 634 816 w=22.2450	(fluff)
-Mx 	175.1850
+Mx 	175.4103
 Set font 	Cormorant Infant;15;400;;normal;;;LTR
 T	2404 w=4.6350	())
 Mx 	14.8819
@@ -538,23 +538,23 @@ Set font 	Cormorant Infant;15;400;;normal;;;LTR
 T	952 699 936 w=24.9000	(fluff)
 My 	356.6951
 T	2530 w=5.9700	(+)
-Mx 	26.1564
+Mx 	26.2555
 Set font 	Cormorant Infant;15;400;Italic;normal;;;LTR
 T	718 555 634 816 w=22.2450	(fluff)
-Mx 	50.1038
+Mx 	50.2029
 Set font 	Cormorant Infant;15;400;;normal;;;LTR
 T	2371 w=3.7050	(!)
-Mx 	59.2925
+Mx 	59.3751
 Set font 	Cormorant Infant;15;400;Italic;normal;;;LTR
 T	718 555 634 816 w=22.2450	(fluff)
-Mx 	88.9226
+Mx 	88.9887
 Set font 	Cormorant Infant;15;400;;normal;;;LTR
 T	952 699 936 w=24.9000	(fluff)
-Mx 	119.2428
+Mx 	119.2923
 T	522 522 522 522 522 522 522 w=51.4500	(aaaaaaa)
-Mx 	176.1129
+Mx 	176.1459
 T	522 522 522 522 w=29.4000	(aaaa)
-Mx 	210.9330
+Mx 	210.9495
 T	522 522 522 522 522 522 w=44.1000	(aaaaaa)
 Mx 	260.5109
 Set font 	Cormorant Infant;15;400;Italic;normal;;;LTR

--- a/typesetters/base.lua
+++ b/typesetters/base.lua
@@ -138,6 +138,13 @@ function typesetter.declareSettings (_)
    })
 
    SILE.settings:declare({
+      parameter = "typesetter.italicCorrection.punctuation",
+      type = "boolean",
+      default = true,
+      help = "Whether italic correction is compensated on special punctuation spaces (e.g. in French)",
+   })
+
+   SILE.settings:declare({
       parameter = "typesetter.softHyphen",
       type = "boolean",
       default = true,
@@ -430,9 +437,15 @@ function typesetter:breakIntoLines (nodelist, breakWidth)
    return self:breakpointsToLines(breakpoints)
 end
 
+--- Extract the last shaped item from a node list.
+-- @tparam table nodelist A list of nodes.
+-- @treturn table The last shaped item.
+-- @treturn boolean Whether the list contains a glue after the last shaped item.
+-- @treturn number|nil The width of a punctuation kern after the last shaped item, if any.
 local function getLastShape (nodelist)
+   local lastShape
    local hasGlue
-   local last
+   local punctSpaceWidth
    if nodelist then
       -- The node list may contain nnodes, penalties, kern and glue
       -- We skip the latter, and retrieve the last shaped item.
@@ -440,24 +453,33 @@ local function getLastShape (nodelist)
          local n = nodelist[i]
          if n.is_nnode then
             local items = n.nodes[#n.nodes].value.items
-            last = items[#items]
+            lastShape = items[#items]
             break
          end
          if n.is_kern and n.subtype == "punctspace" then
             -- Some languages such as French insert a special space around
-            -- punctuations. In those case, we should not need italic correction.
-            break
+            -- punctuations.
+            -- In those case, we have different strategies for handling
+            -- italic correction.
+            punctSpaceWidth = n.width:tonumber()
          end
          if n.is_glue then
             hasGlue = true
          end
       end
    end
-   return last, hasGlue
+   return lastShape, hasGlue, punctSpaceWidth
 end
+
+--- Extract the first shaped item from a node list.
+-- @tparam table nodelist A list of nodes.
+-- @treturn table The first shaped item.
+-- @treturn boolean Whether the list contains a glue before the first shaped item.
+-- @treturn number|nil The width of a punctuation kern before the first shaped item, if any.
 local function getFirstShape (nodelist)
-   local first
+   local firstShape
    local hasGlue
+   local punctSpaceWidth
    if nodelist then
       -- The node list may contain nnodes, penalties, kern and glue
       -- We skip the latter, and retrieve the first shaped item.
@@ -465,58 +487,73 @@ local function getFirstShape (nodelist)
          local n = nodelist[i]
          if n.is_nnode then
             local items = n.nodes[1].value.items
-            first = items[1]
+            firstShape = items[1]
             break
          end
          if n.is_kern and n.subtype == "punctspace" then
             -- Some languages such as French insert a special space around
-            -- punctuations. In those case, we should not need italic correction.
-            break
+            -- punctuations.
+            -- In those case, we have different strategies for handling
+            -- italic correction.
+            punctSpaceWidth = n.width:tonumber()
          end
          if n.is_glue then
             hasGlue = true
          end
       end
    end
-   return first, hasGlue
+   return firstShape, hasGlue, punctSpaceWidth
 end
 
-local function fromItalicCorrection (precShape, curShape)
+--- Compute the italic correction when switching from italic to non-italic.
+-- Computing italic correction is at best heuristics.
+-- The strong assumption is that italic is slanted to the right.
+-- Thus, the part of the character that goes beyond its width is usually maximal at the top of the glyph.
+-- E.g. consider a "f", that would be the top hook extent.
+-- Pathological cases exist, such as fonts with a Q with a long tail, but these will rarely occur in usual languages.
+-- For instance, Klingon's "QaQ" might be an issue, but there's not much we can do...
+-- Another assumption is that we can distribute that extent in proportion with the next character's height.
+-- This might not work that well with non-Latin scripts.
+--
+-- @tparam table precShape The last shaped item (italic).
+-- @tparam table curShape The first shaped item (non-italic).
+-- @tparam number|nil punctSpaceWidth The width of a punctuation kern between the two items, if any.
+local function fromItalicCorrection (precShape, curShape, punctSpaceWidth)
    local xOffset
    if not curShape or not precShape then
       xOffset = 0
+   elseif precShape.height <= 0 then
+      xOffset = 0
    else
-      -- Computing italic correction is at best heuristics.
-      -- The strong assumption is that italic is slanted to the right.
-      -- Thus, the part of the character that goes beyond its width is usually
-      -- maximal at the top of the glyph.
-      -- E.g. consider a "f", that would be the top hook extent.
-      -- Pathological cases exist, such as fonts with a Q with a long tail,
-      -- but these will rarely occur in usual languages. For instance, Klingon's
-      -- "QaQ" might be an issue, but there's not much we can do...
-      -- Another assumption is that we can distribute that extent in proportion
-      -- with the next character's height.
-      -- This might not work that well with non-Latin scripts.
       local d = precShape.glyphWidth + precShape.x_bearing
       local delta = d > precShape.width and d - precShape.width or 0
       xOffset = precShape.height <= curShape.height and delta or delta * curShape.height / precShape.height
+      if punctSpaceWidth and SILE.settings:get("typesetter.italicCorrection.punctuation") then
+         xOffset = xOffset - punctSpaceWidth > 0 and (xOffset - punctSpaceWidth) or 0
+      end
    end
    return xOffset
 end
 
-local function toItalicCorrection (precShape, curShape)
-   if not SILE.settings:get("typesetter.italicCorrection") then
-      return
-   end
+--- Compute the italic correction when switching from non-italic to italic.
+-- Same assumptions as fromItalicCorrection(), but on the starting side of the glyph.
+--
+-- @tparam table precShape The last shaped item (non-italic).
+-- @tparam table curShape The first shaped item (italic).
+-- @tparam number|nil punctSpaceWidth The width of a punctuation kern between the two items, if any.
+local function toItalicCorrection (precShape, curShape, punctSpaceWidth)
    local xOffset
    if not curShape or not precShape then
       xOffset = 0
+   elseif precShape.depth <= 0 then
+      xOffset = 0
    else
-      -- Same assumptions as fromItalicCorrection(), but on the starting side of
-      -- the glyph.
       local d = curShape.x_bearing
       local delta = d < 0 and -d or 0
       xOffset = precShape.depth >= curShape.depth and delta or delta * precShape.depth / curShape.depth
+      if punctSpaceWidth and SILE.settings:get("typesetter.italicCorrection.punctuation") then
+         xOffset = punctSpaceWidth - xOffset > 0 and xOffset or 0
+      end
    end
    return xOffset
 end
@@ -537,23 +574,24 @@ function typesetter.shapeAllNodes (_, nodelist, inplace)
    local newNodelist = {}
    local prec
    local precShapedNodes
+   local isItalicCorrectionEnabled = SILE.settings:get("typesetter.italicCorrection")
    for _, current in ipairs(nodelist) do
       if current.is_unshaped then
          local shapedNodes = current:shape()
 
-         if SILE.settings:get("typesetter.italicCorrection") and prec then
+         if isItalicCorrectionEnabled and prec then
             local itCorrOffset
             local isGlue
             if isItalicLike(prec) and not isItalicLike(current) then
                local precShape, precHasGlue = getLastShape(precShapedNodes)
-               local curShape, curHasGlue = getFirstShape(shapedNodes)
+               local curShape, curHasGlue, curPunctSpaceWidth = getFirstShape(shapedNodes)
                isGlue = precHasGlue or curHasGlue
-               itCorrOffset = fromItalicCorrection(precShape, curShape)
+               itCorrOffset = fromItalicCorrection(precShape, curShape, curPunctSpaceWidth)
             elseif not isItalicLike(prec) and isItalicLike(current) then
-               local precShape, precHasGlue = getLastShape(precShapedNodes)
+               local precShape, precHasGlue, precPunctSpaceWidth = getLastShape(precShapedNodes)
                local curShape, curHasGlue = getFirstShape(shapedNodes)
                isGlue = precHasGlue or curHasGlue
-               itCorrOffset = toItalicCorrection(precShape, curShape)
+               itCorrOffset = toItalicCorrection(precShape, curShape, precPunctSpaceWidth)
             end
             if itCorrOffset and itCorrOffset ~= 0 then
                -- If one of the node contains a glue (e.g. "a \em{proof} is..."),


### PR DESCRIPTION
…ction

The heuristics previously considered that special punctuation spaces (as used in French) would cancel italic automated correction. This could however still lead to character overlaps even with decent fonts, so a slightly better logic is needed here: by default, ensure minimal italic correction if the space is not sufficient, for partial compensation.
A new setting is also added to fully apply italic correction.

Closes #2233 