### PR TITLE
Math boxing and cancelling commands

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -1819,6 +1819,76 @@ function elements.bevelledFraction:output (x, y, line)
    SILE.outputter:drawSVG(svg, xscaled, y, barwidth, h, 1)
 end
 
+--- <menclose> is not part of MathML Core, but is in MathML3 and MathML4.
+elements.enclose = pl.class(elements.mbox)
+elements.enclose._type = "Enclose"
+
+function elements.enclose:__tostring ()
+   return self._type .. "(" .. tostring(self.enclosed) .. ")"
+end
+
+function elements.enclose:_init (attributes, enclosed)
+   elements.mbox._init(self)
+   self.enclosed = enclosed
+   self.attributes = attributes or {}
+   table.insert(self.children, enclosed)
+end
+
+function elements.enclose:styleChildren ()
+   self.enclosed.mode = self.mode
+end
+
+function elements.enclose:shape ()
+   -- MathML4 umpteenth draft, 3.3.0.2: The amount of distance around "the contents are not specified by MathML,
+   -- and left to the renderer."
+   -- "In practice, paddings on each side of 0.4em in the horizontal direction and .5ex in the vertical direction seem to work well."
+   -- This informal appreciation in a standard is... weird at best.
+   -- The renderer says: "It looks nicer with other values."
+   -- MathML Core has nothing to say, since it does not support <menclose>.
+   self.hpadding = SILE.types.length("0.25em"):absolute();
+   self.vpadding = SILE.types.length("0.4ex"):absolute();
+   self.width = self.enclosed.width + 2 * self.hpadding
+   self.height = self.enclosed.height + self.vpadding
+   self.depth = self.enclosed.depth + self.vpadding
+   self.enclosed.relX = self.hpadding
+
+   -- Let's use the fraction rule as a default thickness.
+   -- We're in the land of a totally ill-defined specifications, so at least use something plausible.
+   local constants = self:getMathMetrics().constants
+   local scaleDown = self:getScaleDown()
+   self.ruleThickness = self.attributes.linethickness
+         and SU.cast("measurement", self.attributes.linethickness):tonumber()
+      or constants.fractionRuleThickness * scaleDown
+end
+
+function elements.enclose:output (x, y, line)
+   local notationShapes = require("packages.math.menclose-notations")
+   local h = self.height:tonumber()
+   local d = self.depth:tonumber()
+   local w = scaleWidth(self.width, line):tonumber()
+   local thickness = _r(self.ruleThickness)
+   local offset = SILE.types.measurement("0.1em"):tonumber() -- Empirical, "seems to work well"
+   local arrow = SILE.types.measurement("0.8ex"):tonumber() -- Ibid.
+   local notations = self.attributes.notations
+      and pl.stringx.split(self.attributes.notations)
+      or {}
+   local paths = {}
+   for _, n in ipairs(notations) do
+      if notationShapes[n] then
+         local nShape = notationShapes[n](_r(w), _r(h + d), thickness, offset, arrow)
+         if nShape then
+            table.insert(paths, table.concat(nShape, " "))
+         end
+      end
+   end
+   if #paths == 0 then
+      return
+   end
+   local svg = table.concat(paths, " ")
+   local xscaled = scaleWidth(x, line)
+   SILE.outputter:drawSVG(svg, xscaled, y, w, h, 1)
+end
+
 elements.mathMode = mathMode
 elements.newSubscript = newSubscript
 elements.newUnderOver = newUnderOver

