### PR TITLE
Fix repeated hyphens logic for several languages, and update occitan and galician support

### DIFF
--- a/languages/cs/init.lua
+++ b/languages/cs/init.lua
@@ -1,8 +1,7 @@
 SILE.nodeMakers.cs = pl.class(SILE.nodeMakers.unicode)
 
 -- According to Czech rules, when a break occurs at an explicit hyphen, the hyphen gets repeated on the next line...
-SILE.nodeMakers.cs.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
-SILE.nodeMakers.cs.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
+SILE.nodeMakers.cs.hasFeatureRepeatedHyphen = true
 
 local hyphens = require("languages.cs.hyphens-tex")
 SILE.hyphenator.languages["cs"] = hyphens

--- a/languages/es/init.lua
+++ b/languages/es/init.lua
@@ -1,10 +1,7 @@
 SILE.nodeMakers.es = pl.class(SILE.nodeMakers.unicode)
 
 -- According to Spanish rules, when a break occurs at an explicit hyphen, the hyphen gets repeated on the next line...
-SILE.nodeMakers.es.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
-SILE.nodeMakers.es.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
-
-SILE.hyphenator.languages["es"] = {}
+SILE.nodeMakers.es.hasFeatureRepeatedHyphen = true
 
 local hyphens = require("languages.es.hyphens-tex")
 SILE.hyphenator.languages["es"] = hyphens

