### PR TITLE
docs(manual): Replace URLs in the documentation by actual hyperlinks

### DIFF
--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -16,7 +16,7 @@ Alternatively, Docker containers are available for use on any compatible system.
 \subsection{macOS}
 
 For macOS users, the recommended method for installing SILE is through the Homebrew package manager.
-Once Homebrew is up and running (see \url{http://brew.sh}), you can install SILE effortlessly by running:
+Once Homebrew is up and running (see \href{http://brew.sh}), you can install SILE effortlessly by running:
 
 \terminal{$ brew install sile}
 
@@ -34,11 +34,11 @@ Arch Linux (and derivatives such as Manjaro, Parabola, and others) have prebuilt
 \terminal{$ pacman -S sile}
 
 A VCS package is also available as \code{sile-git} to build from the latest Git commit.
-This may be built and installed like any other AUR\footnote{\url{https://wiki.archlinux.org/title/Arch_User_Repository}} package.
+This may be built and installed like any other AUR\footnote{\href{https://wiki.archlinux.org/title/Arch_User_Repository}} package.
 
 \subsection{Fedora}
 
-A COPR repository\footnote{\url{https://copr.fedorainfracloud.org/coprs/jonny/SILE/}} is available for Fedora users with packages of SILE and all the necessary dependencies including fonts.
+A COPR repository\footnote{\href{https://copr.fedorainfracloud.org/coprs/jonny/SILE/}} is available for Fedora users with packages of SILE and all the necessary dependencies including fonts.
 Fedora 36 and Fedora 37 are supported.
 There is work in progress to get the packages added to the official Fedora repository.
 
@@ -55,7 +55,7 @@ OpenSUSE has official packages ready to install the usual way:
 
 \subsection{Ubuntu}
 
-A PPA\footnote{\url{https://launchpad.net/~sile-typesetter/+archive/ubuntu/sile}} is available for Ubuntu users with packages of SILE and all the necessary dependencies.
+A PPA\footnote{\href{https://launchpad.net/~sile-typesetter/+archive/ubuntu/sile}} is available for Ubuntu users with packages of SILE and all the necessary dependencies.
 We introduced support starting with Bionic (18.04) and maintain packages for all Ubuntu release series since for as long as they are supported by Canonical.
 
 \begin{terminal}
@@ -87,7 +87,7 @@ $ sile <arguments>
 $ nix run nixpkgs/nixpkgs-unstable#sile -- <arguments>
 \end{terminal}
 
-The SILE source repository is also a valid Nix Flake\footnote{\url{https://wiki.nixos.org/wiki/Flakes#Installing_flakes}} which means you can run any specific version or the latest unreleased development code directly:
+The SILE source repository is also a valid Nix Flake\footnote{\href{https://wiki.nixos.org/wiki/Flakes#Installing_flakes}} which means you can run any specific version or the latest unreleased development code directly:
 
 \begin{terminal}
 $ nix run github:sile-typesetter/sile/v0.15.0 -- <arguments>
@@ -269,7 +269,7 @@ If anyone wants to help in this department, we’d be happy to facilitate contri
 
 According to the rumors, SILE may be built on Windows using CMake and Visual Studio.
 Additionally some Windows executables are supposed to be generated using Azure for every commit.
-You may download these executables by selecting the latest build from \url{https://simoncozens-github.visualstudio.com/sile/_build} and downloading the “sile” artifact from the Artifacts drop down.
+You may download these executables by selecting the latest build from \href{https://simoncozens-github.visualstudio.com/sile/_build} and downloading the “sile” artifact from the Artifacts drop down.
 
 \section{Selecting a text editor}
 
@@ -282,11 +282,11 @@ You can get started with even the most basic text editors built into your deskto
 However more advanced text editors (sometimes categorized as \em{code editors}) can offer a lot of features that make the editing process more robust.
 Editors are typically either graphical (GUI) or terminal (TUI) oriented and range from relatively simple to extremely complex integrated development environments (IDE).
 Examples of popular cross-platform GUI oriented editors include VS Code, Sublime Text, and Atom\footnote{Still relatively popular, but was discontinued in late 2022.}.
-Examples of popular terminal based editors include VIM\footnote{VIM & NeoVIM users can benefit from syntax highlighting and other features via the \code{vim-sile} plugin at \url{https://github.com/sile-typesetter/vim-sile}.}, Emacs, and GNU Nano.
+Examples of popular terminal based editors include VIM\footnote{VIM & NeoVIM users can benefit from syntax highlighting and other features via the \code{vim-sile} plugin at \href{https://github.com/sile-typesetter/vim-sile}.}, Emacs, and GNU Nano.
 Depending on your operating system there may be platform-specific editors to consider such as Notepad++ on Windows or TextMate on macOS.
 Many more niche options abound: Lapce, Lite XL, Micro, Geany, BBEdit, UltraEdit, Eclipse, JetBrains IDE(s), Netbrains, Bluefish, CudaText, Leafpad, etc.
 
-For comparisons of editors see \url{https://alternativeto.net/category/developer-tools/code-editor/} and select your platform.
+For comparisons of editors see \href{https://alternativeto.net/category/developer-tools/code-editor/} and select your platform.
 
 \section{Running SILE}
 
@@ -325,7 +325,7 @@ You can use \code{--output -} to write the output directly to the system IO stre
 
 \subsection{Let’s do something cool}
 
-In \url{https://sile-typesetter.org/examples/docbook.xml}, you will find a typical DocBook 5.0 article.
+In \href{https://sile-typesetter.org/examples/docbook.xml}, you will find a typical DocBook 5.0 article.
 Normally turning DocBook to print involves a complicated dance of XSLT processors, format object processors, and/or strange LaTeX packages.
 But SILE can read XML files directly, and comes with a \autodoc:class{docbook} class, which tells SILE how to render (admittedly, a subset of) the DocBook tags onto a page.
 
@@ -388,8 +388,8 @@ With these ideas in mind, other CI systems should be easy to support as well.
 \section{Installing third-party packages}
 
 Third-party SILE packages can be installed using the \code{luarocks} package manager.
-Packages may be hosted anywhere, either on the default \url{https://luarocks.org} repository or (as in the example below) listed in a specific server manifest.
-For example, to install markdown.sile\footnote{\url{https://github.com/Omikhleia/markdown.sile}} (a plugin that provides a SILE inputter that reads and processes Markdown documents) one could run:
+Packages may be hosted anywhere, either on the default \href{https://luarocks.org} repository or (as in the example below) listed in a specific server manifest.
+For example, to install markdown.sile\footnote{\href{https://github.com/Omikhleia/markdown.sile}} (a plugin that provides a SILE inputter that reads and processes Markdown documents) one could run:
 
 \begin{terminal}
 $ luarocks install --server=https://luarocks.org/dev markdown.sile

--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -39,7 +39,7 @@ But there’s more out there!
 As mentioned earlier in this manual, a number of third-party contributed collections of modules can be installed via the LuaRocks package manager.
 
 \autodoc:note{
-A non-authoritative list of third-party modules may be consulted at \url{https://luarocks.org/m/sile}. To publish your own modules to LuaRocks, see the \code{package-template.sile} repository.
+A non-authoritative list of third-party modules may be consulted at \href{https://luarocks.org/m/sile}. To publish your own modules to LuaRocks, see the \code{package-template.sile} repository.
 }
 
 A SILE compatible LuaRock simply installs the relevant class, package, language, internationalization resources, or similar files in a \code{sile} directory.

--- a/documentation/c08-language.sil
+++ b/documentation/c08-language.sil
@@ -74,7 +74,7 @@ For example, Mongolian is written top to bottom with text lines moving from the 
 To change the writing direction for a single frame, use \autodoc:command{\thisframedirection[direction=<dir>]}.
 
 SILE uses the Unicode bidirectional algorithm to handle texts written in mixed directionalities.
-See \url{https://sile-typesetter.org/examples/i18n.sil} for an example which brings together multiple scripts and directionalities.
+See \href{https://sile-typesetter.org/examples/i18n.sil} for an example which brings together multiple scripts and directionalities.
 
 \section{Hyphenation}
 
@@ -91,7 +91,7 @@ If you switch to this language, text will not be hyphenated.
 The command \autodoc:command{\nohyphenation{…}} is provided as a shortcut for \autodoc:command{\font[language=und]{…}}.
 
 The hyphenator uses the same algorithm as TeX and can use TeX hyphenation pattern files if they are converted to Lua format.
-To implement hyphenation for a new language, first check to see if TeX hyphenation dictionaries are available; if not, work through the resources at \url{http://tug.org/docs/liang/}.
+To implement hyphenation for a new language, first check to see if TeX hyphenation dictionaries are available; if not, work through the resources at \href{http://tug.org/docs/liang/}.
 
 \em{Note on Unicode soft hyphens} — By default, soft hyphens (U+00AD) are interpreted as discretionary breaks, allowing line-breaking at that point (using the current font’s hyphen character).
 
@@ -110,7 +110,7 @@ Setting \autodoc:setting{typesetter.softHyphenWarning} to \code{true} triggers w
 A small handful of strings may be programmatically added to documents depending on language, context, and options.
 For example by default in English the \autodoc:class{book} class will prepend “Chapter ” before chapter numbers output by the \autodoc:command{\chapter} command.
 These localized strings are managed internally using the Fluent localization system.%
-\footnote{See Project Fluent (\url{https://projectfluent.org}) for details on the data format and uses.}
+\footnote{See Project Fluent (\href{https://projectfluent.org}) for details on the data format and uses.}
 Some default localizations are provided for a handful of languages, but it is quite likely SILE will not (yet) have your language.
 Even if it does, it may not use the localization of your choice.
 
@@ -224,7 +224,7 @@ This alternative behavior can be achieved by setting \autodoc:setting[check=fals
 
 \subsection{Japanese / Chinese}
 
-SILE aims to conform with the W3G document “Requirements for Japanese Text Layout”\footnote{\url{https://www.w3.org/TR/jlreq/}} which describes the typographic conventions for Japanese (and also Chinese) text.
+SILE aims to conform with the W3G document “Requirements for Japanese Text Layout”\footnote{\href{https://www.w3.org/TR/jlreq/}} which describes the typographic conventions for Japanese (and also Chinese) text.
 Breaking rules \em{(kinzoku shori)} and intercharacter spacing is fully supported on selecting the Japanese language.
 The easiest way to set up the other elements of Japanese typesetting such as the \em{hanmen} grid and optional vertical typesetting support is by using the \autodoc:class{jplain} or \autodoc:class{jbook} classes.
 For other languages with similar layout requirements, more generic \autodoc:class{tplain} and \autodoc:class{tbook} classes are available that setup the layout elements without also setting the default language and font to Japanese specific values.

--- a/documentation/c13-tricks.sil
+++ b/documentation/c13-tricks.sil
@@ -5,7 +5,7 @@ We’ll conclude our tour of SILE by looking at some tricky situations which req
 
 \section{Parallel text}
 
-The example \url{https://sile-typesetter.org/examples/parallel.sil} contains a rendering of Chapter 1 of Matthew’s Gospel in English and Greek.
+The example \href{https://sile-typesetter.org/examples/parallel.sil} contains a rendering of Chapter 1 of Matthew’s Gospel in English and Greek.
 It uses the \autodoc:class{diglot} class to align the two texts side-by-side.
 The latter provides the \autodoc:command[check=false]{\left} and \autodoc:command[check=false]{\right} commands to start entering text on the left column or the right column respectively, and the \autodoc:command[check=false]{\sync} command to ensure that the two columns are in sync with each other.
 It’s an instructive example of what can be done in a SILE class, so we will take it apart and see how it works.
@@ -338,7 +338,7 @@ So far we’ve been assuming that you would want to run SILE as a processor for 
 But what if you have a program which produces or manipulates data, and you would like to produce PDFs from within your application?
 In that case, it may be easier and provide more flexibility to use SILE as a library.
 
-At \url{https://sile-typesetter.org/examples/byhand.lua}, you will find an example of a Lua script which produces a PDF from SILE.
+At \href{https://sile-typesetter.org/examples/byhand.lua}, you will find an example of a Lua script which produces a PDF from SILE.
 It’s actually fairly simple to use SILE from within Lua—the difficult part is setting things up.
 Here’s how to do it.
 

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -1,6 +1,6 @@
 \begin[class=book]{document}
 \include[src=documentation/macros.sil]
-\define[command=silehp]{\url{http://www.sile-typesetter.org/}}
+\define[command=silehp]{\href{http://www.sile-typesetter.org/}}
 \define[command=sileversion]{\lua{SILE.typesetter:typeset(SILE.full_version)}}
 \set[parameter=document.baselineskip,value=3ex]
 % Quite drastic value below, but for a fast-changing technical document with snippets of code,

--- a/packages/counters/init.lua
+++ b/packages/counters/init.lua
@@ -242,7 +242,7 @@ The available built-in display types are:
 \end{itemize}
 
 The ICU library also provides ways of formatting numbers in global (non-Latin) scripts.
-You can use any of the display types in this list: \url{http://www.unicode.org/repos/cldr/tags/latest/common/bcp47/number.xml}.
+You can use any of the display types in this list: \href{http://www.unicode.org/repos/cldr/tags/latest/common/bcp47/number.xml}.
 For example, \autodoc:parameter{display=being} will format your numbers in Bengali digits.
 
 So, for example, the following SILE code:

--- a/packages/date/init.lua
+++ b/packages/date/init.lua
@@ -33,7 +33,7 @@ package.documentation = [[
 The \autodoc:package{date} package provides the \autodoc:command{\date} command, which simply outputs a date using the system’s date function.
 It defaults to the current date and time, but can be used to format any other input time as well using the \autodoc:parameter{time} parameter.
 You can customize the format by passing the \autodoc:parameter{format} parameter, following the formatting codes in the Lua manual
-(\url{https://www.lua.org/pil/22.1.html}).
+(\href{https://www.lua.org/pil/22.1.html}).
 \end{document}
 ]]
 

--- a/packages/features/init.lua
+++ b/packages/features/init.lua
@@ -240,7 +240,7 @@ These features can be turned on and off by passing “raw” feature names to th
 However, this is unwieldy and requires memorizing the feature codes.
 
 The \autodoc:package{features} package provides two commands, \autodoc:command{\add-font-feature} and \autodoc:command{\remove-font-feature}, which make it easier to access OpenType features.
-The interface is patterned on the TeX package \code{fontspec}; for full documentation of the OpenType features supported, see the documentation for that package.\footnote{\code{http://texdoc.net/texmf-dist/doc/latex/fontspec/fontspec.pdf}}
+The interface is patterned on the TeX package \code{fontspec}; for full documentation of the OpenType features supported, see the documentation for that package.\footnote{\href{http://texdoc.net/texmf-dist/doc/latex/fontspec/fontspec.pdf}}
 
 Here is how you would turn on discretionary and historic ligatures with the \autodoc:package{features} package:
 

--- a/packages/inputfilter/init.lua
+++ b/packages/inputfilter/init.lua
@@ -44,7 +44,7 @@ It does this by allowing you to rewrite the abstract syntax tree representing th
 
 Loading \autodoc:package{inputfilter} into your class with \code{class:loadPackage("inputfilter")} provides you with two new Lua functions: \code{transformContent} and \code{createCommand}.
 \code{transformContent} takes a content tree and applies a transformation function to the text within it.
-See \url{https://sile-typesetter.org/examples/inputfilter.sil} for a simple example, and \url{https://sile-typesetter.org/examples/chordmode.sil} for a more complete one.
+See \href{https://sile-typesetter.org/examples/inputfilter.sil} for a simple example, and \href{https://sile-typesetter.org/examples/chordmode.sil} for a more complete one.
 \end{document}
 ]]
 

--- a/packages/parallel/init.lua
+++ b/packages/parallel/init.lua
@@ -167,7 +167,7 @@ package.documentation = [[
 The \autodoc:package{parallel} package provides the mechanism for typesetting diglot or other parallel documents.
 When used by a class such as \code{classes/diglot.lua}, it registers a command for each parallel frame, to allow you to select which frame you’re typesetting into.
 It also defines the \autodoc:command{\sync} command, which adds vertical spacing to each frame such that the \em{next} set of text is vertically aligned.
-See \url{https://sile-typesetter.org/examples/parallel.sil} and the source of \code{classes/diglot.lua} for examples which make the operation clear.
+See \href{https://sile-typesetter.org/examples/parallel.sil} and the source of \code{classes/diglot.lua} for examples which make the operation clear.
 \end{document}
 ]]
 


### PR DESCRIPTION
Since 0.15.0, links can be line-broken, so many calls to "url" (just doing the formatting without hyperlinking) can be replaced by "href".

Closes #393 