### PR TITLE
fix(math): Properly apply 'cramping' styles in text mode and for radicands

### DIFF
--- a/packages/math/base-elements.lua
+++ b/packages/math/base-elements.lua
@@ -1569,13 +1569,17 @@ end
 function elements.table:output () end
 
 local function getRadicandMode (mode)
-   -- Not too sure if we should do something special/
-   return mode
+   -- TeX \sqrt changes regular styles to cramped ones.
+   if isCrampedMode(mode) then
+      return mode
+   end
+   return mode + 1
 end
 
 local function getDegreeMode (mode)
-   -- 2 levels smaller, up to scriptScript evntually.
-   -- Not too sure if we should do something else.
+   -- Two levels smaller, up to scriptScript eventually.
+   -- As far as can be observed, LaTeX doesn't change cramped vs. non-cramped
+   -- for the degree.
    if mode == mathMode.display then
       return mathMode.scriptScript
    elseif mode == mathMode.displayCramped then

--- a/packages/math/typesetter.lua
+++ b/packages/math/typesetter.lua
@@ -315,7 +315,7 @@ local function handleMath (_, mbox, options)
    if mode == "display" then
       mbox.mode = b.mathMode.display
    elseif mode == "text" then
-      mbox.mode = b.mathMode.textCramped
+      mbox.mode = b.mathMode.text
    else
       SU.error("Unknown math mode " .. mode)
    end


### PR DESCRIPTION
Default text style shouldn't be cramped.
Radicands in roots should trigger cramping.

Closes #2341 