### PR TITLE
Feat: Support CSL position condition

### DIFF
--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -437,7 +437,6 @@ function CslEngine:_layout (options, content, entries)
       for _, entry in ipairs(entries) do
          self:_prerender()
          local elem = self:_render_children(content, entry)
-         elem = self:_postrender(elem)
          if elem then
             table.insert(output, elem)
          end
@@ -445,11 +444,14 @@ function CslEngine:_layout (options, content, entries)
       -- The CSL 1.0.2 specification is not very clear on this point, but on
       -- citations, affixes and formatting apply on the whole layout.
       -- Affixes are around the delimited list, e.g. "(Smith, 2000; Jones, 2001)"
-      -- Rendering is done after, so vertical-align, etc. apply to the whole list,
+      -- Formatting is done after, so vertical-align, etc. apply to the whole list,
       -- e.g. <bibSuperScript>1, 2</bibSuperScript>
       local cites = self:_render_delimiter(output, options.delimiter or "; ")
       cites = self:_render_affixes(cites, options)
       cites = self:_render_formatting(cites, options)
+      -- Post-render at the very end, so punctuation-in-quotes, etc. apply to the
+      -- content.
+      cites = self:_postrender(cites)
       return cites
    end
    -- On bibliographies, affixes (usually just a period suffix) apply on each entry.
@@ -1285,7 +1287,7 @@ function CslEngine:_position_test (condition, position)
    if condition == "near-note" then
       -- near-note not implemented yet
       -- There are around 9 styles only in the CSL repository needing it, so it's not a real priority.
-      -- With SILE, this would would require some support from the footnote package.
+      -- With SILE, this would require some support from the footnote package.
       -- Note that we can't support the "first-reference-note-number" variable for a similar reason.
       -- The latter is used in approx. 60 styles in the CSL repository.
       -- There are losts of assumptions there, such as the note counter not being reset, etc.

--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -1569,15 +1569,20 @@ function CslEngine:_postrender (text)
       -- move commas and periods before closing quotes
       text = luautf8.gsub(text, "([" .. rdquote .. rsquote .. "]+)%s*([.,])", "%2%1")
    end
-   -- HACK: fix some double punctuation issues.
+   -- HACK: remove spaces before punctuation
+   -- This and other hacks below tries to fix issues in CSL styles
    -- Maybe some more robust way to handle affixes and delimiters would be better?
-   text = luautf8.gsub(text, "%.%.", ".")
+   -- ABNT, ISO 690, and IEEE for instance look better with this.
+   -- FIX%E But this might be to aggressive, esp. it may affect in URL links with such patterns...
+   text = luautf8.gsub(text, "%s+([%.,])", "%1")
    -- Typography: Prefer to have commas and periods inside italics.
    -- (Better looking if italic automated corrections are applied.)
-   text = luautf8.gsub(text, "(</em>)([%.,])", "%2%1")
-   -- HACK: remove extraneous periods after exclamation and question marks.
+   text = luautf8.gsub(text, "(</em>)([%.,]+)", "%2%1")
+   -- HACK: fix some double punctuation issues
+   text = luautf8.gsub(text, "%.%.", ".")
+   -- HACK: remove extraneous periods after exclamation and question marks, period or ellipsis
    -- (Follows the preceding rule to also account for moved periods.)
-   text = luautf8.gsub(text, "([…!?])%.", "%1")
+   text = luautf8.gsub(text, "([…!?]%.)%.", "%1")
    if not piquote then
       -- HACK: remove extraneous periods after quotes.
       -- Opinionated, e.g. for French at least, some typographers wouldn't

--- a/packages/bibtex/csl/engine.lua
+++ b/packages/bibtex/csl/engine.lua
@@ -315,7 +315,7 @@ function CslEngine:_punctuation_extra (t)
 end
 
 function CslEngine:_render_stripPeriods (t, options)
-   if t and options["strip-periods"] and t:sub(-1) == "." then
+   if t and SU.boolean(options["strip-periods"], false) and t:sub(-1) == "." then
       t = t:sub(1, -2)
    end
    return t

--- a/packages/bibtex/init.lua
+++ b/packages/bibtex/init.lua
@@ -71,7 +71,17 @@ end
 
 function package:_init ()
    base._init(self)
-   SILE.scratch.bibtex = { bib = {}, cited = { keys = {}, citnums = {} } }
+   -- Formerly we used a SILE.scratch variable, but these expose too much of the internals to the outer world.
+   -- So we now use a private member instead.
+   self._data = {
+      bib = {},
+      cited = {
+         keys = {}, -- Cited keys in the order they are cited (ordered set)
+         refs = {}, -- Table of cited keys with their first citation number, last locator and last position (table)
+         lastkey = nil, -- Last entry key used in a citation, to track ibid/ibid-with-locator (string)
+      },
+   }
+
    -- For DOI, PMID, PMCID and URL support.
    self:loadPackage("url")
    -- For underline styling support
