### PR TITLE
fix(math): Fix placement of math stretchable delimiters and accents

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -510,7 +510,12 @@ function elements.stackbox:shape ()
       -- Handle stretchy operators
       for _, elt in ipairs(self.children) do
          if elt:is_a(elements.text) and elt.kind == "operator" and SU.boolean(elt.stretchy, false) then
-            elt:_vertStretchyReshape(self.depth, self.height)
+            local stretched = elt:_vertStretchyReshape(self.depth, self.height)
+            if stretched then
+               -- Stretched elements may have altered height and depth
+               self.height = maxLength(self.height, elt.height)
+               self.depth = maxLength(self.depth, elt.depth)
+            end
          end
       end
       -- Set self.width
@@ -1249,10 +1254,16 @@ function elements.text:_vertStretchyReshape (depth, height)
       -- We only do it if the scaling logic found constructions on the vertical block axis.
       -- It's a dirty hack until we properly implement assembly of glyphs in the case we couldn't
       -- find a big enough variant.
-      self.vertExpectedSz = height + depth
-      self.vertScalingRatio = (depth + height):tonumber() / (self.height:tonumber() + self.depth:tonumber())
-      self.height = height
-      self.depth = depth
+      -- At output, We will peform a symmetric scaling of the glyphs, centered on the height axis.
+      local constants = self:getMathMetrics().constants
+      local scaleDown = self:getScaleDown()
+      local axisHeight = constants.axisHeight * scaleDown
+
+      local midSz = maxLength(height - axisHeight, depth + axisHeight)
+      self.vertScalingRatio = 2 * midSz:tonumber() / (self.height + self.depth):tonumber()
+      self.vertScalingOffset = self.height - (midSz + axisHeight) / self.vertScalingRatio
+      self.height = midSz + axisHeight
+      self.depth = midSz - axisHeight
    end
    return hasStretched
 end
@@ -1285,6 +1296,9 @@ function elements.text:output (x, y, line)
       compensatedY = SILE.types.length(y.length + self.value.items[1].depth - self.value.items[1].fontDepth)
    else
       compensatedY = y
+   end
+   if self.vertScalingOffset then
+      compensatedY = compensatedY + self.vertScalingOffset
    end
    local xs = scaleWidth(x, line) -- account for stretchability/shrinkability in line justification
    SILE.outputter:setCursor(xs, compensatedY.length)

--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -1286,7 +1286,8 @@ function elements.text:output (x, y, line)
    else
       compensatedY = y
    end
-   SILE.outputter:setCursor(scaleWidth(x, line), compensatedY.length)
+   local xs = scaleWidth(x, line) -- account for stretchability/shrinkability in line justification
+   SILE.outputter:setCursor(xs, compensatedY.length)
    SILE.outputter:setFont(self.font)
    -- There should be no stretch or shrink on the width of a text
    -- element.
@@ -1300,7 +1301,7 @@ function elements.text:output (x, y, line)
       local xratio = self.horizScalingRatio or 1
       local yratio = self.vertScalingRatio or 1
       SU.debug("math", "fake glyph stretch: xratio =", xratio, "yratio =", yratio)
-      SILE.outputter:scaleFn(x, y, xratio, yratio, function ()
+      SILE.outputter:scaleFn(xs, y, xratio, yratio, function ()
          SILE.outputter:drawHbox(self.value, width)
       end)
    else


### PR DESCRIPTION
Closes #2300 

Closes #2301 

For #2300, it implements the solution presented in my last [comment](https://github.com/sile-typesetter/sile/issues/2300#issuecomment-3143855759)

CI tests are currently failing due to #2297 -- I have **not** checked whether some of the existing tests are affected or not.

What I _did_ check is:

 - The small scenario covering both formulas mentioned in the issues

   ```
   $$`\def{floor}{\lfloor #1 \rfloor}
   p_n = 1 + \sum_{i=1}^{2^n} \floor{(\frac{n}{\sum_{j=1}^i \floor{\cos^2(\pi \frac{(j-1)! + 1}{j})}})^{\frac{1}{n}}}`

   ---

   Inline $`\mathcal{L}_\phi=\overline{(\partial_\mu\phi)}\partial^\mu\phi-\frac{\mu\phi-m_h^2[\bar{\phi}\phi-\frac{\nu^2}{2}]^2}{2\nu^2}`

   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   $`\mathcal{L}_\phi=\overline{(\partial_\mu\phi)}\partial^\mu\phi-\frac{\mu\phi-m_h^2[\bar{\phi}\phi-\frac{\nu^2}{2}]^2}{2\nu^2}`
   Sedeiusmod tempor incididunt.
   ```

 - A decent set of formulas in my booklet _SILE and the Hydra of Maths_... It's easy to miss something at unexpected places, but a lot more formulas than I thought are actually affected, and as far as I can tell, they all look better, except maybe one (but LaTeX does seem to give a very similar result here, though we don't use the same exact table constructs).[^1]

[^1]: Aside note, if I ever want to re-edit that booklet, the change on vertical delimiters is most of the time subtle, but very visible at some places... Sadly, page breaks occur at different places now, and sometimes my nice "filler" illustrations or quotes would have to be moved here and there. :rofl: 