--- a/packages/math/menclose-notations.lua
+++ b/packages/math/menclose-notations.lua
@@ -1,0 +1,107 @@
+-- SVG rendering instructions for various menclose notations.
+--   box = needed for \boxed
+--   updiagonalstrike = needed for \cancel and \xcancel
+--   downdiagonalstrike = needed for \bcancel and \xcancel
+--   northeastarrow = needed for \cancelto
+-- NOTE: MathML3 defines other notations:
+--   actuarial, phasorangle, roundedbox, circle, left, right, top, bottom, verticalstrike, horizontalstrike, madruwb.
+-- Feel free to implement them as needed.
+
+local function box (w, h, thickness, _, _)
+   return {
+      thickness,
+      "w", -- line width
+      1,
+      "j", -- round line joins
+      0, 0, w, h, "re",
+      "S", -- stroke only
+   }
+end
+
+local function updiagonalstrike (w, h, thickness, offset, _)
+   return {
+      thickness,
+      "w", -- line width
+      1,
+      "J", -- round line caps
+      offset,
+      h - offset,
+      "m",
+      w - offset,
+      offset,
+      "l",
+      "S", -- stroke only
+   }
+end
+
+local function downdiagonalstrike (w, h, thickness, offset, _)
+   return {
+      thickness,
+      "w", -- line width
+      1,
+      "J", -- round line caps
+      offset,
+      offset,
+      "m",
+      w - offset,
+      h - offset,
+      "l",
+      "S", -- stroke only
+   }
+end
+
+local function northeastarrow (w, h, thickness, offset, sw)
+   -- LuaJIT and Lua < 5.3 have atan2.
+   -- Lua 5.3+ deprecated atan2 and supported atan with two args.
+   -- Frankly we live in a world of pain.
+   local atan = SILE.lua_version < "5.3" and math.atan2 or math.atan -- luacheck: ignore
+
+   local angle = atan(h - 2 * offset, w - 2 * offset)
+   local arrowLength = sw
+   local arrowAngle = math.pi / 7 -- about 25 degrees
+   local arrowX1 = arrowLength * math.cos(angle - arrowAngle)
+   local arrowY1 = arrowLength * math.sin(angle - arrowAngle)
+   local arrowX2 = arrowLength * math.cos(angle + arrowAngle)
+   local arrowY2 = arrowLength * math.sin(angle + arrowAngle)
+   return {
+      -- line width
+      thickness,
+      "w", -- line width
+      1,
+      "j", -- round line joinss
+      1,
+      "J", -- round line caps
+      -- Main line
+      offset,
+      h - offset,
+      "m",
+      w - offset,
+      offset,
+      "l",
+      "S", -- stroke only
+      -- Arrow head
+      w - offset - arrowX1,
+      offset + arrowY1,
+      "m",
+      w - offset,
+      offset,
+      "l",
+      "S", -- stroke only
+      -- Other side of arrow head
+      w - offset - arrowX2,
+      offset + arrowY2,
+      "m",
+      w - offset,
+      offset,
+      "l",
+      "S", -- stroke only
+   }
+end
+
+
+return {
+   box = box,
+   updiagonalstrike = updiagonalstrike,
+   downdiagonalstrike = downdiagonalstrike,
+   northeastarrow = northeastarrow,
+}

--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -951,6 +951,15 @@ compileToMathML(
   % Package "amsmath" went with its own generic \overset and \underset.
   \def{overset}{\mover{#2}{#1}}
   \def{underset}{\munder{#2}{#1}}
+
+  % Boxing and cancelling
+  % The boxing command is from "amsmath".
+  \def{boxed}{\menclose[notations=box]{#1}}
+  % Canceling commands are from "cancel" package.
+  \def{cancel}{\menclose[notations=updiagonalstrike]{#1}}
+  \def{bcancel}{\menclose[notations=downdiagonalstrike]{#1}}
+  \def{xcancel}{\menclose[notations=updiagonalstrike downdiagonalstrike]{#1}}
+  \def{cancelto}{\menclose[notations=northeastarrow]{#2}^{#1}}
 ]==],
    })
 )

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -302,6 +302,10 @@ function ConvertMathML (_, content)
       -- MathML Core 3.3.6.1: The <mpadded> element generates an anonymous <mrow> box
       -- called the "impadded inner box"
       return b.padded(content.options, b.stackbox("H", convertChildren(content)))
+   elseif content.command == "menclose" then
+      -- MathML4 §3.3.9:  The <menclose> element accepts a single argument possibly
+      -- being an inferred mrow of multiple children.
+      return b.enclose(content.options, b.stackbox("H", convertChildren(content)))
    else
       SU.error("Unknown math command " .. content.command)
    end


### PR DESCRIPTION
Dear math enthusiasts.

Let's tick another "simple" check-box in #2138 
 - feat(math): Support MathML `<menclose>` element.
   While not part of MathML Core, it's in MathML3 and (draft) MathML4. It is useful and has some semantics...
 - feat(math): Support TeX-like `boxed` and `cancel` commands.
   That is `\boxed` (LaTeX's amsmath package), and `\cancel`, `\xcancel`, `\bcancel`, `\cancelto` (LaTeX's cancel package).

The supported MathML "notations", in this PR, are limited to those needed for the TeX-like commands.
Other than that, there's nothing very complex here.[^1]

Honestly.

It's just for the show.

<img width="934" height="927" alt="image" src="https://github.com/user-attachments/assets/968fbec5-8a67-49e8-ac50-dc2669ba17e8" />

[^1]: My main issue in what was supposed to be **simple**... was Lua < 5.3 having math.atan2, **but** it got deprecated in 5.3 with math.atan supporting two arguments, **and** luacheck complaining whatever I tried, **and** it has these long lists of arcane numerical codes for ignoring rules that just suck... Honestly... :weary: 'Feeling so old. So old.