@@ -112,44 +122,102 @@ end
 --- Retrieve the CSL engine, creating it if necessary.
 -- @treturn CslEngine CSL engine instance
 function package:getCslEngine ()
-   if not SILE.scratch.bibtex.engine then
+   if not self._engine then
       SILE.call("bibliographystyle", { lang = "en-US", style = "chicago-author-date" })
    end
-   return SILE.scratch.bibtex.engine
+   return self._engine
 end
 
 --- Retrieve an entry and mark it as cited if it is not already.
--- The citation key is taken from the options, or from the content if not provided.
--- @tparam table options Options
--- @tparam table content Content
+-- @tparam string key Citation key
 -- @tparam boolean warn_uncited Warn if the entry is not cited yet
 -- @treturn table Bibliography entry
-function package:getEntryForCite (options, content, warn_uncited)
-   if not options.key then
-      options.key = SU.ast.contentToString(content)
-   end
-   local entry = resolveEntry(SILE.scratch.bibtex.bib, options.key)
+-- @treturn number Citation number
+-- @treturn string|nil Locator value
+function package:_getEntryForCite (key, warn_uncited)
+   local entry = resolveEntry(self._data.bib, key)
    if not entry then
       return
    end
    -- Keep track of cited entries
-   local citnum = SILE.scratch.bibtex.cited.citnums[options.key]
-   if not citnum then
+   local cited = self._data.cited.refs[key]
+   if not cited then
       if warn_uncited then
-         SU.warn("Reference to a non-cited entry " .. options.key)
+         SU.warn("Reference to a non-cited entry " .. key)
       end
       -- Make it cited
-      table.insert(SILE.scratch.bibtex.cited.keys, options.key)
-      citnum = #SILE.scratch.bibtex.cited.keys
-      SILE.scratch.bibtex.cited.citnums[options.key] = citnum
+      table.insert(self._data.cited.keys, key)
+      local citnum = #self._data.cited.keys
+      cited = { citnum = citnum }
+      self._data.cited.refs[key] = cited
    end
-   return entry, citnum
+   return entry, cited.citnum
+end
+
+--- Track the position of a citation acconrding to the CSL rules.
+-- @tparam string key Citation key
+-- @tparam table locator Locator (label and value)
+-- @tparam boolean is_single Single or multiple citation
+-- @treturn string Position of the citation (first, subsequent, ibid, ibid-with-locator)
+function package:_getCitePosition (key, locator, is_single)
+   local cited = self._data.cited.refs[key]
+   if not cited then
+      -- This method is assumed to be invoked only for cited entries
+      -- (i.e. after a call to getEntryForCite).
+      SU.error("Entry " .. key .. " not cited yet, cannot track position")
+   end
+   local pos
+   if not cited.position then
+      pos = "first"
+   else
+      -- CSL 1.0.2 for "ibid" and "ibid-with-locator":
+      --    a. the current cite immediately follows on another cite, within the same citation,
+      --       that references the same item
+      --  or
+      --    b. the current cite is the first cite in the citation, and the previous citation consists
+      --       of a single cite referencing the same item.
+      if self._data.cited.lastkey ~= key or not cited.single then
+         pos = "subsequent"
+      elseif cited.locator then
+         -- CSL 1.0.2 rule when preceding cite does have a locator:
+         --    If the current cite has the same locator, the position of the current cite is “ibid”.
+         --    If the locator differs the position is “ibid-with-locator”.
+         --    If the current cite lacks a locator its only position is “subsequent”."
+         if locator then
+            local same = cited.locator.label == locator.label and cited.locator.value == locator.value
+            pos = same and "ibid" or "ibid-with-locator"
+         else
+            pos = "subsequent"
+         end
+      else
+         -- CSL 1.0.2 rule when preceding cite does not have a locator:
+         --    If the current cite has a locator, the position of the current cite is “ibid-with-locator”.
+         --    Otherwise the position is “ibid”."
+         pos = locator and "ibid-with-locator" or "ibid"
+      end
+   end
+   cited.position = pos
+   cited.locator = locator
+   cited.single = is_single
+   self._data.cited.lastkey = key
+   return pos
+end
+
+--- Get the citation key from the options or content (of a command).
+-- @tparam table options Options
+-- @tparam table content Content
+-- @treturn string Citation key
+function package._getCitationKey (_, options, content)
+   if options.key then
+      return options.key
+   end
+   return SU.ast.contentToString(content)
 end
 
 --- Retrieve a locator from the options.
 -- @tparam table options Options
 -- @treturn table Locator
-function package:getLocator (options)
+function package:_getLocator (options)
    local locator
    for k, v in pairs(options) do
       if k ~= "key" then
