### PR TITLE
Small improvements to the Norwegian translations

### DIFF
--- a/languages/nb/messages.ftl
+++ b/languages/nb/messages.ftl
@@ -10,6 +10,6 @@ book-chapter-title = Kapittel { $number }
 
 hello = Hei <em>{ $name }</em>!
 
-tableofcontents-not-generated = Kjør SILE om igjen slik at innholdsfortegnelsen blir behandlet!
+tableofcontents-not-generated = Kjør SILE om igjen for å behandle innholdsfortegnelsen!
 
 tableofcontents-title = Innhold

--- a/languages/nb/messages.ftl
+++ b/languages/nb/messages.ftl
@@ -2,7 +2,7 @@ bibliography-and = og
 
 bibliography-edited-by = Redigert av { $name }
 
-bibliography-et-al = <language main="la">et al</language>.
+bibliography-et-al = mfl.
 
 bibliography-translated-by = Oversatt av { $name }
 

--- a/languages/nn/messages.ftl
+++ b/languages/nn/messages.ftl
@@ -10,6 +10,6 @@ book-chapter-title = Kapittel { $number }
 
 hello = Hei <em>{ $name }</em>!
 
-tableofcontents-not-generated = Køyr SILE om igjen slik at innhaldslista vert behandla!
+tableofcontents-not-generated = Køyr SILE om igjen for å behandle innhaldslista!
 
 tableofcontents-title = Innhald

--- a/languages/nn/messages.ftl
+++ b/languages/nn/messages.ftl
@@ -2,14 +2,14 @@ bibliography-and = og
 
 bibliography-edited-by = Redigert av { $name }
 
-bibliography-et-al = <language main="la">et al</language>.
+bibliography-et-al = mfl.
 
-bibliography-translated-by = Redigert av { $name }
+bibliography-translated-by = Omsett av { $name }
 
 book-chapter-title = Kapittel { $number }
 
 hello = Hei <em>{ $name }</em>!
 
-tableofcontents-not-generated = Kjør SILE om igjen slik at innholdsfortegnelsen blir behandlet!
+tableofcontents-not-generated = Køyr SILE om igjen slik at innhaldslista vert behandla!
 
 tableofcontents-title = Innhald

--- a/languages/no/messages.ftl
+++ b/languages/no/messages.ftl
@@ -2,7 +2,7 @@ bibliography-and = og
 
 bibliography-edited-by = Redigert av { $name }
 
-bibliography-et-al = <language main="la">et al</language>.
+bibliography-et-al = mfl.
 
 bibliography-translated-by = Oversatt av { $name }
 
@@ -10,6 +10,6 @@ book-chapter-title = Kapittel { $number }
 
 hello = Hei <em>{ $name }</em>!
 
-tableofcontents-not-generated = Kjør SILE om igjen slik at innholdsfortegnelsen blir behandlet!
+tableofcontents-not-generated = Kjør SILE om igjen for å behandle innholdsfortegnelsen!
 
 tableofcontents-title = Innhold


### PR DESCRIPTION
This pull request improves the Norwegian translations (especially Nynorsk) slightly, and shifts to the preferred[^1] _et al._ translation in Norwegian.

[^1]: Although _et al._ can be used, it is most often an Anglicism, and native Norwegian abbreviations are better, especially in Nynorsk.