### PR TITLE
fix(math): Adjust math font size to match the current document font

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -209,22 +209,8 @@ function elements.mbox:_init ()
    self.value = {}
    self.mode = mathMode.display
    self.atom = atoms.types.ord
-   local font = {
-      family = SILE.settings:get("math.font.family"),
-      size = SILE.settings:get("math.font.size"),
-      style = SILE.settings:get("math.font.style"),
-      weight = SILE.settings:get("math.font.weight"),
-      -- https://learn.microsoft.com/en-us/typography/opentype/spec/math#opentype-layout-tags-used-with-the-math-table
-      --   "Script tag to be used for features in math layout.
-      --   The only language system supported with this tag is the default language system."
-      -- Thus, needed for the ssty feature in superscript/subscript to work properly.
-      script = "math",
-   }
-   local filename = SILE.settings:get("math.font.filename")
-   if filename and filename ~= "" then
-      font.filename = filename
-   end
-   self.font = SILE.font.loadDefaults(font)
+   -- The math font is assumed to be already set as current by the calling context.
+   self.font = SILE.font.loadDefaults({})
 end
 
 function elements.mbox:styleChildren ()
@@ -1453,7 +1439,7 @@ function elements.table:_init (children, options)
       return #row.children
    end, self.children)))
    SU.debug("math", "self.ncols =", self.ncols)
-   local spacing = SILE.settings:get("math.font.size") * 0.6 -- arbitrary ratio of the current math font size
+   local spacing = self.font.size * 0.6 -- arbitrary ratio of the current math font size
    self.rowspacing = self.options.rowspacing and SILE.types.length(self.options.rowspacing) or spacing
    self.columnspacing = self.options.columnspacing and SILE.types.length(self.options.columnspacing) or spacing
    -- Pad rows that do not have enough cells by adding cells to the
@@ -1737,9 +1723,6 @@ function elements.padded:styleChildren ()
 end
 
 function elements.padded:shape ()
-   -- TODO MathML allows percentages font-relative units (em, ex) for padding
-   -- But our units work with font.size, not math.font.size (possibly adjusted by scaleDown)
-   -- so the expectations might not be met.
    local width = self.attributes.width and SU.cast("measurement", self.attributes.width)
    local height = self.attributes.height and SU.cast("measurement", self.attributes.height)
    local depth = self.attributes.depth and SU.cast("measurement", self.attributes.depth)

--- a/packages/math/init.lua
+++ b/packages/math/init.lua
@@ -48,8 +48,8 @@ function package:declareSettings ()
    })
    SILE.settings:declare({
       parameter = "math.font.size",
-      type = "integer",
-      default = 10,
+      type = "number or nil",
+      default = nil,
    })
    -- Whether to show debug boxes around mboxes
    SILE.settings:declare({
@@ -89,8 +89,35 @@ function package:declareSettings ()
    })
 end
 
