### PR TITLE
docs: 3rd-party markdown.sile is no longer separate from resilient.sile

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,10 @@ Third party packages must be installed for the same version of Lua that SILE use
 On systems with more than one Lua version installed, *and* where SILE does not use the default one you may need to specify the version manually.
 In these examples, we'll ask SILE directory which version it is running.
 
-For example, to install [markdown.sile](https://github.com/Omikhleia/markdown.sile) (a plugin that provides a SILE inputter that reads and processes Markdown documents) one could run:
+For example, to install [resilient.sile](https://github.com/Omikhleia/resilient.sile) (a 3rd-party plugin that provides advanced document classes, and  SILE inputters that read and process Djot and Markdown documents) one could run:
 
 ```console
-$ luarocks --lua-version $(sile -q <<< SILE.lua_version) install markdown.sile
+$ luarocks --lua-version $(sile -q <<< SILE.lua_version) install resilient.sile
 ```
 
 By default, this will try to install the package to your system (the `--global` option).

--- a/documentation/c02-gettingstarted.sil
+++ b/documentation/c02-gettingstarted.sil
@@ -395,10 +395,10 @@ Third party packages must be installed for the same version of Lua that SILE use
 On systems with more than one Lua version installed, \em{and} where SILE does not use the default one, you may need to specify the version manually.
 In these examples, we'll ask SILE directory which version it is running.
 
-For example, to install markdown.sile\footnote{\href{https://github.com/Omikhleia/markdown.sile}} (a plugin that provides a SILE inputter that reads and processes Markdown documents) one could run:
+For example, to install resilient.sile\footnote{\href{https://github.com/Omikhleia/resilient.sile}} (a 3rd-party plugin that provides advanced document classes, and  SILE inputters that read and process Djot and Markdown documents) one could run:
 
 \begin{terminal}
-$ luarocks --lua-version $(sile -q <<< SILE.lua_version) install markdown.sile
+$ luarocks --lua-version $(sile -q <<< SILE.lua_version) install resilient.sile
 \end{terminal}
 
 By default, this will try to install the package to your system (the \code{--global} option).

--- a/documentation/c05-packages.sil
+++ b/documentation/c05-packages.sil
@@ -48,7 +48,7 @@ This directory could be in your system Lua directory, in your user directory, or
 By default, LuaRocks will install these modules to the Lua search path.
 
 \begin[type=autodoc:codeblock]{raw}
-$ luarocks install markdown.sile
+$ luarocks install resilient.sile
 $ sile ...
 \end{raw}
 
@@ -57,7 +57,7 @@ If you either don’t have root permissions or don’t want to pollute your syst
 To use packages installed as a user you will need to have LuaRocks add its user tree to your Lua search path before running SILE.
 
 \begin[type=autodoc:codeblock]{raw}
-$ luarocks --local install markdown.sile
+$ luarocks --local install resilient.sile
 $ eval $(luarocks --local path)
 $ sile ...
 \end{raw}

--- a/documentation/c10-classdesign.sil
+++ b/documentation/c10-classdesign.sil
@@ -172,7 +172,7 @@ end
 “Raw handlers” allow packages to register new handlers (or callbacks) for use with the \autodoc:environment{raw} environment, which content is read as-is by SILE, without being interpreted.
 This is intended for advanced use cases where you may want to provide a way for users to embed arbitrary content (likely in another syntax), and you will provide the complete parsing and handling for it.\footnote{%
 This may be used to implement a “clever” verbatim environment.
-It is also used, for instance, by the \strong{markdown.sile} 3rd-party collection to embed Markdown or Djot content directly in a (SIL or XML) document.}
+It is also used, for instance, by the \strong{resilient.sile} 3rd-party collection to embed Markdown or Djot content directly in a (SIL or XML) document.}
 
 You can define your own raw handlers at the Lua level.
 Overload the \code{registerRawHandlers} package method; and within it, use the \code{self:registerRawHandler} function.


### PR DESCRIPTION
3rd-party collection **markdown.sile** is no longer distributed separately from **resilient.sile** since release [v4.0.0](https://github.com/Omikhleia/resilient.sile/releases/tag/v4.0.0).

This PR therefore replaces any mention accordingly in the README and user guide.

Feel free to adjust at the maintainers' convenience.

See also https://github.com/sile-typesetter/sile/issues/1866#issuecomment-3218382293