### PR TITLE
Update tests for ICU changing default numbering systems

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,8 @@ task:
   name: Cirrus CI (FreeBSD)
   freebsd_instance:
     matrix:
-      - image_family: freebsd-14-0
-      - image_family: freebsd-13-3
+      - image_family: freebsd-14-2
+      - image_family: freebsd-13-5
   env:
     MAKEFLAGS: -j$(nproc) -Otarget
     CFLAGS: -I/usr/local/include -fPIC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
       - name: Cache Nix dependencies
-        uses: DeterminateSystems/flakehub-cache-action@v9
+        uses: DeterminateSystems/flakehub-cache-action@v1
       - name: Setup developer environment
         run: |
           nix develop --command ./bootstrap.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             lua_modules
-          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in') }}
+          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in', 'Cargo.lock') }}
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
@@ -104,7 +104,7 @@ jobs:
         with:
           path: |
             lua_modules
-          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in') }}
+          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in', 'Cargo.lock') }}
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -159,7 +159,7 @@ jobs:
         with:
           path: |
             lua_modules
-          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in') }}
+          key: luarocks-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in', 'Cargo.lock') }}
       - name: Install system dependencies
         run: |
           brew install \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             lua_modules
-          key: luarocks-luajit-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in') }}
+          key: luarocks-luajit-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in', 'Cargo.lock') }}
       - name: Setup ‘lua’
         uses: hishamhm/gh-actions-lua@master
         with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
       - name: Cache Nix dependencies
-        uses: DeterminateSystems/flakehub-cache-action@v9
+        uses: DeterminateSystems/flakehub-cache-action@v1
       # Upstream package sometimes has flags set that disable flake checking
       - name: Setup test env
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           path: |
             lua_modules
-          key: luarocks-${{ matrix.luaVersion[0] }}-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in') }}
+          key: luarocks-${{ matrix.luaVersion[0] }}-${{ hashFiles('Makefile-luarocks', 'sile.rockspec.in', 'Cargo.lock') }}
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
       - name: Install system dependencies

--- a/Makefile.am
+++ b/Makefile.am
@@ -364,7 +364,7 @@ BUSTEDFLAGS ?=
 regressions: $(TESTSRCS) $(ACTUALS)
 	$(LOCALFONTS) $(REGRESSIONSCRIPT) $(TESTSRCS)
 
-test: regressions busted
+check-local: regressions busted
 
 lint: luacheck luarocks-lint stylua
 

--- a/build-aux/que_rust_boilerplate.am
+++ b/build-aux/que_rust_boilerplate.am
@@ -66,7 +66,6 @@ RUST_DEVELOPER_TARGETS = cargo-test clippy rustfmt
 
 if DEVELOPER_MODE
 
-test: cargo-test
 lint: rustfmt clippy
 clean-local: clean-cargo
 check-local: cargo-test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The SILE Typesetter",
   "main": "sile",
   "scripts": {
-    "test": "make test",
+    "test": "make check",
     "lint": "make lint",
     "release": "commit-and-tag-version",
     "prepare": "husky"

--- a/spec/fontmanager_spec.lua
+++ b/spec/fontmanager_spec.lua
@@ -21,14 +21,21 @@ describe("The fontconfig manager", function ()
       assert.is.equal(family, face.family)
    end)
 
-   it("should fallback when it can't find", function ()
-      local family = "Yesteryear Imagination"
-      local face
-      assert.has_no.errors(function ()
-         face = SILE.shaper.getFace({ family = family })
+   -- Disable runing this test unless we have font_variantion support. The test itself does not need the feature, but we
+   -- have *fonts* in the test data set that do and fontconfig is not deterministic about which fallback we might get
+   -- for an unknown font. In this case a font that needs variation support is being returned in some CI environments
+   -- when we request this unknown one.
+   if SILE.features.font_variations then
+      it("should fallback when it can't find a face", function ()
+         local family = "Yesteryear Imagination"
+         local face
+         assert.has_no.errors(function ()
+            face = SILE.shaper.getFace({ family = family })
+         end)
+         assert.is_not.equal(family, face.family)
       end)
-      assert.is_not.equal(family, face.family)
-   end)
+   end
+
 end)
 
 describe("The macfonts manager", function ()

--- a/spec/utilities_spec.lua
+++ b/spec/utilities_spec.lua
@@ -144,16 +144,20 @@ describe("SILE.utilities", function ()
          -- The test assumes Arabic language is relying on ICU
 
          it("should format default numbers", function ()
-            assert.is.equal("١٩٨٤", SU.formatNumber(1984, { style = "default" }))
+            assert.is.equal("١٩٨٤", SU.formatNumber(1984, { style = "default", system = "arab" }))
+            assert.is.equal("۱۹۸۴", SU.formatNumber(1984, { style = "default", system = "arabext" }))
          end)
 
          it("should format decimal numbers", function ()
-            assert.is.equal("١٬٩٨٤", SU.formatNumber(1984, { style = "decimal" }))
+            assert.is.equal("١٬٩٨٤", SU.formatNumber(1984, { style = "decimal", system = "arab" }))
+            assert.is.equal("۱٬۹۸۴", SU.formatNumber(1984, { style = "decimal", system = "arabext" }))
          end)
 
          it("should format ordinal numbers", function ()
-            local expectation = icu73plus and "١٬٩٨٤" or "١٬٩٨٤."
-            assert.is.equal(expectation, SU.formatNumber(1984, { style = "ordinal" }))
+            local expectation1 = icu73plus and "١٬٩٨٤" or "١٬٩٨٤."
+            local expectation2 = icu73plus and "۱٬۹۸۴" or "۱٬۹۸۴."
+            assert.is.equal(expectation1, SU.formatNumber(1984, { style = "ordinal", system = "arab" }))
+            assert.is.equal(expectation2, SU.formatNumber(1984, { style = "ordinal", system = "arabext" }))
          end)
       end)
 


### PR DESCRIPTION
Just trying to get back to green tests so I can even evaluate PRs. Not sure when this changed, maybe ICU 76?