--- a/languages/gl/init.lua
+++ b/languages/gl/init.lua
@@ -1,2 +1,15 @@
+SILE.nodeMakers.gl = pl.class(SILE.nodeMakers.unicode)
+
+-- Real Academia Galega (RAG), _Normas ortográficas e morfolóxicas do idioma
+-- galego,_ 20th ed., 2005, ISBN 978-84-87987-51-9, §3.2
+-- (https://ilg.usc.gal/corrector/docs/normas_galego_2003.pdf)
+-- "Cando un guión que separa dúas palabras ou dous membros dunha palabra
+-- complexa coincide en final de liña, cómpre repetilo ao comezo da liña
+-- seguinte: _dicionario galego-/-inglés._"
+-- So Galician hyphenation rules require that when a break occurs at an
+-- explicit (lexical) hyphen, the hyphen gets repeated on the next line,
+-- following the same rule as in Spanish and Portuguese.
+SILE.nodeMakers.gl.hasFeatureRepeatedHyphen = true
+
 local hyphens = require("languages.gl.hyphens-tex")
 SILE.hyphenator.languages["gl"] = hyphens

--- a/languages/gl/messages.ftl
+++ b/languages/gl/messages.ftl
@@ -1,0 +1,3 @@
+book-chapter-title = Capítulo { $number }
+
+tableofcontents-title = Índice

--- a/languages/hr/init.lua
+++ b/languages/hr/init.lua
@@ -1,8 +1,7 @@
 SILE.nodeMakers.hr = pl.class(SILE.nodeMakers.unicode)
 
 -- According to Croatian rules, when a break occurs at an explicit hyphen, the hyphen gets repeated on the next line...
-SILE.nodeMakers.hr.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
-SILE.nodeMakers.hr.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
+SILE.nodeMakers.hr.hasFeatureRepeatedHyphen = true
 
 local hyphens = require("languages.hr.hyphens-tex")
 SILE.hyphenator.languages["hr"] = hyphens

--- a/languages/oc-aranes/init.lua
+++ b/languages/oc-aranes/init.lua
@@ -1,0 +1,22 @@
+-- Aranese is a Pyrenean "Gascon" variety of the Occitan language, spoken in
+-- the Val d'Aran and in a few places in northwestern Catalonia. It is one of
+-- the "official" languages recognized by the Parliament of Catalonia.
+
+-- TeX hyphenation patterns for Occitan are "supposed to be valid for all the
+-- Occitan variants spoken and written in the wide area called 'Occitanie' by
+-- the French. It ranges from the Val d'Aran within Catalunya (...)"
+local hyphens = require("languages.oc.hyphens-tex")
+SILE.hyphenator.languages["oc-aranes"] = hyphens
+
+-- Aranese slightly differs from standard Occitan however:
+-- While it often uses French-style guillemets for primary quotes, it omits the
+-- punctuation spaces («...») used in (modern revivals of) standard Occitan.
+-- This is not fully authoritative (some linguists advocate for the use of the
+-- curly braces for primary quotes in Aranese, under the influence ofn Spanish
+-- and Catalan), but at least that's what "Pedagogia - Portau deus ensenhaires
+-- d'occitan", a website promoting Occitan, says.
+-- Examples in "Nòrmes ortogràfiques der aranés" (1982, provisional text) also
+-- show the use of French-style guillemets without punctuation spaces, and no
+-- spaces either before "high" punctuation marks.
+-- Hence, we do not use the French node maker for Aranese, contrary to what we
+-- do for standard Occitan.

--- a/languages/oc-aranes/messages.ftl
+++ b/languages/oc-aranes/messages.ftl
@@ -1,0 +1,3 @@
+book-chapter-title = Capítol { $number }
+
+tableofcontents-title = Ensenhador

--- a/languages/oc/init.lua
+++ b/languages/oc/init.lua
@@ -1,2 +1,7 @@
 local hyphens = require("languages.oc.hyphens-tex")
 SILE.hyphenator.languages["oc"] = hyphens
+
+-- In modern revivals, Occitan usually follows the French conventions
+-- for punctuation spacing.
+require("languages.fr") -- HACK force loading of the French language node maker.
+SILE.nodeMakers.oc = SILE.nodeMakers.fr

--- a/languages/oc/messages.ftl
+++ b/languages/oc/messages.ftl
@@ -1,0 +1,3 @@
+book-chapter-title = Capítol { $number }
+
+tableofcontents-title = Ensenhador

--- a/languages/pl/init.lua
+++ b/languages/pl/init.lua
@@ -1,8 +1,6 @@
 SILE.nodeMakers.pl = pl.class(SILE.nodeMakers.unicode)
-
 -- According to Polish rules, when a break occurs at an explicit hyphen, the hyphen gets repeated on the next line...
-SILE.nodeMakers.pl.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
-SILE.nodeMakers.pl.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
+SILE.nodeMakers.pl.hasFeatureRepeatedHyphen = true
 
 local hyphens = require("languages.pl.hyphens-tex")
 SILE.hyphenator.languages["pl"] = hyphens

--- a/languages/pt/init.lua
+++ b/languages/pt/init.lua
@@ -1,8 +1,7 @@
 SILE.nodeMakers.pt = pl.class(SILE.nodeMakers.unicode)
 
 -- According to Portuguese rules, when a break occurs at an explicit hyphen, the hyphen gets repeated on the next line...
-SILE.nodeMakers.pt.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
-SILE.nodeMakers.pt.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
+SILE.nodeMakers.pt.hasFeatureRepeatedHyphen = true
 
 local hyphens = require("languages.pt.hyphens-tex")
 SILE.hyphenator.languages["pt"] = hyphens

--- a/languages/sk/init.lua
+++ b/languages/sk/init.lua
@@ -1,8 +1,7 @@
 SILE.nodeMakers.sk = pl.class(SILE.nodeMakers.unicode)
 
 -- According to Slovak rules, when a break occurs at an explicit hyphen, the hyphen gets repeated on the next line...
-SILE.nodeMakers.sk.handleWordBreak = SILE.nodeMakers.unicode._handleWordBreakRepeatHyphen
-SILE.nodeMakers.sk.handlelineBreak = SILE.nodeMakers.unicode._handlelineBreakRepeatHyphen
+SILE.nodeMakers.sk.hasFeatureRepeatedHyphen = true
 
 local hyphens = require("languages.sk.hyphens-tex")
 SILE.hyphenator.languages["sk"] = hyphens

--- a/languages/unicode/init.lua
+++ b/languages/unicode/init.lua
@@ -189,23 +189,9 @@ function SILE.nodeMakers.unicode:handleICUBreak (chunks, item)
 end
 
 function SILE.nodeMakers.unicode:handleWordBreak (item)
-   self:makeToken()
-   if self:isSpace(item.text) then
-      -- Spacing word break
-      self:makeGlue(item)
-   elseif self:isActiveNonBreakingSpace(item.text) then
-      -- Non-breaking space word break
-      self:makeNonBreakingSpace()
-   else
-      -- a word break which isn't a space
-      self:addToken(item.text, item)
-   end
-end
-
-function SILE.nodeMakers.unicode:_handleWordBreakRepeatHyphen (item)
-   -- According to some language rules, when a break occurs at an explicit hyphen,
-   -- the hyphen gets repeated at the beginning of the new line
-   if item.text == "-" then
+   if self.hasFeatureRepeatedHyphen and item.text == "-" then
+      -- According to some language rules, when a break occurs at an explicit hyphen,
+      -- the hyphen gets repeated at the beginning of the new line
       self:addToken(item.text, item)
       self:makeToken()
       if self.lastnode ~= "discretionary" then
@@ -215,35 +201,41 @@ function SILE.nodeMakers.unicode:_handleWordBreakRepeatHyphen (item)
          self.lastnode = "discretionary"
       end
    else
-      SILE.nodeMakers.unicode.handleWordBreak(self, item)
+      self:makeToken()
+      if self:isSpace(item.text) then
+         -- Spacing word break
+         self:makeGlue(item)
+      elseif self:isActiveNonBreakingSpace(item.text) then
+         -- Non-breaking space word break
+         self:makeNonBreakingSpace()
+      else
+         -- a word break which isn't a space
+         self:addToken(item.text, item)
+      end
    end
 end
 
 function SILE.nodeMakers.unicode:handleLineBreak (item, subtype)
-   -- Because we are in charge of paragraphing, we
-   -- will override space-type line breaks, and treat
-   -- them just as ordinary word spaces.
-   if self:isSpace(item.text) or self:isActiveNonBreakingSpace(item.text) then
-      self:handleWordBreak(item)
-      return
-   end
-   -- But explicit line breaks we will turn into
-   -- soft and hard breaks.
-   self:makeToken()
-   self:makePenalty(subtype == "soft" and 0 or -1000)
-   local char = item.text
-   self:addToken(char, item)
-   local cp = SU.codepoint(char)
-   self.lasttype = chardata[cp] and chardata[cp].linebreak
-end
-
-function SILE.nodeMakers.unicode:_handleLineBreakRepeatHyphen (item, subtype)
    if self.lastnode == "discretionary" then
       -- Initial word boundary after a discretionary:
       -- Bypass it and just deal with the token.
       self:dealWith(item)
    else
-      SILE.nodeMakers.unicode.handleLineBreak(self, item, subtype)
+      -- Because we are in charge of paragraphing, we
+      -- will override space-type line breaks, and treat
+      -- them just as ordinary word spaces.
+      if self:isSpace(item.text) or self:isActiveNonBreakingSpace(item.text) then
+         self:handleWordBreak(item)
+         return
+      end
+      -- But explicit line breaks we will turn into
+      -- soft and hard breaks.
+      self:makeToken()
+      self:makePenalty(subtype == "soft" and 0 or -1000)
+      local char = item.text
+      self:addToken(char, item)
+      local cp = SU.codepoint(char)
+      self.lasttype = chardata[cp] and chardata[cp].linebreak
    end
 end
 


### PR DESCRIPTION
Minimally addressing open issues:

Closes #2372 by refactoring the unicode segmenter used by languages cs, es, hr, pl, pt, sk (switching to a feature flag)

Closes #2321 by changing the language setup for "oc" and introducing support for "oc-aranes"; also adding a minimal i18n translation file for both languages.

Closes #2374 by enabling the repeated hyphen flag on language "gl"; also adding a minimal i18n translation file for this language.
