### PR TITLE
fix(tableofcontents): Cast options.level to integer for TOC entry

### DIFF
--- a/packages/tableofcontents/init.lua
+++ b/packages/tableofcontents/init.lua
@@ -136,7 +136,7 @@ function package:registerCommands ()
          category = "toc",
          value = {
             label = SU.ast.stripContentPos(content),
-            level = (options.level or 1),
+            level = SU.cast("integer", options.level or 1),
             number = options.number,
             link = dest,
          },


### PR DESCRIPTION
When using the `tableofcontents` package, calling `\tocentry[level=1]{title}` stores the level number as a string instead of a number in the TOC file. Then, calling `\tableofcontents` crashes the document parsing.

This PR allows the package to work according to the indicated in documentation.