@@ -171,11 +239,13 @@ end
 function package:registerCommands ()
    self:registerCommand("loadbibliography", function (options, _)
       local file = SU.required(options, "file", "loadbibliography")
-      parseBibtex(file, SILE.scratch.bibtex.bib)
+      parseBibtex(file, self._data.bib)
    end)
 
    self:registerCommand("nocite", function (options, content)
-      self:getEntryForCite(options, content, false)
+      local key = self:_getCitationKey(options, content)
+      -- Just mark the entry as cited.
+      self:_getEntryForCite(key, false) -- no warning if not yet cited
    end, "Mark an entry as cited without actually producing a citation.")
 
    -- LEGACY COMMANDS
@@ -194,10 +264,12 @@ function package:registerCommands ()
          self._deprecated_legacy_warning = true
          SU.warn("Legacy bibtex.style is deprecated, consider enabling the CSL implementation.")
       end
-      local entry = self:getEntryForCite(options, content, false)
+      -- Ensure the key is set in the options as this was the legacy behavior
+      options.key = self:_getCitationKey(options, content)
+      local entry = self:_getEntryForCite(options.key, false) -- no warning if not yet cited
       if entry then
          local bibstyle = require("packages.bibtex.styles." .. style)
-         local cite = Bibliography.produceCitation(options, SILE.scratch.bibtex.bib, bibstyle)
+         local cite = Bibliography.produceCitation(options, self._data.bib, bibstyle)
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
       end
    end, "Produce a single citation.")
@@ -212,10 +284,12 @@ function package:registerCommands ()
          self._deprecated_legacy_warning = true
          SU.warn("Legacy bibtex.style is deprecated, consider enabling the CSL implementation.")
       end
-      local entry = self:getEntryForCite(options, content, true)
+      -- Ensure the key is set in the options as this was the legacy behavior
+      options.key = self:_getCitationKey(options, content)
+      local entry = self:_getEntryForCite(options.key, true) -- warn if uncited
       if entry then
          local bibstyle = require("packages.bibtex.styles." .. style)
-         local cite, err = Bibliography.produceReference(options, SILE.scratch.bibtex.bib, bibstyle)
+         local cite, err = Bibliography.produceReference(options, self._data.bib, bibstyle)
          if cite == Bibliography.Errors.UNKNOWN_TYPE then
             SU.warn("Unknown type @" .. err .. " in citation for reference " .. options.key)
             return
@@ -323,7 +397,7 @@ function package:registerCommands ()
       end
       local lang = SU.required(options, "lang", "bibliographystyle")
       local locale = loadCslLocale(lang)
