### PR TITLE
feat(math): Support TeX-like syntax for roots with degrees

### DIFF
--- a/packages/math/texlike.lua
+++ b/packages/math/texlike.lua
@@ -114,6 +114,7 @@ local mathGrammar = function (_ENV)
       leftrightgroup + -- Important: before command
       V"def" +
       V"text" + -- Important: before command
+      V"sqrt" + -- Important: before command
       V"command" +
       group +
       V"argument" +
@@ -192,6 +193,13 @@ local mathGrammar = function (_ENV)
          + primes -- or standalone primes
       )
 
+   -- For sqrt with degree:
+   -- We might not be very robust below if brackets are used in the optional argument,
+   -- but that's an edge case and both LaTeX and MathJax do weird things in that case too.
+   local mathlist_no_bracket = (comment + (WS * _) + (element - P"]"))^0 / function (...)
+      return { id = "mathlist", ... }
+   end
+
    START "math"
    math = V"mathlist" * EOF"Unexpected character at end of math code"
    mathlist = (comment + (WS * _) + element)^0
@@ -214,6 +222,14 @@ local mathGrammar = function (_ENV)
          Cg(ctrl_sequence_name, "command") *
          Cg(parameters, "options") *
          (dim2_arg + group^0)
+      )
+   -- TeX-like square root (\sqrt{...}) or nth-root (\sqrt[...]{...}):
+   -- One of the very few math commands with an expression as optional argument
+   -- between brackets, and likely the only usual one.
+   sqrt = (
+         P"\\sqrt" *
+         (P"[" * mathlist_no_bracket * P"]")^-1 *
+         P"{" * V"mathlist" * P"}"
       )
    def = P"\\def" * _ * P"{" *
       Cg(ctrl_sequence_name, "command-name") * P"}" * _ *
@@ -595,6 +611,15 @@ local function compileToMathML_aux (_, arg_env, tree)
       return nil
    elseif tree.id == "text" then
       tree.command = "mtext"
+   elseif tree.id == "sqrt" then
+      if #tree == 2 then
+         tree.command = "mroot"
+         local tmp = tree[1]
+         tree[1] = tree[2]
+         tree[2] = tmp
+      else
+         tree.command = "msqrt"
+      end
    elseif tree.id == "command" and commands[tree.command] then
       local argTypes = commands[tree.command][1]
       local cmdFun = commands[tree.command][2]
@@ -827,7 +852,13 @@ compileToMathML(
    convertTexlike(nil, {
       [==[
   \def{frac}{\mfrac{#1}{#2}}
+
+  % Already defined in the parser, but we are not robust against closing brackets in the optional
+  % arguments(see above).
+  % We may hit the macro definition instead of the native command, and the error message
+  % will be less cryptic this way, ensuring the command doesn't reach the MathML typesetter.
   \def{sqrt}{\msqrt{#1}}
+
   \def{bi}{\mi[mathvariant=bold-italic]{#1}}
   \def{dsi}{\mi[mathvariant=double-struck]{#1}}
 


### PR DESCRIPTION
Closes #2225 

Supporting `\sqrt[degree]{radicand}` requires support from the parser due to the unusual syntax with a math expression between square brackets.

This PR does work nicely for simple cases, e.g. 
```latex
\sqrt[17]{7 + \sqrt[19]{A}}
```

It's however _insanely_ slow for deeply nested constructs, e.g.
```latex
\sqrt{1 + \sqrt[3]{2 + \sqrt[5]{3 + \sqrt[7]{4 + \sqrt[11]{5 
   + \sqrt[13]{6 +  \sqrt[17]{7 + \sqrt[19]{A}}}}}}}}
```
 (From Joe's [MathML Browser Test](http://eyeasme.com/Joe/MathML/MathML_browser_test.html), "nested roots" scenario)

**This being said,** the "MathML-like" approach (without any change needed to the current parser) suffers from the same problem. The simple cases works too in a timely manner.
```latex
\mroot{7 + \mroot{A}{19}}{17}
```

But the deeply nested cases is also _equally_ real slow (to a point where this is not acceptable).
```latex
\msqrt{1 + \mroot{2 + \mroot{3 + \mroot{4 + \mroot{5
   + \mroot{6 + \mroot{7 + \mroot{A}{19}}{17}}{13}}{11}}{7}}{5}}{3}}
```

Just to be clear, a very (very) long time is then spent in `convertTexlike()` that just calls the LPEG/EPNF parser... (The time spent afterwards in the tree massaging for conversion to MathML is negligible).

So the slowdown isn’t caused by the proposed "sqrt" parsing rule itself, but by the heavy recursion in our grammar overall. LPeg’s backtracking makes this cost grow exponentially with nesting depth --- the real bottleneck is likely the general deep recursion in "mathlist" constructs...[^2]

Both KaTeX and MathJax are blazingly fast when it comes to render the long nested TeX example...[^1]

So my suggestion would be to accept this PR (so that users would have the usual TeX-like construct support for regular cases, and it's not worse than the MathML-like workaround)...
... But perhaps should we open a dedicated for fully replacing our LPEG-based parser with something more efficient. Aye, this is a painful observation. (**EDIT** --> tracked as #2343)

[^1]: And Typst is real fast too with its own syntax `sqrt(1 + root(3, 2 + root(5, 3 + root(7, 4 + root(11, 5 + root(13, 6 + root(17, 7 + root(19, A))))))))` -- Just sayin'

[^2]: For the record, the degree rule in `\sqrt` as proposed in the PR uses a `- P("]")` on a large element pattern: this _will_ cause some inefficient backtracking too. A faster approach there would be to to parse a shallow "mathlist" specifically for the degree. Still, the performance bottleneck is reached with nested `\mroot`s or even `\msqrt`s... So while the degree root is not of the best efficiency, it's also negligible in this scenario...
