### PR TITLE
fix(math): Shallow-copy options on table to avoid a crash on reuse vi…

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -1447,7 +1447,7 @@ elements.table._type = "table" -- TODO why case difference?
 function elements.table:_init (children, options)
    elements.mbox._init(self)
    self.children = children
-   self.options = options
+   self.options = pl.tablex.copy(options) -- Shallow copy the options as columnalign is modified below
    self.nrows = #self.children
    self.ncols = math.max(pl.utils.unpack(mapList(function (_, row)
       return #row.children


### PR DESCRIPTION
…a macro

The columnalign option is modified (converted to list), but might be the same original object from a TeX-like macro. One invocation of the macro shall not affect the subsequent one.

Closes #2312 