-      SILE.scratch.bibtex.engine = CslEngine(style, locale, {
+      self._engine = CslEngine(style, locale, {
          localizedPunctuation = SU.boolean(options.localizedPunctuation, false),
          italicExtension = SU.boolean(options.italicExtension, true),
          mathExtension = SU.boolean(options.mathExtension, true),
@@ -331,13 +405,16 @@ function package:registerCommands ()
    end)
 
    self:registerCommand("csl:cite", function (options, content)
-      local entry, citnum = self:getEntryForCite(options, content, false)
+      local key = self:_getCitationKey(options, content)
+      local entry, citnum = self:_getEntryForCite(key, false) -- no warning if not yet cited
       if entry then
          local engine = self:getCslEngine()
-         local locator = self:getLocator(options)
+         local locator = self:_getLocator(options)
+         local pos = self:_getCitePosition(key, locator, true) -- locator, single cite
 
          local cslentry = bib2csl(entry, citnum)
          cslentry.locator = locator
+         cslentry.position = pos
          local cite = engine:cite(cslentry)
 
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
@@ -348,21 +425,35 @@ function package:registerCommands ()
       if type(content) ~= "table" then
          SU.error("Table content expected in \\cites")
       end
-      local cites = {}
-      for i = 1, #content do
-         if type(content[i]) == "table" then
-            local c = content[i]
-            if c.command ~= "cite" then
+      -- We need no count cites to properly handle ibid/ibid-with-locator, as these depend
+      -- on the previous citation being a single cite.
+      local children = {}
+      local nb = 0
+      for _, child in ipairs(content) do
+         if type(child) == "table" then
+            if child.command ~= "cite" then
                SU.error("Only \\cite commands are allowed in \\cites")
             end
-            local o = c.options
-            local entry, citnum = self:getEntryForCite(o, c, false)
-            if entry then
-               local locator = self:getLocator(o)
-               local csljson = bib2csl(entry, citnum)
-               csljson.locator = locator
-               cites[#cites + 1] = csljson
-            end
+            nb = nb + 1
+            table.insert(children, child)
+         end
+         -- Silently ignore other content (normally only blank lines)
+      end
+      local is_single = nb == 1
+      -- Now we can collect the citations
+      local cites = {}
+      for _, c in ipairs(children) do
+         local o = c.options
+         local key = self:_getCitationKey(o, c)
+         local entry, citnum = self:_getEntryForCite(key, false) -- no warning if not yet cited
+         if entry then
+            local locator = self:_getLocator(o)
+            local pos = self:_getCitePosition(key, locator, is_single) -- no locator, single or multiple citation
+
+            local cslentry = bib2csl(entry, citnum)
+            cslentry.locator = locator
+            cslentry.position = pos
+            cites[#cites + 1] = cslentry
          end
       end
       if #cites > 0 then
@@ -373,7 +464,8 @@ function package:registerCommands ()
    end, "Produce a group of citations.")
 
    self:registerCommand("csl:reference", function (options, content)
-      local entry, citnum = self:getEntryForCite(options, content, true)
+      local key = self:_getCitationKey(options, content)
+      local entry, citnum = self:_getEntryForCite(key, nil, true) -- no locator, warn if not yet cited
       if entry then
          local engine = self:getCslEngine()
 
@@ -388,21 +480,22 @@ function package:registerCommands ()
       local bib
       if SU.boolean(options.cited, true) then
          bib = {}
-         for _, key in ipairs(SILE.scratch.bibtex.cited.keys) do
-            bib[key] = SILE.scratch.bibtex.bib[key]
+         for _, key in ipairs(self._data.cited.keys) do
+            bib[key] = self._data.bib[key]
          end
       else
-         bib = SILE.scratch.bibtex.bib
+         bib = self._data.bib
       end
 
       local entries = {}
-      local ncites = #SILE.scratch.bibtex.cited.keys
+      local ncites = #self._data.cited.keys
       for key, entry in pairs(bib) do
          if entry.type ~= "xdata" then
             crossrefAndXDataResolve(bib, entry)
             if entry then
-               local citnum = SILE.scratch.bibtex.cited.citnums[key]
-               if not citnum then
+               local citnum
+               local prevcite = self._data.cited.refs[key]
+               if not prevcite then
                   -- This is just to make happy CSL styles that require a citation number
                   -- However, table order is not guaranteed in Lua so the output may be
                   -- inconsistent across runs with styles that use this number for sorting.
@@ -413,19 +506,24 @@ function package:registerCommands ()
                   -- leading to unpredictable order anyway).
                   ncites = ncites + 1
                   citnum = ncites
+               else
+                  citnum = prevcite.citnum
                end
                local cslentry = bib2csl(entry, citnum)
                table.insert(entries, cslentry)
             end
          end
       end
+      -- Reset the list of cited entries after having build the entries
+      self._data.cited = { keys = {}, refs = {}, lastkey = nil }
+
+      local engine = self:getCslEngine()
+      local cite = engine:reference(entries)
 
       print("<bibliography: " .. #entries .. " entries>")
       if not SILE.typesetter:vmode() then
          SILE.call("par")
       end
-      local engine = self:getCslEngine()
-      local cite = engine:reference(entries)
       SILE.settings:temporarily(function ()
          local hanging_indent = SU.boolean(engine.bibliography.options["hanging-indent"], false)
          local must_align = engine.bibliography.options["second-field-align"]
@@ -446,8 +544,6 @@ function package:registerCommands ()
          SILE.processString(("<sile>%s</sile>"):format(cite), "xml")
          SILE.call("par")
       end)
-
-      SILE.scratch.bibtex.cited = { keys = {}, citnums = {} }
    end, "Produce a bibliography of references.")
 end
 


### PR DESCRIPTION
~~Work in progress - pushed for information and to safeguard it before vacations~~

Supporting "position" in `csl:if` construct is one of the things that weren't implemented yet.

It's mostly used in "notes" citation styles, to evaluate and render _ibid._, _cit._ and the likes, rather than repeating the whole entry. Some "in-text" styles do use it too, but they are a minority, and unless mistaken, none of the more usual styles of that kind I checked needed it.

But of course, Chicago (fullnote), Chicago (note) or _Acta Philosophica_ etc. would be much better with it, for people who like to have those shorter references (normally to be put in some foot-or-end notes) rather than to follow author-date, numeric etc. conventions. So I wanted to address it after the completion of other refactors (that eventually went in 0.15.10), and there we are now.

There ought to be two parts of it:
 - [x] Support in the CSL engine[^1]
 - [x] Support in the upper processor (in our case, the SILE package)

[^1]: On my way doing it, I fixed an overlooked boolean coercion issue; and tried to fine-tune a bit the "space/punctuation clean-up" hacks (regexp) at post-rendering (though these are fairly fragile...); and also a small issue with "punctuation-in-quotes" not being applied due the post-rendering being invoked to soon (not noticed earlier as it happens mostly for "notes" citation styles, and... I had checked some output but with French, which does not have punctuation in quotes) :rofl: 