-function package:registerCommands ()
-   self:registerCommand("mathml", function (options, content)
+function package:processMathML (options, content)
+   SILE.settings:temporarily(function ()
+      local font = {
+         style = SILE.settings:get("math.font.style"),
+         weight = SILE.settings:get("math.font.weight"),
+         -- https://learn.microsoft.com/en-us/typography/opentype/spec/math#opentype-layout-tags-used-with-the-math-table
+         --   "Script tag to be used for features in math layout.
+         --   The only language system supported with this tag is the default language system."
+         -- Thus, needed for the ssty feature in superscript/subscript to work properly.
+         script = "math",
+      }
+      local filename = SILE.settings:get("math.font.filename")
+      if filename and filename ~= "" then
+         font.filename = filename
+      else
+         font.family = SILE.settings:get("math.font.family")
+      end
+      local size = SILE.settings:get("math.font.size")
+      if size then
+         font.size = size
+      else
+         font.adjust = "ex-height"
+      end
+      -- Set the current font to the math font
+      SILE.call("font", font)
+      -- Ensure the (possibly adjusted) math font size is stored
+      -- (for use in mu units, etc.)
+      SILE.settings:set("math.font.size", SILE.settings:get("font.size"))
+
       local mbox
       xpcall(function ()
          mbox = self:ConvertMathML(content)
@@ -100,16 +127,16 @@ function package:registerCommands ()
       end)
       self:handleMath(mbox, options)
    end)
+end
+
+function package:registerCommands ()
+   self:registerCommand("mathml", function (options, content)
+      self:processMathML(options, content)
+   end)
 
    self:registerCommand("math", function (options, content)
-      local mbox
-      xpcall(function ()
-         mbox = self:ConvertMathML(self:compileToMathML({}, self:convertTexlike(content)))
-      end, function (err)
-         print(err)
-         print(debug.traceback())
-      end)
-      self:handleMath(mbox, options)
+      content = self:compileToMathML({}, self:convertTexlike(content))
+      self:processMathML(options, content)
    end)
 
    self:registerCommand("math:numberingstyle", function (options, _)
@@ -127,7 +154,6 @@ package.documentation = [[
 \begin{document}
 \use[module=packages.math]
 \set[parameter=math.font.family, value=Libertinus Math]
-\set[parameter=math.font.size, value=11]
 % Default verbatim font (Hack) is missing a few math symbols
 \use[module=packages.font-fallback]
 \font:add-fallback[family=Symbola]
@@ -142,11 +168,16 @@ Feedback and contributions are always welcome.}
 By default, this package uses Libertinus Math, so it will fail if Libertinus Math can’t be found.
 Another font may be specified via the setting \autodoc:setting{math.font.family}.
 If required, you can set the font style and weight via \autodoc:setting{math.font.style} and \autodoc:setting{math.font.weight}.
-The font size can be set via \autodoc:setting{math.font.size}.
+
+The \autodoc:setting{math.font.size} setting controls the math font size.
+By default, it is \emph{not} set, and the math font size is computed to match the ex-height of the current document font (and the setting accordingly is temporarily defined within math mode).
+It allows math formulas to blend well with the surrounding text, even when the text font size changes (e.g., in section titles, footnotes, etc.).
+(At your convenience, fix it to a fixed size, but then the automatic adjustment is disabled.)
+
 The \autodoc:setting{math.font.script.feature} setting can be used to specify OpenType features for the math font, which are applied to the smaller script styles.
 It defaults to \code{ssty} (script style alternates), notably to ensure that some symbols such as the prime, double prime, etc. are displayed correctly.
 The default setting applies to Libertinus Math, STIX Two Math, TeX Gyre Termes Math, and all well-designed math fonts, but some fonts may require different features.
-(The STIX Two Math font has a stylitic set \code{ss04} from primes only, but also supports \code{ssty} with additional optical adjustments.)
+(The STIX Two Math font has a stylistic set \code{ss04} from primes only, but also supports \code{ssty} with additional optical adjustments.)
 
 \paragraph{MathML}
 The first way to typeset math formulas is to enter them in the MathML format.


### PR DESCRIPTION
Math formula in block quotes, footnotes, headers, etc. now adapt to the current document size instead of using a fixed value. The adjustment is based on the eye (ex-height) for consistent optical alignment.

Closes #2145 

Better approach than #2149 :

**Advantages**

 - The user can still set math.font.size to a fixed value (globally or temporarily), and then this will be used.
 - Otherwise, adjustment is to the ex-height, matching the surrounding font (esp. interesting for inline formulas etc.)

**Scenario**

```
{.unnumbered .notoc}
## Regarding Euler's $`e^{\mathrm{i}\pi} + 1 = 0`

Some people say $`e^{\mathrm{i}\pi} + 1 = 0` is one of the most beautiful equation in mathematics.

> But all I want to check here is that $`e^{\mathrm{i}\pi} + 1 = 0` honors the current document font size.[^euler]

[^euler]: And $`e^{\mathrm{i}\pi} + 1 = 0` in a footnote is even smaller.
```

Run with `-u inputters.djot temp/euler-identity.dj -O papersize=a7 -Olandscape=true -c resilient.book`

I.e. adaptation between default text (Gentium) and math (Libertinus).

<img width="853" height="599" alt="image" src="https://github.com/user-attachments/assets/ad9fa581-b155-4351-bc39-09f29acec365" />

**Caveat**

 - In ex-height adjustment mode (default), performances are slightly degraded. We could do some better font caching, but that's a more general question, somewhat orthogonal to that specific case here. I might open a dedicated issue for discussion.
 - Existing tests will fail -- But ideally one would want to make a global pass with all of the proposed math-related PRs for this milestone, after #2297 is also fixed.