### PR TITLE
Make measurement and length parser more strict

### DIFF
--- a/types/length.lua
+++ b/types/length.lua
@@ -49,7 +49,9 @@ function length:_init (spec, stretch, shrink)
       if type(amount) == "number" then
          self:_init(amount)
       else
-         local parsed = SILE.parserBits.length:match(spec)
+         local input = pl.stringx.strip(spec)
+         local length_only_parser = SILE.parserBits.length * -1
+         local parsed = length_only_parser:match(input)
          if not parsed then
             SU.error("Could not parse length '" .. spec .. "'")
          end

--- a/types/measurement.lua
+++ b/types/measurement.lua
@@ -78,7 +78,9 @@ function measurement:_init (amount, unit)
    elseif type(tonumber(amount)) == "number" then
       self.amount = tonumber(amount)
    elseif type(amount) == "string" then
-      local parsed = SILE.parserBits.measurement:match(amount)
+      local input = pl.stringx.strip(amount)
+      local measurement_only_parser = SILE.parserBits.measurement * -1
+      local parsed = measurement_only_parser:match(input)
       if not parsed then
          SU.error("Could not parse measurement '" .. amount .. "'")
       end

--- a/types/unit.lua
+++ b/types/unit.lua
@@ -15,7 +15,9 @@ setmetatable(unittypes, {
       local def = SU.required(spec, "definition", "registering unit " .. unit)
       local relative = SU.boolean(spec.relative, false)
       if type(def) == "string" then
-         local parsed = bits.measurement:match(def)
+         local input = pl.stringx.strip(def)
+         local measurement_only_parser = bits.measurement * -1
+         local parsed = measurement_only_parser:match(input)
          if not parsed then
             SU.error("Could not parse unit definition '" .. def .. "'")
          end


### PR DESCRIPTION
Closes #2258

Accepting random amounts of garbage input after a successful match and calling it good might not have created any problems in most cases, but it does hoist the burden of validation on the end user when we could just as easily be verifying them.

This might cause errors in existing documents, but the input would also be legitimately bogus and *should* be expected to fail since the input may actually be incorrectly parsed. Just because we accepted `1ez minus 4pt plus 1gem` before and silently made it into a length doesn't mean we did it right. The user should be expected to fix the units and order until it parses successfully, e.g. perhaps they meant `1em plus 4pt minus 1em` (or maybe they meant en?).